### PR TITLE
Fix python code in crdb example

### DIFF
--- a/content/rs/getting-started/creating-database/crdbs.md
+++ b/content/rs/getting-started/creating-database/crdbs.md
@@ -186,10 +186,10 @@ rp2 = redis.StrictRedis(host='localhost', port=12002, db=0)
 print ("set key1 123 in cluster 1")
 print (rp1.set('key1', '123'))
 print ("get key1 cluster 1")
-print(rp1.get('key1'))
+print (rp1.get('key1'))
 
 print ("get key1 from cluster 2")
-print(rp1.get('key1'))
+print (rp2.get('key1'))
 ```
 
 Run "redis_test.py" application to connect to the database and store


### PR DESCRIPTION
Original code was getting the key from rp1 when the point of the exercise is to get the key you set in rp1 from rp2. Also added spaces to improve formatting.