### PR TITLE
Add product category to search results

### DIFF
--- a/content/rc/_index.md
+++ b/content/rc/_index.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Cloud (RC)
 description: 
 weight: 20
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 Redis Enterprise Cloud (RC) is a managed, serverless,
 Database-as-a-Service (DBaaS) offering. <!--more-->

--- a/content/rc/_index.md
+++ b/content/rc/_index.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Cloud (RC)
 description: 
 weight: 20
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 Redis Enterprise Cloud (RC) is a managed, serverless,
 Database-as-a-Service (DBaaS) offering. <!--more-->

--- a/content/rc/administration/_index.md
+++ b/content/rc/administration/_index.md
@@ -3,6 +3,7 @@ Title: Administration
 description: 
 weight: 30
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 While there is very little configuration of Redis Enterprise Cloud
 required, there are some things that you can and may want to do to

--- a/content/rc/administration/_index.md
+++ b/content/rc/administration/_index.md
@@ -3,7 +3,7 @@ Title: Administration
 description: 
 weight: 30
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 While there is very little configuration of Redis Enterprise Cloud
 required, there are some things that you can and may want to do to

--- a/content/rc/administration/account-team-settings.md
+++ b/content/rc/administration/account-team-settings.md
@@ -3,6 +3,7 @@ Title: Account and Team Settings
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 On this page, you can view settings for your Redis Enterprise Cloud (RC)
 account and team. You can add or edit your VAT ID, account's Time Zone,

--- a/content/rc/administration/account-team-settings.md
+++ b/content/rc/administration/account-team-settings.md
@@ -3,7 +3,7 @@ Title: Account and Team Settings
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 On this page, you can view settings for your Redis Enterprise Cloud (RC)
 account and team. You can add or edit your VAT ID, account's Time Zone,

--- a/content/rc/administration/billing-history.md
+++ b/content/rc/administration/billing-history.md
@@ -3,7 +3,7 @@ Title: Billing History
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 This page contains a list of purchases, changes, and payments for the
 subscriptions you have in your Redis Enterprise Cloud account. If you

--- a/content/rc/administration/billing-history.md
+++ b/content/rc/administration/billing-history.md
@@ -3,6 +3,7 @@ Title: Billing History
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 This page contains a list of purchases, changes, and payments for the
 subscriptions you have in your Redis Enterprise Cloud account. If you

--- a/content/rc/administration/configure/_index.md
+++ b/content/rc/administration/configure/_index.md
@@ -3,6 +3,7 @@ title: Configuration
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rc/administration/configure/_index.md
+++ b/content/rc/administration/configure/_index.md
@@ -3,7 +3,7 @@ title: Configuration
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rc/administration/configure/backups.md
+++ b/content/rc/administration/configure/backups.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Cloud Database Backups
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 You can back up your Redis Enterprise Cloud (RC) databases to a storage
 bucket of your choosing. This article explains how to create a cloud

--- a/content/rc/administration/configure/backups.md
+++ b/content/rc/administration/configure/backups.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Cloud Database Backups
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 You can back up your Redis Enterprise Cloud (RC) databases to a storage
 bucket of your choosing. This article explains how to create a cloud

--- a/content/rc/administration/configure/monitoring-alerting-metrics.md
+++ b/content/rc/administration/configure/monitoring-alerting-metrics.md
@@ -3,7 +3,7 @@ Title: Monitoring Redis Enterprise Cloud Performance
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 Redis Enterprise Cloud (RC) provides a straightforward dashboard that
 gives you good visibility into each database. Metrics can be viewed on

--- a/content/rc/administration/configure/monitoring-alerting-metrics.md
+++ b/content/rc/administration/configure/monitoring-alerting-metrics.md
@@ -3,6 +3,7 @@ Title: Monitoring Redis Enterprise Cloud Performance
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 Redis Enterprise Cloud (RC) provides a straightforward dashboard that
 gives you good visibility into each database. Metrics can be viewed on

--- a/content/rc/administration/configure/security.md
+++ b/content/rc/administration/configure/security.md
@@ -3,7 +3,7 @@ Title: Securing Your Redis Enterprise Cloud Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 The security controls for your database are:
 

--- a/content/rc/administration/configure/security.md
+++ b/content/rc/administration/configure/security.md
@@ -3,6 +3,7 @@ Title: Securing Your Redis Enterprise Cloud Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 The security controls for your database are:
 

--- a/content/rc/administration/payment-methods.md
+++ b/content/rc/administration/payment-methods.md
@@ -3,6 +3,7 @@ Title: Payment Methods
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 On this page, you can view and edit your account's existing payment
 methods, as well as add new ones to your Redis Enterprise Cloud account.

--- a/content/rc/administration/payment-methods.md
+++ b/content/rc/administration/payment-methods.md
@@ -3,7 +3,7 @@ Title: Payment Methods
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 On this page, you can view and edit your account's existing payment
 methods, as well as add new ones to your Redis Enterprise Cloud account.

--- a/content/rc/administration/setup-and-editing/_index.md
+++ b/content/rc/administration/setup-and-editing/_index.md
@@ -3,6 +3,7 @@ title: Setup
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rc/administration/setup-and-editing/_index.md
+++ b/content/rc/administration/setup-and-editing/_index.md
@@ -3,7 +3,7 @@ title: Setup
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rc/administration/setup-and-editing/changing-subscription-plan.md
+++ b/content/rc/administration/setup-and-editing/changing-subscription-plan.md
@@ -3,6 +3,7 @@ Title: Changing Redis Enterprise Cloud Subscription Plans
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 It is very easy to upgrade or downgrade your subscription at any time,
 all with no downtime.

--- a/content/rc/administration/setup-and-editing/changing-subscription-plan.md
+++ b/content/rc/administration/setup-and-editing/changing-subscription-plan.md
@@ -3,7 +3,7 @@ Title: Changing Redis Enterprise Cloud Subscription Plans
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 It is very easy to upgrade or downgrade your subscription at any time,
 all with no downtime.

--- a/content/rc/administration/setup-and-editing/create-subscription.md
+++ b/content/rc/administration/setup-and-editing/create-subscription.md
@@ -3,6 +3,7 @@ Title: Creating a Redis Enterprise Cloud Subscription
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 A Redis Enterprise Cloud subscription consists of a selected cloud
 provider (and respective region, e.g. "Azure - US Central"),

--- a/content/rc/administration/setup-and-editing/create-subscription.md
+++ b/content/rc/administration/setup-and-editing/create-subscription.md
@@ -3,7 +3,7 @@ Title: Creating a Redis Enterprise Cloud Subscription
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 A Redis Enterprise Cloud subscription consists of a selected cloud
 provider (and respective region, e.g. "Azure - US Central"),

--- a/content/rc/administration/setup-and-editing/creating-databases.md
+++ b/content/rc/administration/setup-and-editing/creating-databases.md
@@ -3,7 +3,7 @@ Title: Creating Databases on Redis Enterprise Cloud (RC)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 Once you have a
 [subscription]({{< relref "/rc/administration/setup-and-editing/create-subscription.md" >}}),

--- a/content/rc/administration/setup-and-editing/creating-databases.md
+++ b/content/rc/administration/setup-and-editing/creating-databases.md
@@ -3,6 +3,7 @@ Title: Creating Databases on Redis Enterprise Cloud (RC)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 Once you have a
 [subscription]({{< relref "/rc/administration/setup-and-editing/create-subscription.md" >}}),

--- a/content/rc/administration/setup-and-editing/delete-databases.md
+++ b/content/rc/administration/setup-and-editing/delete-databases.md
@@ -3,7 +3,7 @@ Title: Deleting Redis Enterprise Cloud (RC) Databases
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 Deleting a database is just as easy as creating one. Make sure that you
 are truly done with the database as once you delete the database, it

--- a/content/rc/administration/setup-and-editing/delete-databases.md
+++ b/content/rc/administration/setup-and-editing/delete-databases.md
@@ -3,6 +3,7 @@ Title: Deleting Redis Enterprise Cloud (RC) Databases
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 Deleting a database is just as easy as creating one. Make sure that you
 are truly done with the database as once you delete the database, it

--- a/content/rc/administration/setup-and-editing/viewing-editing-database.md
+++ b/content/rc/administration/setup-and-editing/viewing-editing-database.md
@@ -3,6 +3,7 @@ Title: Viewing and Editing Databases
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 To view your database, go to the Menu and click on "Databases". You will
 see a list of your databases grouped by

--- a/content/rc/administration/setup-and-editing/viewing-editing-database.md
+++ b/content/rc/administration/setup-and-editing/viewing-editing-database.md
@@ -3,7 +3,7 @@ Title: Viewing and Editing Databases
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 To view your database, go to the Menu and click on "Databases". You will
 see a list of your databases grouped by

--- a/content/rc/administration/setup-and-editing/viewing-subscription.md
+++ b/content/rc/administration/setup-and-editing/viewing-subscription.md
@@ -3,7 +3,7 @@ Title: Viewing a Subscription
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 To view the details of a subscription click "Subscriptions" in the menu
 and then click on the name of the Subscription you wish to view.

--- a/content/rc/administration/setup-and-editing/viewing-subscription.md
+++ b/content/rc/administration/setup-and-editing/viewing-subscription.md
@@ -3,6 +3,7 @@ Title: Viewing a Subscription
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 To view the details of a subscription click "Subscriptions" in the menu
 and then click on the name of the Subscription you wish to view.

--- a/content/rc/administration/setup-editing.md
+++ b/content/rc/administration/setup-editing.md
@@ -3,6 +3,7 @@ Title: Setup and Editing of Redis Enterprise Cloud Resources
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 - [Creating a
     Subscription]({{< relref "/rc/administration/setup-and-editing/create-subscription.md" >}})

--- a/content/rc/administration/setup-editing.md
+++ b/content/rc/administration/setup-editing.md
@@ -3,7 +3,7 @@ Title: Setup and Editing of Redis Enterprise Cloud Resources
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 - [Creating a
     Subscription]({{< relref "/rc/administration/setup-and-editing/create-subscription.md" >}})

--- a/content/rc/administration/system-logs.md
+++ b/content/rc/administration/system-logs.md
@@ -3,7 +3,7 @@ Title: System Logs
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 This page contains events, alerts, and logs from the activities,
 databases, and subscriptions in your Redis Enterprise Cloud account. You

--- a/content/rc/administration/system-logs.md
+++ b/content/rc/administration/system-logs.md
@@ -3,6 +3,7 @@ Title: System Logs
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 This page contains events, alerts, and logs from the activities,
 databases, and subscriptions in your Redis Enterprise Cloud account. You

--- a/content/rc/administration/usage-reports.md
+++ b/content/rc/administration/usage-reports.md
@@ -3,7 +3,7 @@ Title: Usage Reports
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 You can view the number of gigabytes used by this Redis Enterprise Cloud
 account. You are able to filter the data by subscription, database, and

--- a/content/rc/administration/usage-reports.md
+++ b/content/rc/administration/usage-reports.md
@@ -3,6 +3,7 @@ Title: Usage Reports
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 You can view the number of gigabytes used by this Redis Enterprise Cloud
 account. You are able to filter the data by subscription, database, and

--- a/content/rc/concepts/_index.md
+++ b/content/rc/concepts/_index.md
@@ -3,7 +3,7 @@ Title: Concepts behind Redis Enterprise Cloud
 description: 
 weight: 20
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 This section of pages contains content that describes the main concepts
 and architecture that you need to know about for Redis Enterprise Cloud.

--- a/content/rc/concepts/_index.md
+++ b/content/rc/concepts/_index.md
@@ -3,6 +3,7 @@ Title: Concepts behind Redis Enterprise Cloud
 description: 
 weight: 20
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 This section of pages contains content that describes the main concepts
 and architecture that you need to know about for Redis Enterprise Cloud.

--- a/content/rc/concepts/clustering-redis-cloud.md
+++ b/content/rc/concepts/clustering-redis-cloud.md
@@ -3,7 +3,7 @@ Title: Clustering Redis Databases with Redis Enterprise Cloud
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 While it is a design decision that Redis is a (mostly) single-threaded
 process and this does keep it extremely performant yet simple, there are

--- a/content/rc/concepts/clustering-redis-cloud.md
+++ b/content/rc/concepts/clustering-redis-cloud.md
@@ -3,6 +3,7 @@ Title: Clustering Redis Databases with Redis Enterprise Cloud
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 While it is a design decision that Redis is a (mostly) single-threaded
 process and this does keep it extremely performant yet simple, there are

--- a/content/rc/concepts/data-eviction-policies.md
+++ b/content/rc/concepts/data-eviction-policies.md
@@ -3,7 +3,7 @@ Title: Data Eviction Policies
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 There are six supported data eviction policies to choose from for each
 database. They are:

--- a/content/rc/concepts/data-eviction-policies.md
+++ b/content/rc/concepts/data-eviction-policies.md
@@ -3,6 +3,7 @@ Title: Data Eviction Policies
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 There are six supported data eviction policies to choose from for each
 database. They are:

--- a/content/rc/concepts/data-persistence-redis-cloud.md
+++ b/content/rc/concepts/data-persistence-redis-cloud.md
@@ -3,7 +3,7 @@ Title: Data Persistence with Redis Enterprise Cloud
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 Redis Enterprise Cloud (RC) supports persisting your data to disk on a
 per-database basis and in multiple ways. Unlike a few cloud provider's

--- a/content/rc/concepts/data-persistence-redis-cloud.md
+++ b/content/rc/concepts/data-persistence-redis-cloud.md
@@ -3,6 +3,7 @@ Title: Data Persistence with Redis Enterprise Cloud
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 Redis Enterprise Cloud (RC) supports persisting your data to disk on a
 per-database basis and in multiple ways. Unlike a few cloud provider's

--- a/content/rc/how-to/_index.md
+++ b/content/rc/how-to/_index.md
@@ -3,6 +3,6 @@ Title: How Tos
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rc/how-to/_index.md
+++ b/content/rc/how-to/_index.md
@@ -3,5 +3,6 @@ Title: How Tos
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rc/how-to/all-memcached-cloud.md
+++ b/content/rc/how-to/all-memcached-cloud.md
@@ -3,6 +3,7 @@ Title: Using flush_all for Memcached Cloud
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 Follow the instructions below to use flush_all.
 

--- a/content/rc/how-to/all-memcached-cloud.md
+++ b/content/rc/how-to/all-memcached-cloud.md
@@ -3,7 +3,7 @@ Title: Using flush_all for Memcached Cloud
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 Follow the instructions below to use flush_all.
 

--- a/content/rc/how-to/aws-zone-mapping.md
+++ b/content/rc/how-to/aws-zone-mapping.md
@@ -3,7 +3,7 @@ Title: AWS Zone Mapping
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 If you are looking to squeeze every drop of performance out of your
 Redis Enterprise Cloud (RC) Database, then matching the AWS availability

--- a/content/rc/how-to/aws-zone-mapping.md
+++ b/content/rc/how-to/aws-zone-mapping.md
@@ -3,6 +3,7 @@ Title: AWS Zone Mapping
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 If you are looking to squeeze every drop of performance out of your
 Redis Enterprise Cloud (RC) Database, then matching the AWS availability

--- a/content/rc/how-to/flush-db.md
+++ b/content/rc/how-to/flush-db.md
@@ -3,7 +3,7 @@ Title: Using flushall Command on Redis Enterprise Cloud
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 There are times where you want to delete all database data. In previous
 versions of Redis Enterprise Cloud, there was a button to perform this

--- a/content/rc/how-to/flush-db.md
+++ b/content/rc/how-to/flush-db.md
@@ -3,6 +3,7 @@ Title: Using flushall Command on Redis Enterprise Cloud
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 There are times where you want to delete all database data. In previous
 versions of Redis Enterprise Cloud, there was a button to perform this

--- a/content/rc/how-to/importing-dataset-redis-cloud.md
+++ b/content/rc/how-to/importing-dataset-redis-cloud.md
@@ -3,7 +3,7 @@ Title: Importing Data Into Your Redis Enterprise Cloud Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 You can import an existing dataset into your Redis Enterprise Cloud
 instance. This article lists the steps required to share your dataset

--- a/content/rc/how-to/importing-dataset-redis-cloud.md
+++ b/content/rc/how-to/importing-dataset-redis-cloud.md
@@ -3,6 +3,7 @@ Title: Importing Data Into Your Redis Enterprise Cloud Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 You can import an existing dataset into your Redis Enterprise Cloud
 instance. This article lists the steps required to share your dataset

--- a/content/rc/how-to/multiple-accounts.md
+++ b/content/rc/how-to/multiple-accounts.md
@@ -3,6 +3,7 @@ Title: Member of multiple accounts
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 It is possible for you to be a member of multiple accounts in Redis
 Enterprise Cloud. For example, you created your own account, but your

--- a/content/rc/how-to/multiple-accounts.md
+++ b/content/rc/how-to/multiple-accounts.md
@@ -3,7 +3,7 @@ Title: Member of multiple accounts
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 It is possible for you to be a member of multiple accounts in Redis
 Enterprise Cloud. For example, you created your own account, but your

--- a/content/rc/quick-setup-redis-cloud.md
+++ b/content/rc/quick-setup-redis-cloud.md
@@ -3,7 +3,7 @@ Title: Quick Setup of Redis Enterprise Cloud
 description: 
 weight: 10
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 The steps here are super simple and go as follows:
 

--- a/content/rc/quick-setup-redis-cloud.md
+++ b/content/rc/quick-setup-redis-cloud.md
@@ -3,6 +3,7 @@ Title: Quick Setup of Redis Enterprise Cloud
 description: 
 weight: 10
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 The steps here are super simple and go as follows:
 

--- a/content/rc/securing-redis-cloud-connections.md
+++ b/content/rc/securing-redis-cloud-connections.md
@@ -3,7 +3,7 @@ title: Securing Connections with SSL/TLS
 description: 
 weight: 25
 alwaysopen: false
-categories: ["Redis Enterprise Cloud (RC)"]
+categories: ["RC"]
 ---
 To configure your subscription so you can use SSL/TLS with your Redis
 Enterprise Cloud (RC) database, please contact support. To speed up this

--- a/content/rc/securing-redis-cloud-connections.md
+++ b/content/rc/securing-redis-cloud-connections.md
@@ -3,6 +3,7 @@ title: Securing Connections with SSL/TLS
 description: 
 weight: 25
 alwaysopen: false
+categories: ["Redis Enterprise Cloud (RC)"]
 ---
 To configure your subscription so you can use SSL/TLS with your Redis
 Enterprise Cloud (RC) database, please contact support. To speed up this

--- a/content/rs/_index.md
+++ b/content/rs/_index.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software (RS)
 description: 
 weight: 10
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This documentation covers both Redis Enterprise Software 4.5 and
 5.0. Anything that is not explicitly marked for 5.0, applies to 4.5

--- a/content/rs/_index.md
+++ b/content/rs/_index.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software (RS)
 description: 
 weight: 10
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This documentation covers both Redis Enterprise Software 4.5 and
 5.0. Anything that is not explicitly marked for 5.0, applies to 4.5

--- a/content/rs/administering/_index.md
+++ b/content/rs/administering/_index.md
@@ -3,6 +3,7 @@ Title: Administering Redis Enterprise
 description: 
 weight: 60
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section covers everything you need to know to get up and running
 with RS, included installing, configuring a cluster, maintaining a

--- a/content/rs/administering/_index.md
+++ b/content/rs/administering/_index.md
@@ -3,7 +3,7 @@ Title: Administering Redis Enterprise
 description: 
 weight: 60
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section covers everything you need to know to get up and running
 with RS, included installing, configuring a cluster, maintaining a

--- a/content/rs/administering/cluster-operations/_index.md
+++ b/content/rs/administering/cluster-operations/_index.md
@@ -3,6 +3,7 @@ Title: Cluster Operations
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section has all you need to know pertaining to administering the
 cluster in Redis Enterprise Software.

--- a/content/rs/administering/cluster-operations/_index.md
+++ b/content/rs/administering/cluster-operations/_index.md
@@ -3,7 +3,7 @@ Title: Cluster Operations
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section has all you need to know pertaining to administering the
 cluster in Redis Enterprise Software.

--- a/content/rs/administering/cluster-operations/adding-node.md
+++ b/content/rs/administering/cluster-operations/adding-node.md
@@ -3,7 +3,7 @@ Title: Adding a Node to an Existing Cluster
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 To add a node in Redis Enterprise Software (RS):
 

--- a/content/rs/administering/cluster-operations/adding-node.md
+++ b/content/rs/administering/cluster-operations/adding-node.md
@@ -3,6 +3,7 @@ Title: Adding a Node to an Existing Cluster
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 To add a node in Redis Enterprise Software (RS):
 

--- a/content/rs/administering/cluster-operations/cluster-metrics.md
+++ b/content/rs/administering/cluster-operations/cluster-metrics.md
@@ -3,7 +3,7 @@ Title: Viewing cluster metrics on Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 On the **Cluster \> Metrics** page you can view detailed real-time
 graphs of various metrics for the entire cluster, as well as specific

--- a/content/rs/administering/cluster-operations/cluster-metrics.md
+++ b/content/rs/administering/cluster-operations/cluster-metrics.md
@@ -3,6 +3,7 @@ Title: Viewing cluster metrics on Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 On the **Cluster \> Metrics** page you can view detailed real-time
 graphs of various metrics for the entire cluster, as well as specific

--- a/content/rs/administering/cluster-operations/new-cluster-setup.md
+++ b/content/rs/administering/cluster-operations/new-cluster-setup.md
@@ -3,7 +3,7 @@ Title: New Cluster Setup
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 A Redis Enterprise Software (RS) cluster typically consists of several
 nodes. For production deployments, Redis Labs recommends an uneven

--- a/content/rs/administering/cluster-operations/new-cluster-setup.md
+++ b/content/rs/administering/cluster-operations/new-cluster-setup.md
@@ -3,6 +3,7 @@ Title: New Cluster Setup
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 A Redis Enterprise Software (RS) cluster typically consists of several
 nodes. For production deployments, Redis Labs recommends an uneven

--- a/content/rs/administering/cluster-operations/node-metrics.md
+++ b/content/rs/administering/cluster-operations/node-metrics.md
@@ -3,6 +3,7 @@ Title: Viewing node metrics
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 On the **Node \> Metrics** page you can view detailed graphs of various
 node metrics in real-time.

--- a/content/rs/administering/cluster-operations/node-metrics.md
+++ b/content/rs/administering/cluster-operations/node-metrics.md
@@ -3,7 +3,7 @@ Title: Viewing node metrics
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 On the **Node \> Metrics** page you can view detailed graphs of various
 node metrics in real-time.

--- a/content/rs/administering/cluster-operations/removing-node.md
+++ b/content/rs/administering/cluster-operations/removing-node.md
@@ -3,7 +3,7 @@ Title: Removing a Node
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 There are various reasons why you may want to remove a node in Redis
 Enterprise Software (RS):

--- a/content/rs/administering/cluster-operations/removing-node.md
+++ b/content/rs/administering/cluster-operations/removing-node.md
@@ -3,6 +3,7 @@ Title: Removing a Node
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 There are various reasons why you may want to remove a node in Redis
 Enterprise Software (RS):

--- a/content/rs/administering/cluster-operations/replacing-node.md
+++ b/content/rs/administering/cluster-operations/replacing-node.md
@@ -3,6 +3,7 @@ Title: Replacing a node
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If a node in your cluster is faulty, its status appears as **Down **in
 the **Status** column of the **Nodes** page, and in the **Cluster \>

--- a/content/rs/administering/cluster-operations/replacing-node.md
+++ b/content/rs/administering/cluster-operations/replacing-node.md
@@ -3,7 +3,7 @@ Title: Replacing a node
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If a node in your cluster is faulty, its status appears as **Down **in
 the **Status** column of the **Nodes** page, and in the **Cluster \>

--- a/content/rs/administering/cluster-operations/settings/_index.md
+++ b/content/rs/administering/cluster-operations/settings/_index.md
@@ -3,5 +3,6 @@ Title: Settings
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/cluster-operations/settings/_index.md
+++ b/content/rs/administering/cluster-operations/settings/_index.md
@@ -3,6 +3,6 @@ Title: Settings
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/cluster-operations/settings/alerts.md
+++ b/content/rs/administering/cluster-operations/settings/alerts.md
@@ -3,6 +3,7 @@ Title: Managing Cluster Alerts in Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The **Settings \> Alerts** allows you to designate which cluster-level
 events trigger alert notifications.

--- a/content/rs/administering/cluster-operations/settings/alerts.md
+++ b/content/rs/administering/cluster-operations/settings/alerts.md
@@ -3,7 +3,7 @@ Title: Managing Cluster Alerts in Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The **Settings \> Alerts** allows you to designate which cluster-level
 events trigger alert notifications.

--- a/content/rs/administering/cluster-operations/settings/general.md
+++ b/content/rs/administering/cluster-operations/settings/general.md
@@ -3,7 +3,7 @@ Title: General settings
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can view and set various cluster settings in the **Settings \>
 General** page.

--- a/content/rs/administering/cluster-operations/settings/general.md
+++ b/content/rs/administering/cluster-operations/settings/general.md
@@ -3,6 +3,7 @@ Title: General settings
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can view and set various cluster settings in the **Settings \>
 General** page.

--- a/content/rs/administering/cluster-operations/settings/license-keys.md
+++ b/content/rs/administering/cluster-operations/settings/license-keys.md
@@ -3,7 +3,7 @@ Title: Cluster License Keys
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The cluster license key enables features and capacity within Redis
 Enterprise Software. A key can be added, or updated at any time in a

--- a/content/rs/administering/cluster-operations/settings/license-keys.md
+++ b/content/rs/administering/cluster-operations/settings/license-keys.md
@@ -3,6 +3,7 @@ Title: Cluster License Keys
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The cluster license key enables features and capacity within Redis
 Enterprise Software. A key can be added, or updated at any time in a

--- a/content/rs/administering/cluster-operations/shutting-down-node.md
+++ b/content/rs/administering/cluster-operations/shutting-down-node.md
@@ -3,6 +3,7 @@ Title: Shutting Down a Node
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 When you shut down a machine acting as a Redis Enterprise Software (RS)
 node, databases that have persistence enabled will attempt to persist

--- a/content/rs/administering/cluster-operations/shutting-down-node.md
+++ b/content/rs/administering/cluster-operations/shutting-down-node.md
@@ -3,7 +3,7 @@ Title: Shutting Down a Node
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 When you shut down a machine acting as a Redis Enterprise Software (RS)
 node, databases that have persistence enabled will attempt to persist

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -3,7 +3,7 @@ title: Updating SSL/TLS certificates
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) uses self-signed certificates to encrypt
 the following:

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -3,6 +3,7 @@ title: Updating SSL/TLS certificates
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) uses self-signed certificates to encrypt
 the following:

--- a/content/rs/administering/database-operations/_index.md
+++ b/content/rs/administering/database-operations/_index.md
@@ -3,7 +3,7 @@ Title: Database Operations
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section contains all you need to know to operate databases hosted
 on Redis Enterprise Software.

--- a/content/rs/administering/database-operations/_index.md
+++ b/content/rs/administering/database-operations/_index.md
@@ -3,6 +3,7 @@ Title: Database Operations
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section contains all you need to know to operate databases hosted
 on Redis Enterprise Software.

--- a/content/rs/administering/database-operations/administering-database-operations-importing-data.md
+++ b/content/rs/administering/database-operations/administering-database-operations-importing-data.md
@@ -3,7 +3,7 @@ Title: Importing Data into your CRDB
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 When importing data into a CRDB, there are two options:
 

--- a/content/rs/administering/database-operations/administering-database-operations-importing-data.md
+++ b/content/rs/administering/database-operations/administering-database-operations-importing-data.md
@@ -3,6 +3,7 @@ Title: Importing Data into your CRDB
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 When importing data into a CRDB, there are two options:
 

--- a/content/rs/administering/database-operations/alerting.md
+++ b/content/rs/administering/database-operations/alerting.md
@@ -3,6 +3,7 @@ Title: Database alerting
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 In the *Alerts* section of the Redis Enterprise Software database page,
 you can designate which database events will trigger alert

--- a/content/rs/administering/database-operations/alerting.md
+++ b/content/rs/administering/database-operations/alerting.md
@@ -3,7 +3,7 @@ Title: Database alerting
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 In the *Alerts* section of the Redis Enterprise Software database page,
 you can designate which database events will trigger alert

--- a/content/rs/administering/database-operations/causal-consistency-crdb.md
+++ b/content/rs/administering/database-operations/causal-consistency-crdb.md
@@ -3,6 +3,7 @@ Title: Causal Consistency in a Conflict-free Replicated Database (CRDB)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 When enabling Causal Consistency in CRDBs, the order of operations on a
 specific key will be maintained across all CRDB

--- a/content/rs/administering/database-operations/causal-consistency-crdb.md
+++ b/content/rs/administering/database-operations/causal-consistency-crdb.md
@@ -3,7 +3,7 @@ Title: Causal Consistency in a Conflict-free Replicated Database (CRDB)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 When enabling Causal Consistency in CRDBs, the order of operations on a
 specific key will be maintained across all CRDB

--- a/content/rs/administering/database-operations/create-crdb.md
+++ b/content/rs/administering/database-operations/create-crdb.md
@@ -3,7 +3,7 @@ Title: Create a Geo-Replicated Conflict-free Replicated Database (CRDB)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 CRDBs span multiple Redis Enterprise Software (RS) clusters. Overview of
 the steps to create a CRDB:

--- a/content/rs/administering/database-operations/create-crdb.md
+++ b/content/rs/administering/database-operations/create-crdb.md
@@ -3,6 +3,7 @@ Title: Create a Geo-Replicated Conflict-free Replicated Database (CRDB)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 CRDBs span multiple Redis Enterprise Software (RS) clusters. Overview of
 the steps to create a CRDB:

--- a/content/rs/administering/database-operations/creating-database.md
+++ b/content/rs/administering/database-operations/creating-database.md
@@ -3,7 +3,7 @@ Title: Creating a Redis Enterprise Software (RS) database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can create as many databases as you wish in the cluster, so long as
 you do not exceed the available memory or the number of shards you

--- a/content/rs/administering/database-operations/creating-database.md
+++ b/content/rs/administering/database-operations/creating-database.md
@@ -3,6 +3,7 @@ Title: Creating a Redis Enterprise Software (RS) database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can create as many databases as you wish in the cluster, so long as
 you do not exceed the available memory or the number of shards you

--- a/content/rs/administering/database-operations/database-backup.md
+++ b/content/rs/administering/database-operations/database-backup.md
@@ -3,6 +3,7 @@ Title: Periodic Backups
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can back up your dataset to an FTP server, Amazon S3, or OpenStack
 Object Storage ("Swift"), periodically, or ad-hoc. You cannot back up to

--- a/content/rs/administering/database-operations/database-backup.md
+++ b/content/rs/administering/database-operations/database-backup.md
@@ -3,7 +3,7 @@ Title: Periodic Backups
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can back up your dataset to an FTP server, Amazon S3, or OpenStack
 Object Storage ("Swift"), periodically, or ad-hoc. You cannot back up to

--- a/content/rs/administering/database-operations/delete-crdb.md
+++ b/content/rs/administering/database-operations/delete-crdb.md
@@ -3,6 +3,7 @@ Title: Deleting a Conflict-free Replicated Database (CRDB)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Deleting a CRDB is a nearly identical procedure to standard Redis
 databases in Redis Enterprise Software, but with a critical distinction.

--- a/content/rs/administering/database-operations/delete-crdb.md
+++ b/content/rs/administering/database-operations/delete-crdb.md
@@ -3,7 +3,7 @@ Title: Deleting a Conflict-free Replicated Database (CRDB)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Deleting a CRDB is a nearly identical procedure to standard Redis
 databases in Redis Enterprise Software, but with a critical distinction.

--- a/content/rs/administering/database-operations/deleting-database.md
+++ b/content/rs/administering/database-operations/deleting-database.md
@@ -3,7 +3,7 @@ Title: Delete a Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 To delete a database in Redis Enterprise Software (RS):
 

--- a/content/rs/administering/database-operations/deleting-database.md
+++ b/content/rs/administering/database-operations/deleting-database.md
@@ -3,6 +3,7 @@ Title: Delete a Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 To delete a database in Redis Enterprise Software (RS):
 

--- a/content/rs/administering/database-operations/eviction-policy.md
+++ b/content/rs/administering/database-operations/eviction-policy.md
@@ -3,6 +3,7 @@ Title: Eviction policies
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The eviction policy designates a data eviction method for Redis
 Enterprise Software (RS) to use when the database size reaches its

--- a/content/rs/administering/database-operations/eviction-policy.md
+++ b/content/rs/administering/database-operations/eviction-policy.md
@@ -3,7 +3,7 @@ Title: Eviction policies
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The eviction policy designates a data eviction method for Redis
 Enterprise Software (RS) to use when the database size reaches its

--- a/content/rs/administering/database-operations/exporting-data.md
+++ b/content/rs/administering/database-operations/exporting-data.md
@@ -3,6 +3,7 @@ Title: Exporting Data from Redis Enterprise
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Using the Export option, you can back up a database at any time to an
 FTP server, Amazon S3, or OpenStack Object Storage ("Swift"). Other

--- a/content/rs/administering/database-operations/exporting-data.md
+++ b/content/rs/administering/database-operations/exporting-data.md
@@ -3,7 +3,7 @@ Title: Exporting Data from Redis Enterprise
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Using the Export option, you can back up a database at any time to an
 FTP server, Amazon S3, or OpenStack Object Storage ("Swift"). Other

--- a/content/rs/administering/database-operations/importing-data.md
+++ b/content/rs/administering/database-operations/importing-data.md
@@ -3,7 +3,7 @@ Title: Importing Data into Redis Enterprise
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can import data into a Redis Enterprise Software database from an
 HTTP location, FTP server, Amazon S3, or OpenStack Object Storage

--- a/content/rs/administering/database-operations/importing-data.md
+++ b/content/rs/administering/database-operations/importing-data.md
@@ -3,6 +3,7 @@ Title: Importing Data into Redis Enterprise
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can import data into a Redis Enterprise Software database from an
 HTTP location, FTP server, Amazon S3, or OpenStack Object Storage

--- a/content/rs/administering/database-operations/memory-limit.md
+++ b/content/rs/administering/database-operations/memory-limit.md
@@ -3,7 +3,7 @@ Title: Database memory limits in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 When you set a database's memory limit, you define the maximum size the
 database can reach in the cluster, across all database replicas and

--- a/content/rs/administering/database-operations/memory-limit.md
+++ b/content/rs/administering/database-operations/memory-limit.md
@@ -3,6 +3,7 @@ Title: Database memory limits in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 When you set a database's memory limit, you define the maximum size the
 database can reach in the cluster, across all database replicas and

--- a/content/rs/administering/database-operations/metrics/_index.md
+++ b/content/rs/administering/database-operations/metrics/_index.md
@@ -3,7 +3,7 @@ Title: Metrics
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 On the **Database \> Metrics** page you can view detailed real-time
 graphs of various database metrics, as well as shard-related metrics.

--- a/content/rs/administering/database-operations/metrics/_index.md
+++ b/content/rs/administering/database-operations/metrics/_index.md
@@ -3,6 +3,7 @@ Title: Metrics
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 On the **Database \> Metrics** page you can view detailed real-time
 graphs of various database metrics, as well as shard-related metrics.

--- a/content/rs/administering/database-operations/metrics/database-metrics.md
+++ b/content/rs/administering/database-operations/metrics/database-metrics.md
@@ -3,6 +3,7 @@ Title: Database metrics
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can choose which metrics are shown in each of the two detailed
 graphs at the top of the page, as follows:

--- a/content/rs/administering/database-operations/metrics/database-metrics.md
+++ b/content/rs/administering/database-operations/metrics/database-metrics.md
@@ -3,7 +3,7 @@ Title: Database metrics
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can choose which metrics are shown in each of the two detailed
 graphs at the top of the page, as follows:

--- a/content/rs/administering/database-operations/metrics/shard-metrics.md
+++ b/content/rs/administering/database-operations/metrics/shard-metrics.md
@@ -3,6 +3,7 @@ Title: Shards metrics
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can choose which resource(s) and metric(s) are shown in each of the
 two detailed graphs at the top of the page, as follows:

--- a/content/rs/administering/database-operations/metrics/shard-metrics.md
+++ b/content/rs/administering/database-operations/metrics/shard-metrics.md
@@ -3,7 +3,7 @@ Title: Shards metrics
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can choose which resource(s) and metric(s) are shown in each of the
 two detailed graphs at the top of the page, as follows:

--- a/content/rs/administering/database-operations/updating-configurations.md
+++ b/content/rs/administering/database-operations/updating-configurations.md
@@ -3,7 +3,7 @@ Title: Updating database configuration
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can change the configuration of a Redis Enterprise Software
 database at any time.

--- a/content/rs/administering/database-operations/updating-configurations.md
+++ b/content/rs/administering/database-operations/updating-configurations.md
@@ -3,6 +3,7 @@ Title: Updating database configuration
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can change the configuration of a Redis Enterprise Software
 database at any time.

--- a/content/rs/administering/designing-production/_index.md
+++ b/content/rs/administering/designing-production/_index.md
@@ -3,6 +3,7 @@ Title: Designing for Production
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The information in the section discusses important topics you need to
 know about when designing your Redis Enterprise Software cluster for a

--- a/content/rs/administering/designing-production/_index.md
+++ b/content/rs/administering/designing-production/_index.md
@@ -3,7 +3,7 @@ Title: Designing for Production
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The information in the section discusses important topics you need to
 know about when designing your Redis Enterprise Software cluster for a

--- a/content/rs/administering/designing-production/hardware-requirements.md
+++ b/content/rs/administering/designing-production/hardware-requirements.md
@@ -3,7 +3,7 @@ Title: Hardware requirements
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The hardware requirements for Redis Enterprise Software (RS) are different for development and productions environments.
 

--- a/content/rs/administering/designing-production/hardware-requirements.md
+++ b/content/rs/administering/designing-production/hardware-requirements.md
@@ -3,6 +3,7 @@ Title: Hardware requirements
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The hardware requirements for Redis Enterprise Software (RS) are different for development and productions environments.
 

--- a/content/rs/administering/designing-production/networking/_index.md
+++ b/content/rs/administering/designing-production/networking/_index.md
@@ -3,7 +3,7 @@ Title: Networking
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 When architecting a Redis Enterprise Software solution, there are some
 specific networking features that are worth your time to understand and

--- a/content/rs/administering/designing-production/networking/_index.md
+++ b/content/rs/administering/designing-production/networking/_index.md
@@ -3,6 +3,7 @@ Title: Networking
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 When architecting a Redis Enterprise Software solution, there are some
 specific networking features that are worth your time to understand and

--- a/content/rs/administering/designing-production/networking/multi-ip-ipv6.md
+++ b/content/rs/administering/designing-production/networking/multi-ip-ipv6.md
@@ -3,7 +3,7 @@ Title: Multi-IP and IPv6
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) supports server/instances/VMs with
 multiple IP addresses, as well as IPv6 addresses.

--- a/content/rs/administering/designing-production/networking/multi-ip-ipv6.md
+++ b/content/rs/administering/designing-production/networking/multi-ip-ipv6.md
@@ -3,6 +3,7 @@ Title: Multi-IP and IPv6
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) supports server/instances/VMs with
 multiple IP addresses, as well as IPv6 addresses.

--- a/content/rs/administering/designing-production/networking/multiple-active-proxy.md
+++ b/content/rs/administering/designing-production/networking/multiple-active-proxy.md
@@ -3,6 +3,7 @@ Title: Multiple Active Proxy Support
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) provides high-performance data access
 through a proxy process that manages and optimizes access to shards

--- a/content/rs/administering/designing-production/networking/multiple-active-proxy.md
+++ b/content/rs/administering/designing-production/networking/multiple-active-proxy.md
@@ -3,7 +3,7 @@ Title: Multiple Active Proxy Support
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) provides high-performance data access
 through a proxy process that manages and optimizes access to shards

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -3,7 +3,7 @@ Title: Network port configurations
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Servers used as Redis Enterprise Software (RS) nodes should ideally have
 all the below ports open between them for internal cluster communication

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -3,6 +3,7 @@ Title: Network port configurations
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Servers used as Redis Enterprise Software (RS) nodes should ideally have
 all the below ports open between them for internal cluster communication

--- a/content/rs/administering/designing-production/networking/private-public-endpoints.md
+++ b/content/rs/administering/designing-production/networking/private-public-endpoints.md
@@ -3,7 +3,7 @@ Title: Private and Public Endpoints on Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The cluster can be configured to support both private and public IPs to
 connect to database endpoints through both public and private networks.

--- a/content/rs/administering/designing-production/networking/private-public-endpoints.md
+++ b/content/rs/administering/designing-production/networking/private-public-endpoints.md
@@ -3,6 +3,7 @@ Title: Private and Public Endpoints on Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The cluster can be configured to support both private and public IPs to
 connect to database endpoints through both public and private networks.

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -3,7 +3,7 @@ Title: Using the OSS Cluster API
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%excerpt-include filename="rs/concepts/data-access/oss-cluster-api.md" %}} 
 For more information, see [Redis OSS Cluster API]({{< relref "/rs/concepts/data-access/oss-cluster-api.md" >}}).

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -3,6 +3,7 @@ Title: Using the OSS Cluster API
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%excerpt-include filename="rs/concepts/data-access/oss-cluster-api.md" %}} 
 For more information, see [Redis OSS Cluster API]({{< relref "/rs/concepts/data-access/oss-cluster-api.md" >}}).

--- a/content/rs/administering/designing-production/performance/_index.md
+++ b/content/rs/administering/designing-production/performance/_index.md
@@ -3,7 +3,7 @@ Title: Performance
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 When designing for production, there are key performance topics that you
 should read up on.

--- a/content/rs/administering/designing-production/performance/_index.md
+++ b/content/rs/administering/designing-production/performance/_index.md
@@ -3,6 +3,7 @@ Title: Performance
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 When designing for production, there are key performance topics that you
 should read up on.

--- a/content/rs/administering/designing-production/performance/disk-sizing-heavy-write-scenarios.md
+++ b/content/rs/administering/designing-production/performance/disk-sizing-heavy-write-scenarios.md
@@ -3,7 +3,7 @@ Title: Disk Sizing for Heavy Write Scenarios
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 In extreme write scenarios, when AOF is enabled, the AOF rewrite process
 may require considerably more disk space for database persistence.

--- a/content/rs/administering/designing-production/performance/disk-sizing-heavy-write-scenarios.md
+++ b/content/rs/administering/designing-production/performance/disk-sizing-heavy-write-scenarios.md
@@ -3,6 +3,7 @@ Title: Disk Sizing for Heavy Write Scenarios
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 In extreme write scenarios, when AOF is enabled, the AOF rewrite process
 may require considerably more disk space for database persistence.

--- a/content/rs/administering/designing-production/performance/optimization.md
+++ b/content/rs/administering/designing-production/performance/optimization.md
@@ -3,6 +3,7 @@ Title: Performance Optimization
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) employs various algorithms to optimize
 performance. As part of this process, RS examines usage characteristics

--- a/content/rs/administering/designing-production/performance/optimization.md
+++ b/content/rs/administering/designing-production/performance/optimization.md
@@ -3,7 +3,7 @@ Title: Performance Optimization
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) employs various algorithms to optimize
 performance. As part of this process, RS examines usage characteristics

--- a/content/rs/administering/designing-production/persistent-ephemeral-storage.md
+++ b/content/rs/administering/designing-production/persistent-ephemeral-storage.md
@@ -3,6 +3,7 @@ Title: Persistent and ephemeral storage
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 For each node in the cluster, you can configure both a persistent
 storage and an ephemeral storage path.

--- a/content/rs/administering/designing-production/persistent-ephemeral-storage.md
+++ b/content/rs/administering/designing-production/persistent-ephemeral-storage.md
@@ -3,7 +3,7 @@ Title: Persistent and ephemeral storage
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 For each node in the cluster, you can configure both a persistent
 storage and an ephemeral storage path.

--- a/content/rs/administering/designing-production/supported-clients-browsers.md
+++ b/content/rs/administering/designing-production/supported-clients-browsers.md
@@ -3,7 +3,7 @@ Title: Supported Clients and Web Browsers
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can configuration Redis Enterprise Software (RS) programmatically with client libraries 
 or manually with the RS Web Console.

--- a/content/rs/administering/designing-production/supported-clients-browsers.md
+++ b/content/rs/administering/designing-production/supported-clients-browsers.md
@@ -3,6 +3,7 @@ Title: Supported Clients and Web Browsers
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can configuration Redis Enterprise Software (RS) programmatically with client libraries 
 or manually with the RS Web Console.

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -3,6 +3,7 @@ Title: Supported Platforms
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) is supported on several operating
 systems, cloud environments, and virtual environments. All choices below

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -3,7 +3,7 @@ Title: Supported Platforms
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) is supported on several operating
 systems, cloud environments, and virtual environments. All choices below

--- a/content/rs/administering/designing-production/synchronizing-clocks.md
+++ b/content/rs/administering/designing-production/synchronizing-clocks.md
@@ -3,6 +3,7 @@ Title: Synchronizing cluster node clocks
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 It is important to ensure all cluster node's clocks are synchronized
 using Chrony and/or NTP. Without this synchronization, there may be

--- a/content/rs/administering/designing-production/synchronizing-clocks.md
+++ b/content/rs/administering/designing-production/synchronizing-clocks.md
@@ -3,7 +3,7 @@ Title: Synchronizing cluster node clocks
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 It is important to ensure all cluster node's clocks are synchronized
 using Chrony and/or NTP. Without this synchronization, there may be

--- a/content/rs/administering/installing-upgrading/_index.md
+++ b/content/rs/administering/installing-upgrading/_index.md
@@ -3,6 +3,7 @@ Title: Installing and upgrading
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section explains how to install, upgrade and uninstall Redis
 Enterprise Software (RS).

--- a/content/rs/administering/installing-upgrading/_index.md
+++ b/content/rs/administering/installing-upgrading/_index.md
@@ -3,7 +3,7 @@ Title: Installing and upgrading
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section explains how to install, upgrade and uninstall Redis
 Enterprise Software (RS).

--- a/content/rs/administering/installing-upgrading/configuring-aws-instances.md
+++ b/content/rs/administering/installing-upgrading/configuring-aws-instances.md
@@ -3,6 +3,7 @@ Title: Configuring AWS Instances for Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 There are some special considerations that are important when installing
 and running Redis Enterprise Software (RS) on an AWS instances.

--- a/content/rs/administering/installing-upgrading/configuring-aws-instances.md
+++ b/content/rs/administering/installing-upgrading/configuring-aws-instances.md
@@ -3,7 +3,7 @@ Title: Configuring AWS Instances for Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 There are some special considerations that are important when installing
 and running Redis Enterprise Software (RS) on an AWS instances.

--- a/content/rs/administering/installing-upgrading/configuring/_index.md
+++ b/content/rs/administering/installing-upgrading/configuring/_index.md
@@ -3,7 +3,7 @@ Title: Configuring the Installation
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section details many aspects of the OS and Redis Enterprise
 Software configurations necessary.

--- a/content/rs/administering/installing-upgrading/configuring/_index.md
+++ b/content/rs/administering/installing-upgrading/configuring/_index.md
@@ -3,6 +3,7 @@ Title: Configuring the Installation
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section details many aspects of the OS and Redis Enterprise
 Software configurations necessary.

--- a/content/rs/administering/installing-upgrading/configuring/centos-rhel-7-firewall.md
+++ b/content/rs/administering/installing-upgrading/configuring/centos-rhel-7-firewall.md
@@ -3,6 +3,7 @@ title: CentOS / RHEL 7 firewall configuration
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 CentOS / RHEL7 distributions have, by default, a restrictive firewall
 mechanism based on **firewalld** (which in turn configures the standard

--- a/content/rs/administering/installing-upgrading/configuring/centos-rhel-7-firewall.md
+++ b/content/rs/administering/installing-upgrading/configuring/centos-rhel-7-firewall.md
@@ -3,7 +3,7 @@ title: CentOS / RHEL 7 firewall configuration
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 CentOS / RHEL7 distributions have, by default, a restrictive firewall
 mechanism based on **firewalld** (which in turn configures the standard

--- a/content/rs/administering/installing-upgrading/configuring/change-location-socket-files.md
+++ b/content/rs/administering/installing-upgrading/configuring/change-location-socket-files.md
@@ -3,7 +3,7 @@ Title: Change Location of Socket Files
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can change the location of the socket files anytime, but to limit
 downtime, it is best to perform this change when you are

--- a/content/rs/administering/installing-upgrading/configuring/change-location-socket-files.md
+++ b/content/rs/administering/installing-upgrading/configuring/change-location-socket-files.md
@@ -3,6 +3,7 @@ Title: Change Location of Socket Files
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can change the location of the socket files anytime, but to limit
 downtime, it is best to perform this change when you are

--- a/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/_index.md
+++ b/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/_index.md
@@ -3,7 +3,7 @@ Title: DNS Setup
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 DNS is critical to the default operation of Redis Enterprise Software
 (RS) deployments. This can be altered, but instead using the [Discovery

--- a/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/_index.md
+++ b/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/_index.md
@@ -3,6 +3,7 @@ Title: DNS Setup
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 DNS is critical to the default operation of Redis Enterprise Software
 (RS) deployments. This can be altered, but instead using the [Discovery

--- a/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/configuring-aws-route53-dns-redis-enterprise.md
+++ b/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/configuring-aws-route53-dns-redis-enterprise.md
@@ -3,7 +3,7 @@ Title: Configuring AWS Route53
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) requires DNS to be properly configured to
 achieve high-availability (HA) and fail-over regardless of where it is

--- a/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/configuring-aws-route53-dns-redis-enterprise.md
+++ b/content/rs/administering/installing-upgrading/configuring/cluster-name-dns-connection-management/configuring-aws-route53-dns-redis-enterprise.md
@@ -3,6 +3,7 @@ Title: Configuring AWS Route53
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) requires DNS to be properly configured to
 achieve high-availability (HA) and fail-over regardless of where it is

--- a/content/rs/administering/installing-upgrading/configuring/linux-swap.md
+++ b/content/rs/administering/installing-upgrading/configuring/linux-swap.md
@@ -3,6 +3,7 @@ Title: Configuring Swap in Linux for Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Swap space is used by the Linux OS to help manage memory (pages) by
 copying pages from RAM to disk and the OS is configured by default to be

--- a/content/rs/administering/installing-upgrading/configuring/linux-swap.md
+++ b/content/rs/administering/installing-upgrading/configuring/linux-swap.md
@@ -3,7 +3,7 @@ Title: Configuring Swap in Linux for Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Swap space is used by the Linux OS to help manage memory (pages) by
 copying pages from RAM to disk and the OS is configured by default to be

--- a/content/rs/administering/installing-upgrading/configuring/mdns.md
+++ b/content/rs/administering/installing-upgrading/configuring/mdns.md
@@ -3,7 +3,7 @@ Title: Client prerequisites for mDNS
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 **Note:** mDNS is **not** supported for use with production environments
 and should only be used in dev/test environments.

--- a/content/rs/administering/installing-upgrading/configuring/mdns.md
+++ b/content/rs/administering/installing-upgrading/configuring/mdns.md
@@ -3,6 +3,7 @@ Title: Client prerequisites for mDNS
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 **Note:** mDNS is **not** supported for use with production environments
 and should only be used in dev/test environments.

--- a/content/rs/administering/installing-upgrading/downloading-installing.md
+++ b/content/rs/administering/installing-upgrading/downloading-installing.md
@@ -3,6 +3,7 @@ Title: Installing the setup package
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The first thing you need to decide is how you will deploy Redis
 Enterprise Software. If on-premise or in the cloud and you want to

--- a/content/rs/administering/installing-upgrading/downloading-installing.md
+++ b/content/rs/administering/installing-upgrading/downloading-installing.md
@@ -3,7 +3,7 @@ Title: Installing the setup package
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The first thing you need to decide is how you will deploy Redis
 Enterprise Software. If on-premise or in the cloud and you want to

--- a/content/rs/administering/installing-upgrading/file-locations.md
+++ b/content/rs/administering/installing-upgrading/file-locations.md
@@ -3,6 +3,7 @@ Title: File Locations
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Below is a table of which directories Redis Enterprise Software (RS)
 installs into and/or utilizes.

--- a/content/rs/administering/installing-upgrading/file-locations.md
+++ b/content/rs/administering/installing-upgrading/file-locations.md
@@ -3,7 +3,7 @@ Title: File Locations
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Below is a table of which directories Redis Enterprise Software (RS)
 installs into and/or utilizes.

--- a/content/rs/administering/installing-upgrading/offline-installation.md
+++ b/content/rs/administering/installing-upgrading/offline-installation.md
@@ -3,6 +3,7 @@ Title: Offline Installation
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 By default, the installation process requires an Internet connection to
 enable installing dependency packages and for synchronizing the

--- a/content/rs/administering/installing-upgrading/offline-installation.md
+++ b/content/rs/administering/installing-upgrading/offline-installation.md
@@ -3,7 +3,7 @@ Title: Offline Installation
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 By default, the installation process requires an Internet connection to
 enable installing dependency packages and for synchronizing the

--- a/content/rs/administering/installing-upgrading/uninstalling.md
+++ b/content/rs/administering/installing-upgrading/uninstalling.md
@@ -3,7 +3,7 @@ Title: Uninstalling Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 In the event that you need to uninstall Redis Enterprise Software
 (RS) from a server, please run the following command in the operating

--- a/content/rs/administering/installing-upgrading/uninstalling.md
+++ b/content/rs/administering/installing-upgrading/uninstalling.md
@@ -3,6 +3,7 @@ Title: Uninstalling Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 In the event that you need to uninstall Redis Enterprise Software
 (RS) from a server, please run the following command in the operating

--- a/content/rs/administering/installing-upgrading/upgrading.md
+++ b/content/rs/administering/installing-upgrading/upgrading.md
@@ -3,7 +3,7 @@ Title: Upgrading Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Upgrading Redis Enterprise Software (RS) consists of upgrading the
 software on each of the nodes.

--- a/content/rs/administering/installing-upgrading/upgrading.md
+++ b/content/rs/administering/installing-upgrading/upgrading.md
@@ -3,6 +3,7 @@ Title: Upgrading Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Upgrading Redis Enterprise Software (RS) consists of upgrading the
 software on each of the nodes.

--- a/content/rs/administering/intercluster-replication/_index.md
+++ b/content/rs/administering/intercluster-replication/_index.md
@@ -3,6 +3,6 @@ Title: Intercluster Replication
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/intercluster-replication/_index.md
+++ b/content/rs/administering/intercluster-replication/_index.md
@@ -3,5 +3,6 @@ Title: Intercluster Replication
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/intercluster-replication/crdbs.md
+++ b/content/rs/administering/intercluster-replication/crdbs.md
@@ -3,6 +3,7 @@ Title: Administering CRDBs
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Conflict Free Replicated Databases (CRDBs) provide a simple and
 effective way to replicate your data between one or more Redis

--- a/content/rs/administering/intercluster-replication/crdbs.md
+++ b/content/rs/administering/intercluster-replication/crdbs.md
@@ -3,7 +3,7 @@ Title: Administering CRDBs
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Conflict Free Replicated Databases (CRDBs) provide a simple and
 effective way to replicate your data between one or more Redis

--- a/content/rs/administering/intercluster-replication/replica-of.md
+++ b/content/rs/administering/intercluster-replication/replica-of.md
@@ -3,7 +3,7 @@ Title: Unidirectional Replication with Replica of
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 *Replica of* is a feature of Redis Enterprise Software (RS) where an
 administrator designates a database to be a replica (destination) of one

--- a/content/rs/administering/intercluster-replication/replica-of.md
+++ b/content/rs/administering/intercluster-replication/replica-of.md
@@ -3,6 +3,7 @@ Title: Unidirectional Replication with Replica of
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 *Replica of* is a feature of Redis Enterprise Software (RS) where an
 administrator designates a database to be a replica (destination) of one

--- a/content/rs/administering/kubernetes/_index.md
+++ b/content/rs/administering/kubernetes/_index.md
@@ -3,6 +3,7 @@ Title: Kubernetes
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section contains Kubernetes specific articles which cover various aspects of administering a Redis Enterprise Cluster K8s deployment.
 

--- a/content/rs/administering/kubernetes/_index.md
+++ b/content/rs/administering/kubernetes/_index.md
@@ -3,7 +3,7 @@ Title: Kubernetes
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section contains Kubernetes specific articles which cover various aspects of administering a Redis Enterprise Cluster K8s deployment.
 

--- a/content/rs/administering/kubernetes/kubernetes-operator-deployment-persistent-volumes.md
+++ b/content/rs/administering/kubernetes/kubernetes-operator-deployment-persistent-volumes.md
@@ -3,7 +3,7 @@ Title: Kubernetes Operator Deployment – Persistent Volumes
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 To deploy a Redis Enterprise Cluster with Redis Enterprise Operator the
 spec should include a *persistentSpec* section, in the

--- a/content/rs/administering/kubernetes/kubernetes-operator-deployment-persistent-volumes.md
+++ b/content/rs/administering/kubernetes/kubernetes-operator-deployment-persistent-volumes.md
@@ -3,6 +3,7 @@ Title: Kubernetes Operator Deployment – Persistent Volumes
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 To deploy a Redis Enterprise Cluster with Redis Enterprise Operator the
 spec should include a *persistentSpec* section, in the

--- a/content/rs/administering/kubernetes/sizing-scaling-redis-enterprise-cluster-kubernetes-deployment.md
+++ b/content/rs/administering/kubernetes/sizing-scaling-redis-enterprise-cluster-kubernetes-deployment.md
@@ -3,6 +3,7 @@ Title: Sizing and scaling a Redis Enterprise Cluster Kubernetes deployment
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The following article reviews the mechanism and methods available for sizing 
 and scaling a Redis Enterprise Cluster deployment.

--- a/content/rs/administering/kubernetes/sizing-scaling-redis-enterprise-cluster-kubernetes-deployment.md
+++ b/content/rs/administering/kubernetes/sizing-scaling-redis-enterprise-cluster-kubernetes-deployment.md
@@ -3,7 +3,7 @@ Title: Sizing and scaling a Redis Enterprise Cluster Kubernetes deployment
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The following article reviews the mechanism and methods available for sizing 
 and scaling a Redis Enterprise Cluster deployment.

--- a/content/rs/administering/kubernetes/upgrading-redis-enterprise-cluster-kubernetes-deployment-operator.md
+++ b/content/rs/administering/kubernetes/upgrading-redis-enterprise-cluster-kubernetes-deployment-operator.md
@@ -3,6 +3,7 @@ Title: Upgrading a Redis Enterprise Cluster – Kubernetes Deployment with Opera
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Labs implements rolling updates for software upgrades in Kubernetes deployments.
 

--- a/content/rs/administering/kubernetes/upgrading-redis-enterprise-cluster-kubernetes-deployment-operator.md
+++ b/content/rs/administering/kubernetes/upgrading-redis-enterprise-cluster-kubernetes-deployment-operator.md
@@ -3,7 +3,7 @@ Title: Upgrading a Redis Enterprise Cluster – Kubernetes Deployment with Opera
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Labs implements rolling updates for software upgrades in Kubernetes deployments.
 

--- a/content/rs/administering/logging/_index.md
+++ b/content/rs/administering/logging/_index.md
@@ -3,6 +3,7 @@ Title: Logging and Audit Events
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Management actions performed with Redis Enterprise are audited in order
 to fulfill two major objectives:

--- a/content/rs/administering/logging/_index.md
+++ b/content/rs/administering/logging/_index.md
@@ -3,7 +3,7 @@ Title: Logging and Audit Events
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Management actions performed with Redis Enterprise are audited in order
 to fulfill two major objectives:

--- a/content/rs/administering/logging/redis-slow-log.md
+++ b/content/rs/administering/logging/redis-slow-log.md
@@ -3,6 +3,7 @@ Title: Viewing Redis Slow Log
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 On the **Database** \> **Slow Log** page, you can view Slow Log details
 for Redis Enterprise Software (RS) databases.

--- a/content/rs/administering/logging/redis-slow-log.md
+++ b/content/rs/administering/logging/redis-slow-log.md
@@ -3,7 +3,7 @@ Title: Viewing Redis Slow Log
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 On the **Database** \> **Slow Log** page, you can view Slow Log details
 for Redis Enterprise Software (RS) databases.

--- a/content/rs/administering/logging/rsyslog-logging.md
+++ b/content/rs/administering/logging/rsyslog-logging.md
@@ -3,7 +3,7 @@ Title: rsyslog logging
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This document explains the structure of Redis Enterprise Software (RS)
 log entries that go into rsyslog and how to use these log entries to

--- a/content/rs/administering/logging/rsyslog-logging.md
+++ b/content/rs/administering/logging/rsyslog-logging.md
@@ -3,6 +3,7 @@ Title: rsyslog logging
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This document explains the structure of Redis Enterprise Software (RS)
 log entries that go into rsyslog and how to use these log entries to

--- a/content/rs/administering/monitoring-metrics/_index.md
+++ b/content/rs/administering/monitoring-metrics/_index.md
@@ -3,5 +3,6 @@ Title: Monitoring and Metrics
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/monitoring-metrics/_index.md
+++ b/content/rs/administering/monitoring-metrics/_index.md
@@ -3,6 +3,6 @@ Title: Monitoring and Metrics
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/monitoring-metrics/definitions.md
+++ b/content/rs/administering/monitoring-metrics/definitions.md
@@ -3,6 +3,7 @@ Title: Metrics Definitions
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) includes many useful metrics that can be
 tracked to give you a detailed picture of what is going on in the

--- a/content/rs/administering/monitoring-metrics/definitions.md
+++ b/content/rs/administering/monitoring-metrics/definitions.md
@@ -3,7 +3,7 @@ Title: Metrics Definitions
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) includes many useful metrics that can be
 tracked to give you a detailed picture of what is going on in the

--- a/content/rs/administering/monitoring-metrics/nagios-plugin.md
+++ b/content/rs/administering/monitoring-metrics/nagios-plugin.md
@@ -3,6 +3,7 @@ Title: Nagios plugin for Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The RS Nagios plugin enables you to monitor the status of RS related
 objects and alerts. The RS alerts can be related to the cluster, nodes,

--- a/content/rs/administering/monitoring-metrics/nagios-plugin.md
+++ b/content/rs/administering/monitoring-metrics/nagios-plugin.md
@@ -3,7 +3,7 @@ Title: Nagios plugin for Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The RS Nagios plugin enables you to monitor the status of RS related
 objects and alerts. The RS alerts can be related to the cluster, nodes,

--- a/content/rs/administering/product-lifecycle.md
+++ b/content/rs/administering/product-lifecycle.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software Product Lifecycle
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can view the Redis Enterprise Software subscription agreement
 [here](https://redislabs.com/company/terms-of-use#software). For details of the End of Life

--- a/content/rs/administering/product-lifecycle.md
+++ b/content/rs/administering/product-lifecycle.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software Product Lifecycle
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can view the Redis Enterprise Software subscription agreement
 [here](https://redislabs.com/company/terms-of-use#software). For details of the End of Life

--- a/content/rs/administering/security/_index.md
+++ b/content/rs/administering/security/_index.md
@@ -3,6 +3,6 @@ Title: Security
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/security/_index.md
+++ b/content/rs/administering/security/_index.md
@@ -3,5 +3,6 @@ Title: Security
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/administering/security/account-management.md
+++ b/content/rs/administering/security/account-management.md
@@ -3,7 +3,7 @@ Title: Account Management
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 You can view and update the cluster users in the** **cluster's
 **Settings \> team** page.

--- a/content/rs/administering/security/account-management.md
+++ b/content/rs/administering/security/account-management.md
@@ -3,6 +3,7 @@ Title: Account Management
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 You can view and update the cluster users in the** **cluster's
 **Settings \> team** page.

--- a/content/rs/administering/security/client-connections.md
+++ b/content/rs/administering/security/client-connections.md
@@ -3,6 +3,7 @@ Title: Securing Redis Client Connections
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you configure it, Redis Enterprise Software (RS) can
 use industry-standard encryption to protect your data in transit between

--- a/content/rs/administering/security/client-connections.md
+++ b/content/rs/administering/security/client-connections.md
@@ -3,7 +3,7 @@ Title: Securing Redis Client Connections
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you configure it, Redis Enterprise Software (RS) can
 use industry-standard encryption to protect your data in transit between

--- a/content/rs/administering/security/ldap-integration.md
+++ b/content/rs/administering/security/ldap-integration.md
@@ -3,7 +3,7 @@ Title: Integrating LDAP Authentication
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) provides you with the ability to
 integrate your existing LDAP server for authentication for account

--- a/content/rs/administering/security/ldap-integration.md
+++ b/content/rs/administering/security/ldap-integration.md
@@ -3,6 +3,7 @@ Title: Integrating LDAP Authentication
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) provides you with the ability to
 integrate your existing LDAP server for authentication for account

--- a/content/rs/administering/troubleshooting/_index.md
+++ b/content/rs/administering/troubleshooting/_index.md
@@ -3,6 +3,7 @@ Title: Troubleshooting
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section includes various troubleshooting tips and tricks for Redis
 Enterprise Software (RES).

--- a/content/rs/administering/troubleshooting/_index.md
+++ b/content/rs/administering/troubleshooting/_index.md
@@ -3,7 +3,7 @@ Title: Troubleshooting
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section includes various troubleshooting tips and tricks for Redis
 Enterprise Software (RES).

--- a/content/rs/administering/troubleshooting/cluster-recovery.md
+++ b/content/rs/administering/troubleshooting/cluster-recovery.md
@@ -3,7 +3,7 @@ Title: Cluster Recovery
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Cluster recovery in Redis Enterprise Software (RS) is used for restoring
 an entire cluster, usually due to a complete cluster failure. The

--- a/content/rs/administering/troubleshooting/cluster-recovery.md
+++ b/content/rs/administering/troubleshooting/cluster-recovery.md
@@ -3,6 +3,7 @@ Title: Cluster Recovery
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Cluster recovery in Redis Enterprise Software (RS) is used for restoring
 an entire cluster, usually due to a complete cluster failure. The

--- a/content/rs/administering/troubleshooting/creating-support-package.md
+++ b/content/rs/administering/troubleshooting/creating-support-package.md
@@ -3,6 +3,7 @@ Title: Creating a support package
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you encounter any issues that you are not able to resolve yourself
 and need to contact Redis Labs support for assistance, you can create a

--- a/content/rs/administering/troubleshooting/creating-support-package.md
+++ b/content/rs/administering/troubleshooting/creating-support-package.md
@@ -3,7 +3,7 @@ Title: Creating a support package
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you encounter any issues that you are not able to resolve yourself
 and need to contact Redis Labs support for assistance, you can create a

--- a/content/rs/administering/troubleshooting/database-metrics-blank-during-resharding.md
+++ b/content/rs/administering/troubleshooting/database-metrics-blank-during-resharding.md
@@ -3,6 +3,7 @@ Title: Database metrics are blank during resharding
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Because data is being moved around across shards during the resharding
 process, it is impossible to report the values of some of the metrics in

--- a/content/rs/administering/troubleshooting/database-metrics-blank-during-resharding.md
+++ b/content/rs/administering/troubleshooting/database-metrics-blank-during-resharding.md
@@ -3,7 +3,7 @@ Title: Database metrics are blank during resharding
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Because data is being moved around across shards during the resharding
 process, it is impossible to report the values of some of the metrics in

--- a/content/rs/administering/troubleshooting/network-configuration.md
+++ b/content/rs/administering/troubleshooting/network-configuration.md
@@ -3,6 +3,7 @@ Title: Network configuration
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Nodes in the same cluster must reside on the same VLAN. If you cannot
 host the nodes on the same VLAN then you must configure all ports

--- a/content/rs/administering/troubleshooting/network-configuration.md
+++ b/content/rs/administering/troubleshooting/network-configuration.md
@@ -3,7 +3,7 @@ Title: Network configuration
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Nodes in the same cluster must reside on the same VLAN. If you cannot
 host the nodes on the same VLAN then you must configure all ports

--- a/content/rs/administering/troubleshooting/replicaof-repeatedly-fails.md
+++ b/content/rs/administering/troubleshooting/replicaof-repeatedly-fails.md
@@ -3,6 +3,7 @@ Title: ReplicaOf Repeatedly Fails
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 There might be instances in which the Replica of process repeatedly
 fails and restarts itself on Redis Enterprise Software (RS). This can

--- a/content/rs/administering/troubleshooting/replicaof-repeatedly-fails.md
+++ b/content/rs/administering/troubleshooting/replicaof-repeatedly-fails.md
@@ -3,7 +3,7 @@ Title: ReplicaOf Repeatedly Fails
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 There might be instances in which the Replica of process repeatedly
 fails and restarts itself on Redis Enterprise Software (RS). This can

--- a/content/rs/administering/troubleshooting/testing-client-connectivity.md
+++ b/content/rs/administering/troubleshooting/testing-client-connectivity.md
@@ -3,6 +3,7 @@ Title: Testing client connectivity
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 In various scenarios, such as after creating a new cluster or upgrading
 the cluster, it is highly advisable to verify client connectivity to the

--- a/content/rs/administering/troubleshooting/testing-client-connectivity.md
+++ b/content/rs/administering/troubleshooting/testing-client-connectivity.md
@@ -3,7 +3,7 @@ Title: Testing client connectivity
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 In various scenarios, such as after creating a new cluster or upgrading
 the cluster, it is highly advisable to verify client connectivity to the

--- a/content/rs/concepts/_index.md
+++ b/content/rs/concepts/_index.md
@@ -3,6 +3,7 @@ Title: Concepts and Architecture
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 A Redis Enterprise cluster is composed of identical nodes that are
 deployed within a data center or stretched across local availability

--- a/content/rs/concepts/_index.md
+++ b/content/rs/concepts/_index.md
@@ -3,7 +3,7 @@ Title: Concepts and Architecture
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 A Redis Enterprise cluster is composed of identical nodes that are
 deployed within a data center or stretched across local availability

--- a/content/rs/concepts/compatibility.md
+++ b/content/rs/concepts/compatibility.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software Compatibility with Open Source Redis
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RES) is fully compatible with open source
 Redis. Redis Labs contributes extensively to the open source Redis

--- a/content/rs/concepts/compatibility.md
+++ b/content/rs/concepts/compatibility.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software Compatibility with Open Source Redis
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RES) is fully compatible with open source
 Redis. Redis Labs contributes extensively to the open source Redis

--- a/content/rs/concepts/data-access/_index.md
+++ b/content/rs/concepts/data-access/_index.md
@@ -3,5 +3,6 @@ Title: Data Access Architecture
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/concepts/data-access/_index.md
+++ b/content/rs/concepts/data-access/_index.md
@@ -3,6 +3,6 @@ Title: Data Access Architecture
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/concepts/data-access/consistency-durability.md
+++ b/content/rs/concepts/data-access/consistency-durability.md
@@ -3,7 +3,7 @@ Title: Consistency and Durability
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RES) comes with the ability to replicate data
 to another slave for high availability and persist in-memory data on

--- a/content/rs/concepts/data-access/consistency-durability.md
+++ b/content/rs/concepts/data-access/consistency-durability.md
@@ -3,6 +3,7 @@ Title: Consistency and Durability
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RES) comes with the ability to replicate data
 to another slave for high availability and persist in-memory data on

--- a/content/rs/concepts/data-access/discovery-service.md
+++ b/content/rs/concepts/data-access/discovery-service.md
@@ -3,7 +3,7 @@ Title: Discovery Service
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The Discovery Service provides an IP-based connection management service
 used when connecting to Redis Enterprise Software databases. When used

--- a/content/rs/concepts/data-access/discovery-service.md
+++ b/content/rs/concepts/data-access/discovery-service.md
@@ -3,6 +3,7 @@ Title: Discovery Service
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The Discovery Service provides an IP-based connection management service
 used when connecting to Redis Enterprise Software databases. When used

--- a/content/rs/concepts/data-access/oss-cluster-api.md
+++ b/content/rs/concepts/data-access/oss-cluster-api.md
@@ -4,6 +4,7 @@ description:
 weight: $weight
 alwaysopen: false
 aliases: /rs/concepts/data-access/cluster-api/
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%excerpt%}}The Redis OSS Cluster API support in Redis Enterprise Software (RS)
 provides a simple mechanism for cluster-aware Redis clients to learn

--- a/content/rs/concepts/data-access/oss-cluster-api.md
+++ b/content/rs/concepts/data-access/oss-cluster-api.md
@@ -4,7 +4,7 @@ description:
 weight: $weight
 alwaysopen: false
 aliases: /rs/concepts/data-access/cluster-api/
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%excerpt%}}The Redis OSS Cluster API support in Redis Enterprise Software (RS)
 provides a simple mechanism for cluster-aware Redis clients to learn

--- a/content/rs/concepts/data-access/persistence.md
+++ b/content/rs/concepts/data-access/persistence.md
@@ -3,7 +3,7 @@ Title: Database Persistence with Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 All data is stored and managed exclusively in either RAM or RAM + Flash
 Memory ([Redis on

--- a/content/rs/concepts/data-access/persistence.md
+++ b/content/rs/concepts/data-access/persistence.md
@@ -3,6 +3,7 @@ Title: Database Persistence with Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 All data is stored and managed exclusively in either RAM or RAM + Flash
 Memory ([Redis on

--- a/content/rs/concepts/high-availability/_index.md
+++ b/content/rs/concepts/high-availability/_index.md
@@ -3,5 +3,6 @@ Title: High Availability
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/concepts/high-availability/_index.md
+++ b/content/rs/concepts/high-availability/_index.md
@@ -3,6 +3,6 @@ Title: High Availability
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/concepts/high-availability/clustering.md
+++ b/content/rs/concepts/high-availability/clustering.md
@@ -3,7 +3,7 @@ Title: Database clustering
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 [Redis](https://redislabs.com/redis-features/redis) is (mostly) a
 single-threaded process. This is a design decision that allows it to be

--- a/content/rs/concepts/high-availability/clustering.md
+++ b/content/rs/concepts/high-availability/clustering.md
@@ -3,6 +3,7 @@ Title: Database clustering
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 [Redis](https://redislabs.com/redis-features/redis) is (mostly) a
 single-threaded process. This is a design decision that allows it to be

--- a/content/rs/concepts/high-availability/rack-zone-awareness.md
+++ b/content/rs/concepts/high-availability/rack-zone-awareness.md
@@ -3,7 +3,7 @@ Title: Rack-zone awareness in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The rack-zone awareness feature enables more sophisticated placement of
 database shards and endpoints in high-availability scenarios, as

--- a/content/rs/concepts/high-availability/rack-zone-awareness.md
+++ b/content/rs/concepts/high-availability/rack-zone-awareness.md
@@ -3,6 +3,7 @@ Title: Rack-zone awareness in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The rack-zone awareness feature enables more sophisticated placement of
 database shards and endpoints in high-availability scenarios, as

--- a/content/rs/concepts/high-availability/replication.md
+++ b/content/rs/concepts/high-availability/replication.md
@@ -3,6 +3,7 @@ Title: Database replication
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Database replication provides a mechanism to ensure high availability.
 When replication is enabled, your dataset is replicated to a slave node,

--- a/content/rs/concepts/high-availability/replication.md
+++ b/content/rs/concepts/high-availability/replication.md
@@ -3,7 +3,7 @@ Title: Database replication
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Database replication provides a mechanism to ensure high availability.
 When replication is enabled, your dataset is replicated to a slave node,

--- a/content/rs/concepts/intercluster-replication.md
+++ b/content/rs/concepts/intercluster-replication.md
@@ -3,7 +3,7 @@ Title: Geo-Distributed Active-Active Redis Applications with Conflict-free Repli
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Developing globally distributed applications can be challenging, as
 developers have to think about race conditions and complex combinations

--- a/content/rs/concepts/intercluster-replication.md
+++ b/content/rs/concepts/intercluster-replication.md
@@ -3,6 +3,7 @@ Title: Geo-Distributed Active-Active Redis Applications with Conflict-free Repli
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Developing globally distributed applications can be challenging, as
 developers have to think about race conditions and complex combinations

--- a/content/rs/concepts/kubernetes-architecture/_index.md
+++ b/content/rs/concepts/kubernetes-architecture/_index.md
@@ -3,7 +3,7 @@ Title: Kubernetes Architecture
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Kubernetes is becoming an industry standard for orchestrating containerized applications efficiently and at scale. Redis Labs has developed support for a robust, highly available K8s deployment simplifying lifecycle management of multiple Redis Enterprise databases on a Redis Enterprise Cluster. Redis Labs K8s deployments are supports over multiple K8s distributions and implementations.
 

--- a/content/rs/concepts/kubernetes-architecture/_index.md
+++ b/content/rs/concepts/kubernetes-architecture/_index.md
@@ -3,6 +3,7 @@ Title: Kubernetes Architecture
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Kubernetes is becoming an industry standard for orchestrating containerized applications efficiently and at scale. Redis Labs has developed support for a robust, highly available K8s deployment simplifying lifecycle management of multiple Redis Enterprise databases on a Redis Enterprise Cluster. Redis Labs K8s deployments are supports over multiple K8s distributions and implementations.
 

--- a/content/rs/concepts/kubernetes-architecture/k8s-operator-based-deployments.md
+++ b/content/rs/concepts/kubernetes-architecture/k8s-operator-based-deployments.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise K8s Operator-based deployments – Overview
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The Redis Enterprise Operator is the fastest, most efficient way to
 deploy and maintain a Redis Enterprise Cluster in Kubernetes.

--- a/content/rs/concepts/kubernetes-architecture/k8s-operator-based-deployments.md
+++ b/content/rs/concepts/kubernetes-architecture/k8s-operator-based-deployments.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise K8s Operator-based deployments – Overview
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The Redis Enterprise Operator is the fastest, most efficient way to
 deploy and maintain a Redis Enterprise Cluster in Kubernetes.

--- a/content/rs/concepts/kubernetes-architecture/redis-labs-kubernetes-architecture-overview.md
+++ b/content/rs/concepts/kubernetes-architecture/redis-labs-kubernetes-architecture-overview.md
@@ -3,6 +3,7 @@ Title: Redis Labs Kubernetes Architecture – Overview
 description: 
 weight: 30
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Labs bases its Kubernetes architecture on the several vital concepts.
 

--- a/content/rs/concepts/kubernetes-architecture/redis-labs-kubernetes-architecture-overview.md
+++ b/content/rs/concepts/kubernetes-architecture/redis-labs-kubernetes-architecture-overview.md
@@ -3,7 +3,7 @@ Title: Redis Labs Kubernetes Architecture – Overview
 description: 
 weight: 30
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Labs bases its Kubernetes architecture on the several vital concepts.
 

--- a/content/rs/concepts/memory-architecture/_index.md
+++ b/content/rs/concepts/memory-architecture/_index.md
@@ -3,7 +3,7 @@ Title: Memory Architecture in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software has multiple memory mechanisms in its
 architecture, from RAM to Flash Memory, to having databases that span

--- a/content/rs/concepts/memory-architecture/_index.md
+++ b/content/rs/concepts/memory-architecture/_index.md
@@ -3,6 +3,7 @@ Title: Memory Architecture in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software has multiple memory mechanisms in its
 architecture, from RAM to Flash Memory, to having databases that span

--- a/content/rs/concepts/memory-architecture/memory-management.md
+++ b/content/rs/concepts/memory-architecture/memory-management.md
@@ -3,6 +3,7 @@ Title: Memory Mangement with Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 By default, RS manages node memory so that data is entirely in RAM for improved
 database performance. RS is designed to handle memory management to optimize database 

--- a/content/rs/concepts/memory-architecture/memory-management.md
+++ b/content/rs/concepts/memory-architecture/memory-management.md
@@ -3,7 +3,7 @@ Title: Memory Mangement with Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 By default, RS manages node memory so that data is entirely in RAM for improved
 database performance. RS is designed to handle memory management to optimize database 

--- a/content/rs/concepts/memory-architecture/redis-flash.md
+++ b/content/rs/concepts/memory-architecture/redis-flash.md
@@ -3,7 +3,7 @@ Title: Redis on Flash
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis on Flash (RoF) offers users of [Redis Enterprise
 Software]({{< relref "/rs/_index.md" >}}) and [Redis

--- a/content/rs/concepts/memory-architecture/redis-flash.md
+++ b/content/rs/concepts/memory-architecture/redis-flash.md
@@ -3,6 +3,7 @@ Title: Redis on Flash
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis on Flash (RoF) offers users of [Redis Enterprise
 Software]({{< relref "/rs/_index.md" >}}) and [Redis

--- a/content/rs/concepts/rebalancing-shard-placement.md
+++ b/content/rs/concepts/rebalancing-shard-placement.md
@@ -3,6 +3,7 @@ Title: Rebalancing and Shard Placement
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RES) cluster offer a few master and slave
 shard placement policies that govern how shards of each database is

--- a/content/rs/concepts/rebalancing-shard-placement.md
+++ b/content/rs/concepts/rebalancing-shard-placement.md
@@ -3,7 +3,7 @@ Title: Rebalancing and Shard Placement
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RES) cluster offer a few master and slave
 shard placement policies that govern how shards of each database is

--- a/content/rs/concepts/terminology.md
+++ b/content/rs/concepts/terminology.md
@@ -3,7 +3,7 @@ Title: Terminology in Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Here are explanations of some of the terms used in RS.
 

--- a/content/rs/concepts/terminology.md
+++ b/content/rs/concepts/terminology.md
@@ -3,6 +3,7 @@ Title: Terminology in Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Here are explanations of some of the terms used in RS.
 

--- a/content/rs/developing/_index.md
+++ b/content/rs/developing/_index.md
@@ -3,6 +3,6 @@ Title: Developing for Redis Enterprise
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/developing/_index.md
+++ b/content/rs/developing/_index.md
@@ -3,5 +3,6 @@ Title: Developing for Redis Enterprise
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/developing/crdbs/_index.md
+++ b/content/rs/developing/crdbs/_index.md
@@ -3,7 +3,7 @@ Title: Developing Applications with Geo-replicated CRDBs on Redis Enterprise Sof
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Developing geo-distributed, multi-master applications can be difficult.
 Application developers may have to understand a large number of race

--- a/content/rs/developing/crdbs/_index.md
+++ b/content/rs/developing/crdbs/_index.md
@@ -3,6 +3,7 @@ Title: Developing Applications with Geo-replicated CRDBs on Redis Enterprise Sof
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Developing geo-distributed, multi-master applications can be difficult.
 Application developers may have to understand a large number of race

--- a/content/rs/developing/crdbs/developing-hashes-crdb.md
+++ b/content/rs/developing/crdbs/developing-hashes-crdb.md
@@ -3,7 +3,7 @@ Title: Developing with Hashes in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Hashes are great for structured data that contain a map of fields and
 values. They are used for managing distributed user or app session

--- a/content/rs/developing/crdbs/developing-hashes-crdb.md
+++ b/content/rs/developing/crdbs/developing-hashes-crdb.md
@@ -3,6 +3,7 @@ Title: Developing with Hashes in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Hashes are great for structured data that contain a map of fields and
 values. They are used for managing distributed user or app session

--- a/content/rs/developing/crdbs/developing-lists-crdb.md
+++ b/content/rs/developing/crdbs/developing-lists-crdb.md
@@ -3,7 +3,7 @@ Title: Developing with Lists in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Lists are simply lists of strings, sorted by insertion order. It
 is possible to add elements to a Redis List that push new elements to

--- a/content/rs/developing/crdbs/developing-lists-crdb.md
+++ b/content/rs/developing/crdbs/developing-lists-crdb.md
@@ -3,6 +3,7 @@ Title: Developing with Lists in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Lists are simply lists of strings, sorted by insertion order. It
 is possible to add elements to a Redis List that push new elements to

--- a/content/rs/developing/crdbs/developing-sets-crdb.md
+++ b/content/rs/developing/crdbs/developing-sets-crdb.md
@@ -3,6 +3,7 @@ Title: Developing with Sets in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Sets are an unordered collection of Strings. It is possible to
 add, remove, and test for the existence of members with Redis commands.

--- a/content/rs/developing/crdbs/developing-sets-crdb.md
+++ b/content/rs/developing/crdbs/developing-sets-crdb.md
@@ -3,7 +3,7 @@ Title: Developing with Sets in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Sets are an unordered collection of Strings. It is possible to
 add, remove, and test for the existence of members with Redis commands.

--- a/content/rs/developing/crdbs/developing-sorted-sets-crdb.md
+++ b/content/rs/developing/crdbs/developing-sorted-sets-crdb.md
@@ -3,7 +3,7 @@ Title: Developing with Sorted Sets in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Similar to Redis Sets, Redis Sorted Sets are non-repeating collections
 of Strings. The difference between the two is that every member of a

--- a/content/rs/developing/crdbs/developing-sorted-sets-crdb.md
+++ b/content/rs/developing/crdbs/developing-sorted-sets-crdb.md
@@ -3,6 +3,7 @@ Title: Developing with Sorted Sets in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Similar to Redis Sets, Redis Sorted Sets are non-repeating collections
 of Strings. The difference between the two is that every member of a

--- a/content/rs/developing/crdbs/strings.md
+++ b/content/rs/developing/crdbs/strings.md
@@ -3,7 +3,7 @@ Title: Developing with Strings in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Strings have particular unique characteristics in a CRDB. First off,
 they are the only data type that Last Write Wins (LWW) applies to. As

--- a/content/rs/developing/crdbs/strings.md
+++ b/content/rs/developing/crdbs/strings.md
@@ -3,6 +3,7 @@ Title: Developing with Strings in a CRDB
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Strings have particular unique characteristics in a CRDB. First off,
 they are the only data type that Last Write Wins (LWW) applies to. As

--- a/content/rs/developing/modules/_index.md
+++ b/content/rs/developing/modules/_index.md
@@ -3,6 +3,7 @@ Title: Developing with Redis Modules in Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Note: Modules are not supported in Redis Enterprise Software on
 RHEL/CentOS 6.x

--- a/content/rs/developing/modules/_index.md
+++ b/content/rs/developing/modules/_index.md
@@ -3,7 +3,7 @@ Title: Developing with Redis Modules in Redis Enterprise Software (RS)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Note: Modules are not supported in Redis Enterprise Software on
 RHEL/CentOS 6.x

--- a/content/rs/developing/modules/bloom-filters.md
+++ b/content/rs/developing/modules/bloom-filters.md
@@ -3,7 +3,7 @@ Title: Developing with Bloom Filters
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 A Bloom filter is a probabilistic data structure which provides an
 efficient way to verify that an entry is certainly *not* in a set. This

--- a/content/rs/developing/modules/bloom-filters.md
+++ b/content/rs/developing/modules/bloom-filters.md
@@ -3,6 +3,7 @@ Title: Developing with Bloom Filters
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 A Bloom filter is a probabilistic data structure which provides an
 efficient way to verify that an entry is certainly *not* in a set. This

--- a/content/rs/developing/modules/installing.md
+++ b/content/rs/developing/modules/installing.md
@@ -3,7 +3,7 @@ Title: Installing a Module
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Before you can install a module, it must be packaged to be used in Redis
 Enterprise Software (RS). There are two types

--- a/content/rs/developing/modules/installing.md
+++ b/content/rs/developing/modules/installing.md
@@ -3,6 +3,7 @@ Title: Installing a Module
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Before you can install a module, it must be packaged to be used in Redis
 Enterprise Software (RS). There are two types

--- a/content/rs/developing/modules/redisearch.md
+++ b/content/rs/developing/modules/redisearch.md
@@ -3,7 +3,7 @@ Title: Developing Fast Search and Query with In-Memory Indexing
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The RediSearch Enterprise Module combined with Redis Enterprise Software
 (RS) provides a high performance, integrated query, and full-text search

--- a/content/rs/developing/modules/redisearch.md
+++ b/content/rs/developing/modules/redisearch.md
@@ -3,6 +3,7 @@ Title: Developing Fast Search and Query with In-Memory Indexing
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The RediSearch Enterprise Module combined with Redis Enterprise Software
 (RS) provides a high performance, integrated query, and full-text search

--- a/content/rs/developing/modules/rejson.md
+++ b/content/rs/developing/modules/rejson.md
@@ -3,7 +3,7 @@ Title: Developing Applications with ReJSON
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Applications developed with the open source version of ReJSON are 100%
 compatible with ReJSON in Redis Enterprise Software (RS).

--- a/content/rs/developing/modules/rejson.md
+++ b/content/rs/developing/modules/rejson.md
@@ -3,6 +3,7 @@ Title: Developing Applications with ReJSON
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Applications developed with the open source version of ReJSON are 100%
 compatible with ReJSON in Redis Enterprise Software (RS).

--- a/content/rs/developing/modules/upgrading.md
+++ b/content/rs/developing/modules/upgrading.md
@@ -3,6 +3,7 @@ Title: Upgrading a Module in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 As modules are upgraded, you will need to load them into Redis
 Enterprise if you desire having the new features and/or

--- a/content/rs/developing/modules/upgrading.md
+++ b/content/rs/developing/modules/upgrading.md
@@ -3,7 +3,7 @@ Title: Upgrading a Module in Redis Enterprise Software
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 As modules are upgraded, you will need to load them into Redis
 Enterprise if you desire having the new features and/or

--- a/content/rs/faqs/_index.md
+++ b/content/rs/faqs/_index.md
@@ -3,7 +3,7 @@ Title: FAQs
 description: 
 weight: 70
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section includes various frequently asked questions.
 

--- a/content/rs/faqs/_index.md
+++ b/content/rs/faqs/_index.md
@@ -3,6 +3,7 @@ Title: FAQs
 description: 
 weight: 70
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section includes various frequently asked questions.
 

--- a/content/rs/getting-started/_index.md
+++ b/content/rs/getting-started/_index.md
@@ -3,6 +3,7 @@ Title: Getting Started with Redis Enterprise Software (RS)
 description: 
 weight: 30
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 This section contains pages to help you get started quickly with a
 minimum setup and use the various features, environments, and systems

--- a/content/rs/getting-started/_index.md
+++ b/content/rs/getting-started/_index.md
@@ -3,7 +3,7 @@ Title: Getting Started with Redis Enterprise Software (RS)
 description: 
 weight: 30
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 This section contains pages to help you get started quickly with a
 minimum setup and use the various features, environments, and systems

--- a/content/rs/getting-started/creating-database/_index.md
+++ b/content/rs/getting-started/creating-database/_index.md
@@ -3,7 +3,7 @@ title: Creating a Database
 description: 
 weight: 20
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rs/getting-started/creating-database/_index.md
+++ b/content/rs/getting-started/creating-database/_index.md
@@ -3,6 +3,7 @@ title: Creating a Database
 description: 
 weight: 20
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rs/getting-started/creating-database/crdbs.md
+++ b/content/rs/getting-started/creating-database/crdbs.md
@@ -3,7 +3,7 @@ Title: Getting Started with Redis Enterprise CRDBs (conflict-free replicated dat
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 In this guide, we'll set up a scale-minimized CRDB (conflict-free
 replicated database) spanning across two Redis Enterprise Software

--- a/content/rs/getting-started/creating-database/crdbs.md
+++ b/content/rs/getting-started/creating-database/crdbs.md
@@ -3,6 +3,7 @@ Title: Getting Started with Redis Enterprise CRDBs (conflict-free replicated dat
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 In this guide, we'll set up a scale-minimized CRDB (conflict-free
 replicated database) spanning across two Redis Enterprise Software

--- a/content/rs/getting-started/creating-database/rebloom.md
+++ b/content/rs/getting-started/creating-database/rebloom.md
@@ -3,7 +3,7 @@ Title: ReBloom Quick Start Tutorial
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 For this quick start, you will need the following:
 

--- a/content/rs/getting-started/creating-database/rebloom.md
+++ b/content/rs/getting-started/creating-database/rebloom.md
@@ -3,6 +3,7 @@ Title: ReBloom Quick Start Tutorial
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 For this quick start, you will need the following:
 

--- a/content/rs/getting-started/creating-database/redis-flash.md
+++ b/content/rs/getting-started/creating-database/redis-flash.md
@@ -3,6 +3,7 @@ Title: Quick Setup of a Redis on Flash Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The steps to set up a Redis Enterprise Software cluster using [Redis on
 Flash]({{< relref "/rs/concepts/memory-architecture/redis-flash.md" >}})

--- a/content/rs/getting-started/creating-database/redis-flash.md
+++ b/content/rs/getting-started/creating-database/redis-flash.md
@@ -3,7 +3,7 @@ Title: Quick Setup of a Redis on Flash Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The steps to set up a Redis Enterprise Software cluster using [Redis on
 Flash]({{< relref "/rs/concepts/memory-architecture/redis-flash.md" >}})

--- a/content/rs/getting-started/creating-database/redisearch.md
+++ b/content/rs/getting-started/creating-database/redisearch.md
@@ -3,6 +3,7 @@ Title: RediSearch Quick Start Tutorial
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 For this quick start, you will need the following:
 

--- a/content/rs/getting-started/creating-database/redisearch.md
+++ b/content/rs/getting-started/creating-database/redisearch.md
@@ -3,7 +3,7 @@ Title: RediSearch Quick Start Tutorial
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 For this quick start, you will need the following:
 

--- a/content/rs/getting-started/creating-database/rejson-quick-start.md
+++ b/content/rs/getting-started/creating-database/rejson-quick-start.md
@@ -3,6 +3,7 @@ Title: ReJSON Quick Start Tutorial
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 For this quick start, you will need the following:
 

--- a/content/rs/getting-started/creating-database/rejson-quick-start.md
+++ b/content/rs/getting-started/creating-database/rejson-quick-start.md
@@ -3,7 +3,7 @@ Title: ReJSON Quick Start Tutorial
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 For this quick start, you will need the following:
 

--- a/content/rs/getting-started/docker/_index.md
+++ b/content/rs/getting-started/docker/_index.md
@@ -3,6 +3,7 @@ Title: Working with Redis Enterprise Software (RES) with Docker Containers
 description: 
 weight: 30
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software can be deployed using Docker Container on
 [Windows]({{< relref "/rs/getting-started/docker/windows.md" >}}),

--- a/content/rs/getting-started/docker/_index.md
+++ b/content/rs/getting-started/docker/_index.md
@@ -3,7 +3,7 @@ Title: Working with Redis Enterprise Software (RES) with Docker Containers
 description: 
 weight: 30
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software can be deployed using Docker Container on
 [Windows]({{< relref "/rs/getting-started/docker/windows.md" >}}),

--- a/content/rs/getting-started/docker/linux.md
+++ b/content/rs/getting-started/docker/linux.md
@@ -3,7 +3,7 @@ Title: Getting Started with Redis Enterprise Software using Docker on Linux
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 To get started with a single Redis Enterprise Software container on
 Linux, follow these four steps:

--- a/content/rs/getting-started/docker/linux.md
+++ b/content/rs/getting-started/docker/linux.md
@@ -3,6 +3,7 @@ Title: Getting Started with Redis Enterprise Software using Docker on Linux
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 To get started with a single Redis Enterprise Software container on
 Linux, follow these four steps:

--- a/content/rs/getting-started/docker/macos.md
+++ b/content/rs/getting-started/docker/macos.md
@@ -3,6 +3,7 @@ Title: Getting Started Tutorial with Redis Enterprise Software using Docker on 
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Note: macOS is only supported as a development and testing environment.
 

--- a/content/rs/getting-started/docker/macos.md
+++ b/content/rs/getting-started/docker/macos.md
@@ -3,7 +3,7 @@ Title: Getting Started Tutorial with Redis Enterprise Software using Docker on 
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Note: macOS is only supported as a development and testing environment.
 

--- a/content/rs/getting-started/docker/windows.md
+++ b/content/rs/getting-started/docker/windows.md
@@ -3,7 +3,7 @@ Title: Getting Started Tutorial with Redis Enterprise Software using Docker on W
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Note: Due to the docker image being Linux-based currently, Windows is
 only supported as a development and testing environment.

--- a/content/rs/getting-started/docker/windows.md
+++ b/content/rs/getting-started/docker/windows.md
@@ -3,6 +3,7 @@ Title: Getting Started Tutorial with Redis Enterprise Software using Docker on W
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Note: Due to the docker image being Linux-based currently, Windows is
 only supported as a development and testing environment.

--- a/content/rs/getting-started/getting-started-kubernetes.md
+++ b/content/rs/getting-started/getting-started-kubernetes.md
@@ -3,6 +3,7 @@ Title: Getting Started with Redis Enterprise Software using Kubernetes
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Kubernetes provides simpler orchestration with containers and has been widely adapted. It is simple to get a Redis Enterprise cluster on Kubernetes with the new Redis Enterprise Docker container.
 

--- a/content/rs/getting-started/getting-started-kubernetes.md
+++ b/content/rs/getting-started/getting-started-kubernetes.md
@@ -3,7 +3,7 @@ Title: Getting Started with Redis Enterprise Software using Kubernetes
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Kubernetes provides simpler orchestration with containers and has been widely adapted. It is simple to get a Redis Enterprise cluster on Kubernetes with the new Redis Enterprise Docker container.
 

--- a/content/rs/getting-started/k8s-openshift.md
+++ b/content/rs/getting-started/k8s-openshift.md
@@ -3,6 +3,7 @@ Title: Getting Started with Kubernetes and OpenShift
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 These are the steps required to set up a Redis Enterprise Software
 Cluster with OpenShift.

--- a/content/rs/getting-started/k8s-openshift.md
+++ b/content/rs/getting-started/k8s-openshift.md
@@ -3,7 +3,7 @@ Title: Getting Started with Kubernetes and OpenShift
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 These are the steps required to set up a Redis Enterprise Software
 Cluster with OpenShift.

--- a/content/rs/getting-started/memtier-benchmark.md
+++ b/content/rs/getting-started/memtier-benchmark.md
@@ -3,7 +3,7 @@ Title: Benchmarking Redis Enterprise
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you need to do a quick performance benchmark of Redis Enterprise, we
 have a tool just for this; memtier_benchmark.

--- a/content/rs/getting-started/memtier-benchmark.md
+++ b/content/rs/getting-started/memtier-benchmark.md
@@ -3,6 +3,7 @@ Title: Benchmarking Redis Enterprise
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you need to do a quick performance benchmark of Redis Enterprise, we
 have a tool just for this; memtier_benchmark.

--- a/content/rs/getting-started/pcf.md
+++ b/content/rs/getting-started/pcf.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software for Pivotal Cloud Foundry (PCF)
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise for Pivotal Cloud Foundry (PCF) exposes its service
 plans on the Marketplace. Developers can provision highly available and

--- a/content/rs/getting-started/pcf.md
+++ b/content/rs/getting-started/pcf.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software for Pivotal Cloud Foundry (PCF)
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise for Pivotal Cloud Foundry (PCF) exposes its service
 plans on the Marketplace. Developers can provision highly available and

--- a/content/rs/getting-started/quick-setup.md
+++ b/content/rs/getting-started/quick-setup.md
@@ -3,6 +3,7 @@ Title: Quick Setup of Redis Enterprise Software (RS)
 description: 
 weight: 10
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 The steps to set up a Redis Enterprise Software (RS) cluster with a
 single node are super simple and go as follows:

--- a/content/rs/getting-started/quick-setup.md
+++ b/content/rs/getting-started/quick-setup.md
@@ -3,7 +3,7 @@ Title: Quick Setup of Redis Enterprise Software (RS)
 description: 
 weight: 10
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 The steps to set up a Redis Enterprise Software (RS) cluster with a
 single node are super simple and go as follows:

--- a/content/rs/new-features-redis-enterprise.md
+++ b/content/rs/new-features-redis-enterprise.md
@@ -3,6 +3,7 @@ Title: What's new in Redis Enterprise Software 5.0?
 description: 
 weight: 20
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Below are detailed a few of the major features of this release of Redis
 Enterprise Software along with bug fixes and patches.

--- a/content/rs/new-features-redis-enterprise.md
+++ b/content/rs/new-features-redis-enterprise.md
@@ -3,7 +3,7 @@ Title: What's new in Redis Enterprise Software 5.0?
 description: 
 weight: 20
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Below are detailed a few of the major features of this release of Redis
 Enterprise Software along with bug fixes and patches.

--- a/content/rs/references/_index.md
+++ b/content/rs/references/_index.md
@@ -3,7 +3,7 @@ Title: Developer References
 description: 
 weight: 80
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rs/references/_index.md
+++ b/content/rs/references/_index.md
@@ -3,6 +3,7 @@ Title: Developer References
 description: 
 weight: 80
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rs/references/cli-reference/_index.md
+++ b/content/rs/references/cli-reference/_index.md
@@ -3,6 +3,6 @@ Title: CLI References
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/references/cli-reference/_index.md
+++ b/content/rs/references/cli-reference/_index.md
@@ -3,5 +3,6 @@ Title: CLI References
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rs/references/cli-reference/memtier-benchmark.md
+++ b/content/rs/references/cli-reference/memtier-benchmark.md
@@ -3,7 +3,7 @@ Title: Benchmark a Redis on Flash Enabled Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis on Flash (RoF) on Redis Enterprise Software (RS) enables you to
 use more cost-effective Flash memory as a RAM extension for your

--- a/content/rs/references/cli-reference/memtier-benchmark.md
+++ b/content/rs/references/cli-reference/memtier-benchmark.md
@@ -3,6 +3,7 @@ Title: Benchmark a Redis on Flash Enabled Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis on Flash (RoF) on Redis Enterprise Software (RS) enables you to
 use more cost-effective Flash memory as a RAM extension for your

--- a/content/rs/references/cli-reference/rladmin.md
+++ b/content/rs/references/cli-reference/rladmin.md
@@ -3,7 +3,7 @@ Title: rladmin command-line interface
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) includes a command-line interface (CLI),
 called *rladmin* that can be used for various advanced administrative

--- a/content/rs/references/cli-reference/rladmin.md
+++ b/content/rs/references/cli-reference/rladmin.md
@@ -3,6 +3,7 @@ Title: rladmin command-line interface
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) includes a command-line interface (CLI),
 called *rladmin* that can be used for various advanced administrative

--- a/content/rs/references/cli-reference/rlcheck.md
+++ b/content/rs/references/cli-reference/rlcheck.md
@@ -3,7 +3,7 @@ Title: rlcheck - Node Verification Utility
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 rlcheck is a utility that runs various health checks on an Redis
 Enterprise Software (RS) node, and alerts on any issues found. This

--- a/content/rs/references/cli-reference/rlcheck.md
+++ b/content/rs/references/cli-reference/rlcheck.md
@@ -3,6 +3,7 @@ Title: rlcheck - Node Verification Utility
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 rlcheck is a utility that runs various health checks on an Redis
 Enterprise Software (RS) node, and alerts on any issues found. This

--- a/content/rs/references/procedures-previous-releases.md
+++ b/content/rs/references/procedures-previous-releases.md
@@ -3,6 +3,7 @@ Title: Procedures for Previous Releases
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Here you can find procedures that were used in previous releases.
 

--- a/content/rs/references/procedures-previous-releases.md
+++ b/content/rs/references/procedures-previous-releases.md
@@ -3,7 +3,7 @@ Title: Procedures for Previous Releases
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Here you can find procedures that were used in previous releases.
 

--- a/content/rs/release-notes/_index.md
+++ b/content/rs/release-notes/_index.md
@@ -3,5 +3,6 @@ Title: Release Notes
 description: 
 weight: 90
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 {{%children style="h2" sort="Weight"%}}  

--- a/content/rs/release-notes/_index.md
+++ b/content/rs/release-notes/_index.md
@@ -3,6 +3,6 @@ Title: Release Notes
 description: 
 weight: 90
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 {{%children style="h2" sort="Weight"%}}  

--- a/content/rs/release-notes/redis-enterprise-5.md
+++ b/content/rs/release-notes/redis-enterprise-5.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Pack 5.0 Release Notes (November 2017)
 description: 
 weight: 93
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software 5.0 is now available. Key features include
 Geo-Distributed Active-Active Conflict-free Replicated Databases (CRDB),

--- a/content/rs/release-notes/redis-enterprise-5.md
+++ b/content/rs/release-notes/redis-enterprise-5.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Pack 5.0 Release Notes (November 2017)
 description: 
 weight: 93
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software 5.0 is now available. Key features include
 Geo-Distributed Active-Active Conflict-free Replicated Databases (CRDB),

--- a/content/rs/release-notes/redis-pack-4-5-0-may-2017.md
+++ b/content/rs/release-notes/redis-pack-4-5-0-may-2017.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Pack 4.5 Release Notes (May 2017)
 description: 
 weight: 94
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you are upgrading from a previous version, make sure to review the
 upgrade instructions before beginning the upgrade process.

--- a/content/rs/release-notes/redis-pack-4-5-0-may-2017.md
+++ b/content/rs/release-notes/redis-pack-4-5-0-may-2017.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Pack 4.5 Release Notes (May 2017)
 description: 
 weight: 94
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you are upgrading from a previous version, make sure to review the
 upgrade instructions before beginning the upgrade process.

--- a/content/rs/release-notes/release-notes-redis-enterprise-software-v5-0-2.md
+++ b/content/rs/release-notes/release-notes-redis-enterprise-software-v5-0-2.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software 5.0.2 (2018 March)
 description: 
 weight: 92
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software 5.0.2 is now available. Key features include
 functional and performance updates for CRDB, changes to module

--- a/content/rs/release-notes/release-notes-redis-enterprise-software-v5-0-2.md
+++ b/content/rs/release-notes/release-notes-redis-enterprise-software-v5-0-2.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software 5.0.2 (2018 March)
 description: 
 weight: 92
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software 5.0.2 is now available. Key features include
 functional and performance updates for CRDB, changes to module

--- a/content/rs/release-notes/rlec-0-99-5-11-january-2015.md
+++ b/content/rs/release-notes/rlec-0-99-5-11-january-2015.md
@@ -3,7 +3,7 @@ Title: RLEC 0.99.5-11 Release Notes (January 5, 2015)
 description: 
 weight:
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 ### New features
 

--- a/content/rs/release-notes/rlec-0-99-5-11-january-2015.md
+++ b/content/rs/release-notes/rlec-0-99-5-11-january-2015.md
@@ -3,6 +3,7 @@ Title: RLEC 0.99.5-11 Release Notes (January 5, 2015)
 description: 
 weight:
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 ### New features
 

--- a/content/rs/release-notes/rlec-0-99-february-2015.md
+++ b/content/rs/release-notes/rlec-0-99-february-2015.md
@@ -3,7 +3,7 @@ Title: RLEC 0.99.5-24 Release Notes (February 15, 2015)
 description: 
 weight: 99
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-0-99-february-2015.md
+++ b/content/rs/release-notes/rlec-0-99-february-2015.md
@@ -3,6 +3,7 @@ Title: RLEC 0.99.5-24 Release Notes (February 15, 2015)
 description: 
 weight: 99
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-0-june-2015.md
+++ b/content/rs/release-notes/rlec-4-0-june-2015.md
@@ -3,7 +3,7 @@ Title: RLEC 4.0.0-49 Release Notes (June 18, 2015)
 description: 
 weight: 98
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-0-june-2015.md
+++ b/content/rs/release-notes/rlec-4-0-june-2015.md
@@ -3,6 +3,7 @@ Title: RLEC 4.0.0-49 Release Notes (June 18, 2015)
 description: 
 weight: 98
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-2-october-2015.md
+++ b/content/rs/release-notes/rlec-4-2-october-2015.md
@@ -3,6 +3,7 @@ Title: RLEC 4.2.1-30 Release Notes (October 18, 2015)
 description: 
 weight: 97
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-2-october-2015.md
+++ b/content/rs/release-notes/rlec-4-2-october-2015.md
@@ -3,7 +3,7 @@ Title: RLEC 4.2.1-30 Release Notes (October 18, 2015)
 description: 
 weight: 97
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-3-aug-2016.md
+++ b/content/rs/release-notes/rlec-4-3-aug-2016.md
@@ -3,6 +3,7 @@ Title: RLEC 4.3.0-230 Release Notes (August 2, 2016)
 description: 
 weight: 96
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-3-aug-2016.md
+++ b/content/rs/release-notes/rlec-4-3-aug-2016.md
@@ -3,7 +3,7 @@ Title: RLEC 4.3.0-230 Release Notes (August 2, 2016)
 description: 
 weight: 96
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-4-dec-2016.md
+++ b/content/rs/release-notes/rlec-4-4-dec-2016.md
@@ -3,6 +3,7 @@ Title: RLEC 4.4 Release Notes (December 2016)
 description: 
 weight: 95
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rlec-4-4-dec-2016.md
+++ b/content/rs/release-notes/rlec-4-4-dec-2016.md
@@ -3,7 +3,7 @@ Title: RLEC 4.4 Release Notes (December 2016)
 description: 
 weight: 95
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 If you are upgrading from a previous version, make sure to review the
 [upgrade

--- a/content/rs/release-notes/rs-5-2-2-august-2018.md
+++ b/content/rs/release-notes/rs-5-2-2-august-2018.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software 5.2.2 (August 2018)
 description: 
 weight: 89
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) 5.2.2 is now available.
 

--- a/content/rs/release-notes/rs-5-2-2-august-2018.md
+++ b/content/rs/release-notes/rs-5-2-2-august-2018.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software 5.2.2 (August 2018)
 description: 
 weight: 89
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) 5.2.2 is now available.
 

--- a/content/rs/release-notes/rs-5-2-june-2018.md
+++ b/content/rs/release-notes/rs-5-2-june-2018.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software Release Notes 5.2 (June 2018)
 description: 
 weight: 91
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) 5.2 is now available. Key features
 include new data types and Causal Consistency for active-active (also

--- a/content/rs/release-notes/rs-5-2-june-2018.md
+++ b/content/rs/release-notes/rs-5-2-june-2018.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software Release Notes 5.2 (June 2018)
 description: 
 weight: 91
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) 5.2 is now available. Key features
 include new data types and Causal Consistency for active-active (also

--- a/content/rs/release-notes/rs-5-3-beta-july-2018.md
+++ b/content/rs/release-notes/rs-5-3-beta-july-2018.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise Software Release Notes 5.3 BETA (July 2018)
 description: 
 weight: 90
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 Redis Enterprise Software (RS) 5.3 is now available.
 

--- a/content/rs/release-notes/rs-5-3-beta-july-2018.md
+++ b/content/rs/release-notes/rs-5-3-beta-july-2018.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise Software Release Notes 5.3 BETA (July 2018)
 description: 
 weight: 90
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 Redis Enterprise Software (RS) 5.3 is now available.
 

--- a/content/rs/technology-behind-redis-enterprise.md
+++ b/content/rs/technology-behind-redis-enterprise.md
@@ -3,7 +3,7 @@ Title: The Technology Behind Redis Enterprise Software (RS)
 description: 
 weight: 10
 alwaysopen: false
-categories: ["Redis Enterprise Software (RS)"]
+categories: ["RS"]
 ---
 RS's unique and patented technology was developed to meet these main
 objectives:

--- a/content/rs/technology-behind-redis-enterprise.md
+++ b/content/rs/technology-behind-redis-enterprise.md
@@ -3,6 +3,7 @@ Title: The Technology Behind Redis Enterprise Software (RS)
 description: 
 weight: 10
 alwaysopen: false
+categories: ["Redis Enterprise Software (RS)"]
 ---
 RS's unique and patented technology was developed to meet these main
 objectives:

--- a/content/rv/_index.md
+++ b/content/rv/_index.md
@@ -3,7 +3,7 @@ Title: Redis Enterprise VPC (RV)
 description: 
 weight: 30
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 Redis Enterprise VPC (RV) delivers a cost-effective, fully managed
 Database-as-a-Service (DBaaS) offering hosted on your Cloud account. <!--more-->

--- a/content/rv/_index.md
+++ b/content/rv/_index.md
@@ -3,6 +3,7 @@ Title: Redis Enterprise VPC (RV)
 description: 
 weight: 30
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 Redis Enterprise VPC (RV) delivers a cost-effective, fully managed
 Database-as-a-Service (DBaaS) offering hosted on your Cloud account. <!--more-->

--- a/content/rv/administration/_index.md
+++ b/content/rv/administration/_index.md
@@ -3,7 +3,7 @@ Title: Administration
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 While there is very little configuration of Redis Enterprise VPC
 required, there are some tasks that you can and may want to perform to

--- a/content/rv/administration/_index.md
+++ b/content/rv/administration/_index.md
@@ -3,6 +3,7 @@ Title: Administration
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 While there is very little configuration of Redis Enterprise VPC
 required, there are some tasks that you can and may want to perform to

--- a/content/rv/administration/account-team-settings.md
+++ b/content/rv/administration/account-team-settings.md
@@ -3,6 +3,7 @@ Title: Account and Team Settings
 description: 
 weight: 60
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 On this page you can view settings for your Redis Enterprise VPC account
 and team. You can add or edit your VAT ID, account's Time Zone, and New

--- a/content/rv/administration/account-team-settings.md
+++ b/content/rv/administration/account-team-settings.md
@@ -3,7 +3,7 @@ Title: Account and Team Settings
 description: 
 weight: 60
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 On this page you can view settings for your Redis Enterprise VPC account
 and team. You can add or edit your VAT ID, account's Time Zone, and New

--- a/content/rv/administration/billing-history.md
+++ b/content/rv/administration/billing-history.md
@@ -3,7 +3,7 @@ Title: Billing History
 description: 
 weight: 30
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 This page contains a list of purchases, changes, and payments for the
 subscriptions you have in your account. If you have a question about

--- a/content/rv/administration/billing-history.md
+++ b/content/rv/administration/billing-history.md
@@ -3,6 +3,7 @@ Title: Billing History
 description: 
 weight: 30
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 This page contains a list of purchases, changes, and payments for the
 subscriptions you have in your account. If you have a question about

--- a/content/rv/administration/configuration/_index.md
+++ b/content/rv/administration/configuration/_index.md
@@ -3,6 +3,7 @@ Title: Configuring Redis Enterprise VPC Resources
 description: 
 weight: 20
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 While there is very little configuration of Redis Enterprise VPC
 required, there are some things that you can and may want to do to

--- a/content/rv/administration/configuration/_index.md
+++ b/content/rv/administration/configuration/_index.md
@@ -3,7 +3,7 @@ Title: Configuring Redis Enterprise VPC Resources
 description: 
 weight: 20
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 While there is very little configuration of Redis Enterprise VPC
 required, there are some things that you can and may want to do to

--- a/content/rv/administration/configuration/backups.md
+++ b/content/rv/administration/configuration/backups.md
@@ -3,7 +3,7 @@ Title: Database Backups on Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 You can back up your Redis Enterprise VPC databases to a storage bucket
 of your choosing. This article explains how to create a cloud storage

--- a/content/rv/administration/configuration/backups.md
+++ b/content/rv/administration/configuration/backups.md
@@ -3,6 +3,7 @@ Title: Database Backups on Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 You can back up your Redis Enterprise VPC databases to a storage bucket
 of your choosing. This article explains how to create a cloud storage

--- a/content/rv/administration/configuration/monitoring-performance.md
+++ b/content/rv/administration/configuration/monitoring-performance.md
@@ -3,7 +3,7 @@ Title: Monitoring Performance in Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 Redis Enterprise VPC (RV) provides a straightforward dashboard that
 gives you good visibility into each database. Metrics can be viewed on

--- a/content/rv/administration/configuration/monitoring-performance.md
+++ b/content/rv/administration/configuration/monitoring-performance.md
@@ -3,6 +3,7 @@ Title: Monitoring Performance in Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 Redis Enterprise VPC (RV) provides a straightforward dashboard that
 gives you good visibility into each database. Metrics can be viewed on

--- a/content/rv/administration/configuration/securing-your-database.md
+++ b/content/rv/administration/configuration/securing-your-database.md
@@ -3,6 +3,7 @@ Title: Securing Your Database in Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 The security controls for your database are:
 

--- a/content/rv/administration/configuration/securing-your-database.md
+++ b/content/rv/administration/configuration/securing-your-database.md
@@ -3,7 +3,7 @@ Title: Securing Your Database in Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 The security controls for your database are:
 

--- a/content/rv/administration/payment-methods.md
+++ b/content/rv/administration/payment-methods.md
@@ -3,7 +3,7 @@ Title: Payment Methods
 description: 
 weight: 40
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 On this page you can view and edit your account's existing payment
 methods, as well as add new ones to your account. Click the name of an

--- a/content/rv/administration/payment-methods.md
+++ b/content/rv/administration/payment-methods.md
@@ -3,6 +3,7 @@ Title: Payment Methods
 description: 
 weight: 40
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 On this page you can view and edit your account's existing payment
 methods, as well as add new ones to your account. Click the name of an

--- a/content/rv/administration/setup_and_editing/_index.md
+++ b/content/rv/administration/setup_and_editing/_index.md
@@ -3,6 +3,7 @@ title: Setup and Editing
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rv/administration/setup_and_editing/_index.md
+++ b/content/rv/administration/setup_and_editing/_index.md
@@ -3,7 +3,7 @@ title: Setup and Editing
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 
 {{%children style="h2" description="true"%}}

--- a/content/rv/administration/setup_and_editing/creating-cloud-account.md
+++ b/content/rv/administration/setup_and_editing/creating-cloud-account.md
@@ -3,6 +3,7 @@ Title: Creating a Redis Enterprise VPC (RV) Cloud Account
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 An RV Cloud Account contains all necessary credentials and information
 for an account with your cloud provider. This Cloud Account enables RV

--- a/content/rv/administration/setup_and_editing/creating-cloud-account.md
+++ b/content/rv/administration/setup_and_editing/creating-cloud-account.md
@@ -3,7 +3,7 @@ Title: Creating a Redis Enterprise VPC (RV) Cloud Account
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 An RV Cloud Account contains all necessary credentials and information
 for an account with your cloud provider. This Cloud Account enables RV

--- a/content/rv/administration/setup_and_editing/creating-databases.md
+++ b/content/rv/administration/setup_and_editing/creating-databases.md
@@ -3,7 +3,7 @@ Title: Creating Databases on Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 Once you have a subscription, you can easily create a database in Redis
 Enterprise VPC by following these steps:

--- a/content/rv/administration/setup_and_editing/creating-databases.md
+++ b/content/rv/administration/setup_and_editing/creating-databases.md
@@ -3,6 +3,7 @@ Title: Creating Databases on Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 Once you have a subscription, you can easily create a database in Redis
 Enterprise VPC by following these steps:

--- a/content/rv/administration/setup_and_editing/creating-subscription.md
+++ b/content/rv/administration/setup_and_editing/creating-subscription.md
@@ -3,6 +3,7 @@ Title: Creating a Subscription in Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 A Redis Enterprise VPC (RV) subscription consists of a selected cloud
 provider (and respective region, e.g. "AWS - US-West-2"), architectural

--- a/content/rv/administration/setup_and_editing/creating-subscription.md
+++ b/content/rv/administration/setup_and_editing/creating-subscription.md
@@ -3,7 +3,7 @@ Title: Creating a Subscription in Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 A Redis Enterprise VPC (RV) subscription consists of a selected cloud
 provider (and respective region, e.g. "AWS - US-West-2"), architectural

--- a/content/rv/administration/setup_and_editing/deleting-database.md
+++ b/content/rv/administration/setup_and_editing/deleting-database.md
@@ -3,6 +3,7 @@ Title: Deleting a Database in Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 Deleting a database is just as easy as creating one. Make sure that you
 are truly done with the database, as once you delete the database it

--- a/content/rv/administration/setup_and_editing/deleting-database.md
+++ b/content/rv/administration/setup_and_editing/deleting-database.md
@@ -3,7 +3,7 @@ Title: Deleting a Database in Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 Deleting a database is just as easy as creating one. Make sure that you
 are truly done with the database, as once you delete the database it

--- a/content/rv/administration/setup_and_editing/view-edit-cloud-account.md
+++ b/content/rv/administration/setup_and_editing/view-edit-cloud-account.md
@@ -3,7 +3,7 @@ Title: View and Edit a Redis Enterprise VPC (RV) Cloud Account
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 To view or edit your existing cloud accounts please select **Cloud
 Accounts** from the right side menu.

--- a/content/rv/administration/setup_and_editing/view-edit-cloud-account.md
+++ b/content/rv/administration/setup_and_editing/view-edit-cloud-account.md
@@ -3,6 +3,7 @@ Title: View and Edit a Redis Enterprise VPC (RV) Cloud Account
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 To view or edit your existing cloud accounts please select **Cloud
 Accounts** from the right side menu.

--- a/content/rv/administration/setup_and_editing/viewing-editing-databases.md
+++ b/content/rv/administration/setup_and_editing/viewing-editing-databases.md
@@ -3,6 +3,7 @@ Title: View and Edit a Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 To view your database, select **Databases** from the menu. You will see
 a list of your databases grouped by Subscription.

--- a/content/rv/administration/setup_and_editing/viewing-editing-databases.md
+++ b/content/rv/administration/setup_and_editing/viewing-editing-databases.md
@@ -3,7 +3,7 @@ Title: View and Edit a Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 To view your database, select **Databases** from the menu. You will see
 a list of your databases grouped by Subscription.

--- a/content/rv/administration/system-logs.md
+++ b/content/rv/administration/system-logs.md
@@ -3,7 +3,7 @@ Title: System Logs
 description: 
 weight: 50
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 This page contains events, alerts, and logs from the activities,
 databases, and subscriptions in your account. You can sort by any of the

--- a/content/rv/administration/system-logs.md
+++ b/content/rv/administration/system-logs.md
@@ -3,6 +3,7 @@ Title: System Logs
 description: 
 weight: 50
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 This page contains events, alerts, and logs from the activities,
 databases, and subscriptions in your account. You can sort by any of the

--- a/content/rv/administration/usage-reports.md
+++ b/content/rv/administration/usage-reports.md
@@ -3,7 +3,7 @@ Title: Usage Reports
 description: 
 weight: 70
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 You can view the number of gigabytes used by this account. You are able
 to filter the data by subscription, database, and statement month/year.

--- a/content/rv/administration/usage-reports.md
+++ b/content/rv/administration/usage-reports.md
@@ -3,6 +3,7 @@ Title: Usage Reports
 description: 
 weight: 70
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 You can view the number of gigabytes used by this account. You are able
 to filter the data by subscription, database, and statement month/year.

--- a/content/rv/concepts/_index.md
+++ b/content/rv/concepts/_index.md
@@ -3,7 +3,7 @@ Title: Concepts
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 This section of pages contains content that describes the main concepts
 that Redis Enterprise VPC is built around.

--- a/content/rv/concepts/_index.md
+++ b/content/rv/concepts/_index.md
@@ -3,6 +3,7 @@ Title: Concepts
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 This section of pages contains content that describes the main concepts
 that Redis Enterprise VPC is built around.

--- a/content/rv/concepts/clustering.md
+++ b/content/rv/concepts/clustering.md
@@ -3,6 +3,7 @@ Title: Clustering Redis Databases with Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 While it is a design decision that Redis is a (mostly) single-threaded
 process and this does keep it extremely performant yet simple, there are

--- a/content/rv/concepts/clustering.md
+++ b/content/rv/concepts/clustering.md
@@ -3,7 +3,7 @@ Title: Clustering Redis Databases with Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 While it is a design decision that Redis is a (mostly) single-threaded
 process and this does keep it extremely performant yet simple, there are

--- a/content/rv/concepts/data-eviction-policies.md
+++ b/content/rv/concepts/data-eviction-policies.md
@@ -3,6 +3,7 @@ Title: Data Eviction Policies
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 For each database, you can choose from these six supported data eviction
 policies:

--- a/content/rv/concepts/data-eviction-policies.md
+++ b/content/rv/concepts/data-eviction-policies.md
@@ -3,7 +3,7 @@ Title: Data Eviction Policies
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 For each database, you can choose from these six supported data eviction
 policies:

--- a/content/rv/concepts/data-persistence.md
+++ b/content/rv/concepts/data-persistence.md
@@ -3,6 +3,7 @@ Title: Data Persistence with Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 Redis Enterprise VPC supports persisting your data to disk on a
 per-database basis and in multiple ways. Unlike a few cloud provider's

--- a/content/rv/concepts/data-persistence.md
+++ b/content/rv/concepts/data-persistence.md
@@ -3,7 +3,7 @@ Title: Data Persistence with Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 Redis Enterprise VPC supports persisting your data to disk on a
 per-database basis and in multiple ways. Unlike a few cloud provider's

--- a/content/rv/how-to/_index.md
+++ b/content/rv/how-to/_index.md
@@ -3,5 +3,6 @@ Title: How Tos
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rv/how-to/_index.md
+++ b/content/rv/how-to/_index.md
@@ -3,6 +3,6 @@ Title: How Tos
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 {{%children style="h2" description="true"%}}

--- a/content/rv/how-to/creating-aws-user-redis-enterprise-vpc.md
+++ b/content/rv/how-to/creating-aws-user-redis-enterprise-vpc.md
@@ -3,7 +3,7 @@ Title: Creating an AWS User for Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 Redis Enterprise VPC (RV) automatically manages your cluster and
 provisions instances when needed. In order for RV to be able to manager AWS 

--- a/content/rv/how-to/creating-aws-user-redis-enterprise-vpc.md
+++ b/content/rv/how-to/creating-aws-user-redis-enterprise-vpc.md
@@ -3,6 +3,7 @@ Title: Creating an AWS User for Redis Enterprise VPC
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 Redis Enterprise VPC (RV) automatically manages your cluster and
 provisions instances when needed. In order for RV to be able to manager AWS 

--- a/content/rv/how-to/importing-data-database.md
+++ b/content/rv/how-to/importing-data-database.md
@@ -3,6 +3,7 @@ Title: Importing Data Into Your Redis Enterprise VPC Database
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 You can import an existing dataset into your Redis Enterprise VPC
 instance. This article lists the steps required to share your dataset

--- a/content/rv/how-to/importing-data-database.md
+++ b/content/rv/how-to/importing-data-database.md
@@ -3,7 +3,7 @@ Title: Importing Data Into Your Redis Enterprise VPC Database
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 You can import an existing dataset into your Redis Enterprise VPC
 instance. This article lists the steps required to share your dataset

--- a/content/rv/quick-setup.md
+++ b/content/rv/quick-setup.md
@@ -3,6 +3,7 @@ Title: Quick Setup of Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
+categories: ["Redis Enterprise VPC (RV)"]
 ---
 The steps for creating a simple Redis Enterprise VPC (RV) deployment are
 as follows:

--- a/content/rv/quick-setup.md
+++ b/content/rv/quick-setup.md
@@ -3,7 +3,7 @@ Title: Quick Setup of Redis Enterprise VPC (RV)
 description: 
 weight: $weight
 alwaysopen: false
-categories: ["Redis Enterprise VPC (RV)"]
+categories: ["RV"]
 ---
 The steps for creating a simple Redis Enterprise VPC (RV) deployment are
 as follows:

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -308,6 +308,13 @@ section a {
   right: 30px;
   cursor: pointer; }
 
+.autocomplete-suggestion .category {
+  color: #888;
+  margin-left: 10px;
+  font-size: 12px;
+  font-style: italic;
+}
+
 #sidebar-toggle-span {
   display: none; }
 

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -308,8 +308,12 @@ section a {
   right: 30px;
   cursor: pointer; }
 
+.autocomplete-suggestion {
+  padding-left: 36px !important;
+}
+
 .autocomplete-suggestion .category {
-  color: #888;
+  color: #a7a7a7;
   margin-left: 10px;
   font-size: 12px;
   font-style: italic;

--- a/themes/docdock/layouts/index.json
+++ b/themes/docdock/layouts/index.json
@@ -6,7 +6,8 @@
 	"title": "{{ htmlEscape $page.Title}}",
 	"tags": [{{ range $tindex, $tag := $page.Params.tags }}{{ if $tindex }}, {{ end }}"{{ $tag| htmlEscape }}"{{ end }}],
 	"description": "{{ htmlEscape .Description}}",
-	"content": {{$page.Plain | jsonify}}
+	"content": {{$page.Plain | jsonify}},
+	"categories": [{{ range $cindex, $category := $page.Params.categories }}{{ if $cindex }}, {{ end }}"{{ $category| htmlEscape }}"{{ end }}]	
 }
 {{- end -}}
 {{- end -}}]

--- a/themes/docdock/static/js/search.js
+++ b/themes/docdock/static/js/search.js
@@ -27,6 +27,9 @@ function initLunr() {
             lunrIndex.field("content", {
                 boost: 5
             });
+            lunrIndex.field("categories", {
+                boost: 1
+            });            
 
             // Feed lunr with each file and let lunr actually index them
             pagesIndex.forEach(function(page) {
@@ -72,6 +75,7 @@ $( document ).ready(function() {
                 "(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}" +
                     term+"(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}");
             item.context = text;
+            item.cat = (item.categories && item.categories.length > 0)? item.categories[0] : '';
             return '<div class="autocomplete-suggestion" ' +
                 'data-term="' + term + '" ' +
                 'data-title="' + item.title + '" ' +
@@ -80,6 +84,7 @@ $( document ).ready(function() {
                 '» ' + item.title +
                 '<div class="context">' +
                 (item.context || '') +'</div>' +
+                '<strong class="category">' + item.cat + '</strong>' +
                 '</div>';
         },
         /* onSelect callback fires when a search suggestion is chosen */

--- a/themes/docdock/static/js/search.js
+++ b/themes/docdock/static/js/search.js
@@ -81,7 +81,7 @@ $( document ).ready(function() {
                 'data-title="' + item.title + '" ' +
                 'data-uri="'+ item.uri + '" ' +
                 'data-context="' + item.context + '">' +
-                '» ' + item.title +
+                '' + item.title +
                 '<div class="context">' +
                 (item.context || '') +'</div>' +
                 '<strong class="category">' + item.cat + '</strong>' +


### PR DESCRIPTION
In search results (autocomplete) the category of each result will be displayed next to the title of the article/page to easily distinguish to which product category each article belongs (Enterprise, Enterprise Software or Enterprise Cloud).

I have added **categories** taxonomy to several pages so it can be tested. To test, type in anything related to Kuberenetes so these pages show up in the results.