### PR TITLE
Add information to create pkg from command-line

### DIFF
--- a/content/rs/administering/troubleshooting/creating-support-package.md
+++ b/content/rs/administering/troubleshooting/creating-support-package.md
@@ -18,7 +18,9 @@ To create a support package:
 1. Click **Create Support Package** at the bottom of the page, and
     confirm the action.
 
-The package is created and downloaded to your browser.
+The package is created and downloaded by your browser.
+
+If you get `internal error` on the UI while creating support package, or if you cannot access the UI, please execute `/opt/redislabs/bin/rladmin cluster debug_info` for version > 4.4 on any one of the node in the cluster. If it still fails, then please execute the command `/opt/redislabs/bin/debuginfo` on each node of the cluster and upload the tarball thus created. The path to the tarball is shown at the end after the command executes successfully.
 
 Note that creating a support package might take several minutes and
 might overload the system; therefore, do not attempt to initiate this


### PR DESCRIPTION
Add information to create pkg from command-line and also the debuginfo command is the entire package creation fails for some reason.