### PR TITLE
Change weights to put in chronological order

### DIFF
--- a/content/rs/release-notes/_index.md
+++ b/content/rs/release-notes/_index.md
@@ -4,4 +4,4 @@ description:
 weight: 90
 alwaysopen: false
 ---
-{{%children style="h2" sort="Weight"%}}
+{{%children style="h2" sort="Weight"%}}  

--- a/content/rs/release-notes/rs-5-2-2-august-2018.md
+++ b/content/rs/release-notes/rs-5-2-2-august-2018.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise Software 5.2.2 (August 2018)
 description: 
-weight: 90
+weight: 89
 alwaysopen: false
 ---
 Redis Enterprise Software (RS) 5.2.2 is now available.

--- a/content/rs/release-notes/rs-5-3-beta-july-2018.md
+++ b/content/rs/release-notes/rs-5-3-beta-july-2018.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise Software Release Notes 5.3 BETA (July 2018)
 description: 
-weight: 89
+weight: 90
 alwaysopen: false
 ---
 Redis Enterprise Software (RS) 5.3 is now available.


### PR DESCRIPTION
Please change the order of the first two lines as it was in the original doc.
I.e. the correct order is:
Redis Enterprise Software 5.2.2 (August 2018) 
Redis Enterprise Software Release Notes 5.3 BETA (July 2018)