### PR TITLE
Add "Expand All / Collapse All" toggle in the menu

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -1,7 +1,12 @@
 
+{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ with .Site.Params.googleTagManager }}
+  {{ partial "gtm-body" . | safeHTML }}
+{{ end }}
+{{ end }}
 <header>
-  <div class="logo">
-    
+<div class="logo">
+  {{ partial "header.html" . }}    
   </div>
   {{- with .Site.Menus.shortcuts}}
     <nav class="shortcuts">

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -1,11 +1,7 @@
-{{ if eq (getenv "HUGO_ENV") "production" }}
-  {{ with .Site.Params.googleTagManager }}
-    {{ partial "gtm-body" . | safeHTML }}
-  {{ end }}
-{{ end }}
+
 <header>
   <div class="logo">
-    {{ partial "header.html" . }}
+    
   </div>
   {{- with .Site.Menus.shortcuts}}
     <nav class="shortcuts">

--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -9,7 +9,8 @@
       <link rel="shortcut icon" href="{{"/images/icon_logo/favicon-32x32.png" | relURL}}" type="image/x-icon" />
       <link href="{{"css/font-awesome.min.css" | relURL}}" rel="stylesheet">
       <link href="{{"css/nucleus.css" | relURL}}" rel="stylesheet">
-      {{ $style := resources.Get "theme-flex/style.css"  | resources.Fingerprint }}
+      {{ $style := resources.Get "theme-flex/style.css"   }}
+      <!-- | resources.Fingerprint -->
       <link href="{{$style.RelPermalink}}" rel="stylesheet" integrity="{{$style.Data.Integrity}}">      
       <link href="{{"css/bootstrap.min.css" | relURL}}" rel="stylesheet">
       <link href="{{"css/foundation-icons.css" | relURL}}" rel="stylesheet">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -23,7 +23,8 @@
         {{- if .IsAncestor $currentNode}} parent{{end}}
         {{- if eq .URL $currentNode.URL}} active{{end}}
         {{- if .Params.alwaysopen}} alwaysopen{{end -}}
-        {{- if ne $numberOfPages 0 }} haschildren{{end}}
+        {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") }} root-item {{end}}
+        {{- if ne $numberOfPages 0 }} haschildren{{end}}        
         ">
       {{- if or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") }}
         <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>
@@ -40,13 +41,13 @@
           {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") }}
             <div class="menu-divider"></div>
             
-            {{- if ne $numberOfPages 0 }}
-              {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+            {{- if ne $numberOfPages 0 }}                       
+              {{- if or (eq $currentNode.URL "/rs/") (eq $currentNode.URL "/rc/") (eq $currentNode.URL "/rv/") }}
+                <a class="expander-title"><span class="SideMenuExpanderTitle">Expand all</span></a>     
+                <i class="fa fa-angle-double-down fa-lg category-icon expand-all-icon"></i>
+              {{ else }}
                 <a class="expander-title"><span class="SideMenuExpanderTitle">Collapse all</span></a>
                 <i class="fa fa-angle-double-up fa-lg category-icon expand-all-icon"></i>
-              {{- else -}}
-                <a class="expander-title"><span class="SideMenuExpanderTitle">Expand all</span></a>
-                <i class="fa fa-angle-double-right fa-lg category-icon expand-all-icon"></i>
               {{- end}}
             {{- end}}
       

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -15,6 +15,10 @@
 {{- define "section-tree-nav" }}
 {{- $showvisitedlinks := .showvisitedlinks }}
 {{- $currentNode := .currentnode }}
+{{- $isFirstLevel := eq $currentNode.Parent .CurrentSection -}}
+{{- $isParentless := eq (len $currentNode.Sections) 0 -}}
+{{- $collapsed := or (eq $currentNode.URL "/rs/") (eq $currentNode.URL "/rc/") (eq $currentNode.URL "/rv/") (and $isFirstLevel $isParentless) -}}
+
  {{- with .sect}}
   {{- if and .IsSection (or (not .Params.hidden) $.showhidden)}}
     {{- $numberOfPages := (add (len .Pages) (len .Sections)) }}
@@ -22,7 +26,8 @@
     <li data-nav-id="{{.URL}}" class="dd-item
         {{- if .IsAncestor $currentNode}} parent{{end}}
         {{- if eq .URL $currentNode.URL}} active{{end}}
-        {{- if .Params.alwaysopen}} alwaysopen{{end -}}
+        {{- if .Params.alwaysopen}} alwaysopen{{end -}}        
+        {{- if $collapsed}} collapsed {{- else}} expanded {{end -}}
         {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") }} root-item {{end}}
         {{- if ne $numberOfPages 0 }} haschildren{{end}}        
         ">
@@ -40,15 +45,16 @@
 
           {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") }}
             <div class="menu-divider"></div>
-            
-            {{- if ne $numberOfPages 0 }}                       
-              {{- if or (eq $currentNode.URL "/rs/") (eq $currentNode.URL "/rc/") (eq $currentNode.URL "/rv/") }}
-                <a class="expander-title"><span class="SideMenuExpanderTitle --expander">Expand all</span></a>     
-                <i class="fa fa-angle-double-down fa-lg category-icon expand-all-icon --expander"></i>
-              {{ else }}
-                <a class="expander-title"><span class="SideMenuExpanderTitle --collapser">Collapse all</span></a>
-                <i class="fa fa-angle-double-up fa-lg category-icon expand-all-icon --collapser"></i>
-              {{- end}}
+            {{- if $collapsed }}
+              <span class="SideMenuToggle --expander">
+                <a class="expander-title"><span class="SideMenuExpanderTitle">Expand all</span></a>
+                <i class="fa fa-angle-double-down fa-lg category-icon expand-all-icon"></i>
+              </span>
+            {{- else}}
+              <span class="SideMenuToggle --collapser">
+                <a class="expander-title"><span class="SideMenuExpanderTitle">Collapse all</span></a>
+                <i class="fa fa-angle-double-up fa-lg category-icon expand-all-icon"></i>
+              </span>
             {{- end}}
       
           {{- else}}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -25,11 +25,11 @@
         {{- if .Params.alwaysopen}} alwaysopen{{end -}}
         {{- if ne $numberOfPages 0 }} haschildren{{end}}
         ">
-        {{- if or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") }}
-          <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>          
-        {{- end}}
+      {{- if or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") }}
+        <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>
+      {{- end}}
 
-        {{- if eq .URL .RelPermalink }}
+      {{- if eq .URL .RelPermalink }}
           <!-- Child items -->          
           {{if or (eq .URL "/rs/") }}
             <div class="children --has-version-selector">
@@ -37,23 +37,34 @@
             <div class="children">
           {{end}}
 
-              {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") }}
-                <div class="menu-divider"></div>                                
-              {{- else}}
-                <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>
-
-                {{- if ne $numberOfPages 0 }}
-                  {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
-                    <i class="fa fa-angle-down fa-lg category-icon"></i>
-                  {{- else -}}
-                    <i class="fa fa-angle-right fa-lg category-icon"></i>
-                  {{- end}}
-                {{- end}}                
-              {{- end}}
+          {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") }}
+            <div class="menu-divider"></div>
             
-            {{- if $showvisitedlinks}}<i class="fa fa-circle-thin read-icon"></i>{{end}}
-          </div>
-        {{- end}}
+            {{- if ne $numberOfPages 0 }}
+              {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+                <a class="expander-title"><span class="SideMenuExpanderTitle">Collapse all</span></a>
+                <i class="fa fa-angle-double-up fa-lg category-icon expand-all-icon"></i>
+              {{- else -}}
+                <a class="expander-title"><span class="SideMenuExpanderTitle">Expand all</span></a>
+                <i class="fa fa-angle-double-right fa-lg category-icon expand-all-icon"></i>
+              {{- end}}
+            {{- end}}
+      
+          {{- else}}
+            <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>
+
+            {{- if ne $numberOfPages 0 }}
+              {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+                <i class="fa fa-angle-down fa-lg category-icon"></i>
+              {{- else -}}
+                <i class="fa fa-angle-right fa-lg category-icon"></i>
+              {{- end}}
+            {{- end}}                
+          {{- end}}
+          
+          {{- if $showvisitedlinks}}<i class="fa fa-circle-thin read-icon"></i>{{end}}
+        </div>
+      {{- end}}
 
       {{- if ne $numberOfPages 0 }}
         <ul>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -43,11 +43,11 @@
             
             {{- if ne $numberOfPages 0 }}                       
               {{- if or (eq $currentNode.URL "/rs/") (eq $currentNode.URL "/rc/") (eq $currentNode.URL "/rv/") }}
-                <a class="expander-title"><span class="SideMenuExpanderTitle">Expand all</span></a>     
-                <i class="fa fa-angle-double-down fa-lg category-icon expand-all-icon"></i>
+                <a class="expander-title"><span class="SideMenuExpanderTitle --expander">Expand all</span></a>     
+                <i class="fa fa-angle-double-down fa-lg category-icon expand-all-icon --expander"></i>
               {{ else }}
-                <a class="expander-title"><span class="SideMenuExpanderTitle">Collapse all</span></a>
-                <i class="fa fa-angle-double-up fa-lg category-icon expand-all-icon"></i>
+                <a class="expander-title"><span class="SideMenuExpanderTitle --collapser">Collapse all</span></a>
+                <i class="fa fa-angle-double-up fa-lg category-icon expand-all-icon --collapser"></i>
               {{- end}}
             {{- end}}
       

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -193,6 +193,30 @@ article > aside .menu .dd-item div i.category-icon:hover {
 article > aside section {
   margin: 2rem 0rem; }
 
+/* Expand/Collapse menu */
+article > aside .menu .dd-item div i.expand-all-icon {
+  margin-left: 15px;
+  color: #354253;
+}
+
+article > aside .menu .dd-item div i.expand-all-icon:hover,
+article > aside .menu .dd-item div i.expand-all-icon.--hovered {
+  color: #b62411;
+}
+
+article > aside .menu .dd-item .highlight:hover {
+  color: #b62411;
+}
+
+.expander-title span {
+  color: #354253;
+}
+
+.expander-title span:hover, .expander-title span.--hovered {
+  color: #b62411;
+  cursor: pointer;
+}
+
 /*!
  * facette-docs - Facette project documentation
  * Website: http://docs.facette.io/

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -194,6 +194,14 @@ article > aside section {
   margin: 2rem 0rem; }
 
 /* Expand/Collapse menu */
+article > aside .menu > li.dd-item.active > ul {
+  display: none;
+}
+
+article > aside .menu > li.dd-item:not(.parent) .children {
+  display: none;
+}
+
 article > aside .menu .dd-item div i.expand-all-icon {
   margin-left: 15px;
   color: #354253;

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -1933,10 +1933,6 @@ article > aside .menu > li.parent > .children {
   padding-top: 30px;
 }
 
-article > aside .menu > li.parent > .children.--has-version-selector {
-  padding-top: 60px;
-}
-
 article > aside .menu .dd-item .highlight:hover {
   color: #b62411;
 }

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -195,8 +195,20 @@ article > aside section {
 
 /* Expand/Collapse menu */
 article > aside .menu > li.dd-item.active > ul {
-  display: none;
+  display: block;
 }
+
+article > aside .menu > li.dd-item.active > ul.active-menu-expanded .haschildren ul {
+  display: block;
+}
+
+/* article > aside .menu > li.dd-item.active > ul.active-menu-expanded .haschildren ul .fa-angle-down {
+  display: block;
+}
+
+article > aside .menu > li.dd-item.active > ul.active-menu-expanded .haschildren ul .fa-angle-right {
+  display: none;
+} */
 
 article > aside .menu > li.dd-item:not(.parent) .children {
   display: none;

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -198,17 +198,32 @@ article > aside .menu > li.dd-item.active > ul {
   display: block;
 }
 
-article > aside .menu > li.dd-item.active > ul.active-menu-expanded .haschildren ul {
-  display: block;
+article > aside .menu .SideMenuToggle {
+  color: #354253;
+  display: flex;
 }
 
-/* article > aside .menu > li.dd-item.active > ul.active-menu-expanded .haschildren ul .fa-angle-down {
-  display: block;
+
+article > aside .menu .SideMenuToggle:hover {
+  cursor: pointer;
+  color: #b62411 !important;
 }
 
-article > aside .menu > li.dd-item.active > ul.active-menu-expanded .haschildren ul .fa-angle-right {
+article > aside .menu .SideMenuToggle:hover i.expand-all-icon {
+  color: #b62411 !important;
+}
+
+article > aside .menu .dd-item.parent.root-item.collapsed > ul {
+  display: block !important;
+}
+
+article > aside .menu .dd-item.parent.root-item.collapsed ul {
   display: none;
-} */
+}
+
+article > aside .menu .dd-item.parent.root-item.expanded > ul {
+  display: block;
+}
 
 article > aside .menu > li.dd-item:not(.parent) .children {
   display: none;
@@ -219,22 +234,8 @@ article > aside .menu .dd-item div i.expand-all-icon {
   color: #354253;
 }
 
-article > aside .menu .dd-item div i.expand-all-icon:hover,
-article > aside .menu .dd-item div i.expand-all-icon.--hovered {
-  color: #b62411;
-}
-
 article > aside .menu .dd-item .highlight:hover {
   color: #b62411;
-}
-
-.expander-title span {
-  color: #354253;
-}
-
-.expander-title span:hover, .expander-title span.--hovered {
-  color: #b62411;
-  cursor: pointer;
 }
 
 /*!

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -1,32 +1,26 @@
 jQuery(document).ready(function() {
-    // jQuery('.category-icon').on('click', function() {
-    //     $( this ).toggleClass("fa-angle-down fa-angle-right") ;
-    //     $( this ).parent().parent().children('ul').toggle() ;
-    //     return false;
-    // });
-
     jQuery('.category-icon').on('click', function() {
         if($( this ).attr("class").indexOf('expand-all-icon') !== -1) {
             return;
         }
 
         $( this ).toggleClass("fa-angle-down fa-angle-right") ;
-        $( this ).parent().parent().children('ul').toggle() ;
+        $( this ).parent().parent().children('ul').toggle();
         return false;
     });
 
     jQuery('.parent .expand-all-icon').on('click', function() {
-        $( this ).toggleClass("fa-angle-double-up fa-angle-double-right") ;
+        $( this ).toggleClass("fa-angle-double-up fa-angle-double-down") ;
         $( this ).parent().parent().children('ul').toggle() ;
-        // _toggleExpanderTitle();
+        _toggleExpanderTitle();
         return false;
     });  
     
     jQuery('.SideMenuExpanderTitle').on('click', function() {
         var $i = jQuery( '.parent .expand-all-icon' );
-        $i.toggleClass("fa-angle-double-up fa-angle-double-right") ;
+        $i.toggleClass("fa-angle-double-up fa-angle-double-down") ;
         $i.parent().parent().children('ul').toggle() ;
-        // _toggleExpanderTitle();
+        _toggleExpanderTitle();
         return false;
     });
 
@@ -52,7 +46,7 @@ jQuery(document).ready(function() {
 
     jQuery('.expand-all-icon').on('mouseleave', function() {
         jQuery('.SideMenuExpanderTitle').removeClass('--hovered');
-    });        
+    });   
 
 
     // Images

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -1,10 +1,59 @@
 jQuery(document).ready(function() {
+    // jQuery('.category-icon').on('click', function() {
+    //     $( this ).toggleClass("fa-angle-down fa-angle-right") ;
+    //     $( this ).parent().parent().children('ul').toggle() ;
+    //     return false;
+    // });
+
     jQuery('.category-icon').on('click', function() {
+        if($( this ).attr("class").indexOf('expand-all-icon') !== -1) {
+            return;
+        }
+
         $( this ).toggleClass("fa-angle-down fa-angle-right") ;
         $( this ).parent().parent().children('ul').toggle() ;
         return false;
     });
+
+    jQuery('.parent .expand-all-icon').on('click', function() {
+        $( this ).toggleClass("fa-angle-double-up fa-angle-double-right") ;
+        $( this ).parent().parent().children('ul').toggle() ;
+        // _toggleExpanderTitle();
+        return false;
+    });  
     
+    jQuery('.SideMenuExpanderTitle').on('click', function() {
+        var $i = jQuery( '.parent .expand-all-icon' );
+        $i.toggleClass("fa-angle-double-up fa-angle-double-right") ;
+        $i.parent().parent().children('ul').toggle() ;
+        // _toggleExpanderTitle();
+        return false;
+    });
+
+    function _toggleExpanderTitle() {
+        $e = jQuery('.parent .SideMenuExpanderTitle');
+        if($e && $e[0]) {
+            var isOpen = (jQuery( '.parent .expand-all-icon' ).attr("class").indexOf('fa-angle-double-up') !== -1);
+            $e[0].innerText = isOpen? 'Collapse all': 'Expand all';
+        }
+    }
+
+    jQuery('.SideMenuExpanderTitle').on('mouseenter', function() {
+        jQuery('.expand-all-icon').addClass('--hovered');
+    });
+
+    jQuery('.SideMenuExpanderTitle').on('mouseleave', function() {
+        jQuery('.expand-all-icon').removeClass('--hovered');
+    });
+
+    jQuery('.expand-all-icon').on('mouseenter', function() {
+        jQuery('.SideMenuExpanderTitle').addClass('--hovered');
+    });
+
+    jQuery('.expand-all-icon').on('mouseleave', function() {
+        jQuery('.SideMenuExpanderTitle').removeClass('--hovered');
+    });        
+
 
     // Images
     // Execute actions on images generated from Markdown pages

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -9,31 +9,64 @@ jQuery(document).ready(function() {
         return false;
     });
 
+    // Expand/Collapse All
     jQuery('.parent .expand-all-icon').on('click', function() {
-        $( this ).toggleClass("fa-angle-double-up fa-angle-double-down") ;
-        _toggleFirstLevelItems();
-        _toggleExpanderTitle();
-        return false;
-    });  
+        if($( this ).attr("class").indexOf('--expander') !== -1) {
+            $( this ).addClass("fa-angle-double-up").removeClass("fa-angle-double-down");
+            _toggleFirstLevelItems('expand');
+            _toggleExpanderTitle('expand');
+            return false;
+        }                
+
+        if($( this ).attr("class").indexOf('--collapser') !== -1) {
+            $( this ).addClass("fa-angle-double-down").removeClass("fa-angle-double-up");
+            _toggleFirstLevelItems('collapse');
+            _toggleExpanderTitle('collapse');
+            return false;
+        }
+    });
     
     jQuery('.SideMenuExpanderTitle').on('click', function() {
-        var $i = jQuery( '.parent .expand-all-icon' );
-        $i.toggleClass("fa-angle-double-up fa-angle-double-down") ;
-        _toggleFirstLevelItems();
-        _toggleExpanderTitle();
-        return false;
+        if($( this ).attr("class").indexOf('--expander') !== -1) {
+            var $i = jQuery( '.parent .expand-all-icon' );
+            $i.addClass("fa-angle-double-up").removeClass("fa-angle-double-down");
+            _toggleFirstLevelItems('expand');
+            _toggleExpanderTitle('expand');
+            return false;
+        }
+
+        if($( this ).attr("class").indexOf('--collapser') !== -1) {
+            var $i = jQuery( '.parent .expand-all-icon' );
+            $i.addClass("fa-angle-double-down").removeClass("fa-angle-double-up");
+            _toggleFirstLevelItems('collapse');
+            _toggleExpanderTitle('collapse');
+            return false;
+        }        
     });
 
-    function _toggleFirstLevelItems() {
-        $('.menu .root-item.parent').children('ul').children('li').children('ul').toggleClass('--open');
+    function _toggleFirstLevelItems(act) {
+        if(act === 'expand') {
+            $('article > aside .menu > li.dd-item.active > ul').addClass('active-menu-expanded');
+            $('article > aside .menu > li.dd-item.active > ul .fa.fa-angle-right').addClass('fa-angle-down').removeClass('fa-angle-right');
+            return;
+        }
+
+        $('article > aside .menu > li.dd-item.active > ul').removeClass('active-menu-expanded');
+        $('article > aside .menu > li.dd-item.active > ul .fa.fa-angle-down').addClass('fa-angle-right');
+        $('article > aside .menu > li.dd-item.active > ul .fa.fa-angle-down').removeClass('fa-angle-down');
     }
 
-    function _toggleExpanderTitle() {
-        $e = jQuery('.parent .SideMenuExpanderTitle');
-        if($e && $e[0]) {
-            var isOpen = (jQuery( '.parent .expand-all-icon' ).attr("class").indexOf('fa-angle-double-up') !== -1);
-            $e[0].innerText = isOpen? 'Collapse all': 'Expand all';
+    function _toggleExpanderTitle(act) {        
+        if(act === 'expand') {
+            var $e = jQuery('.parent .SideMenuExpanderTitle.--expander');
+            $e[0].innerText = 'Collapse all';
+            $e.addClass('--collapser').removeClass('--expander')
+            return;
         }
+
+        var $e = jQuery('.parent .SideMenuExpanderTitle.--collapser');
+        $e[0].innerText = 'Expand all';
+        $e.addClass('--expander').removeClass('--collapser')
     }
 
     jQuery('.SideMenuExpanderTitle').on('mouseenter', function() {

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -10,81 +10,48 @@ jQuery(document).ready(function() {
     });
 
     // Expand/Collapse All
-    jQuery('.parent .expand-all-icon').on('click', function() {
-        if($( this ).attr("class").indexOf('--expander') !== -1) {
-            $( this ).addClass("fa-angle-double-up").removeClass("fa-angle-double-down");
-            _toggleFirstLevelItems('expand');
-            _toggleExpanderTitle('expand');
-            return false;
-        }                
+    jQuery('.menu .parent .SideMenuToggle').on('click', function() {
+        var $i = jQuery('.menu .parent .SideMenuToggle .expand-all-icon');
 
-        if($( this ).attr("class").indexOf('--collapser') !== -1) {
-            $( this ).addClass("fa-angle-double-down").removeClass("fa-angle-double-up");
-            _toggleFirstLevelItems('collapse');
-            _toggleExpanderTitle('collapse');
-            return false;
-        }
-    });
-    
-    jQuery('.SideMenuExpanderTitle').on('click', function() {
-        if($( this ).attr("class").indexOf('--expander') !== -1) {
-            var $i = jQuery( '.parent .expand-all-icon' );
+        if($( this ).attr("class").indexOf('--expander') !== -1) {            
             $i.addClass("fa-angle-double-up").removeClass("fa-angle-double-down");
-            _toggleFirstLevelItems('expand');
+
+            _toggleItems('expand');
             _toggleExpanderTitle('expand');
             return false;
         }
 
-        if($( this ).attr("class").indexOf('--collapser') !== -1) {
-            var $i = jQuery( '.parent .expand-all-icon' );
-            $i.addClass("fa-angle-double-down").removeClass("fa-angle-double-up");
-            _toggleFirstLevelItems('collapse');
-            _toggleExpanderTitle('collapse');
-            return false;
-        }        
+        $i.addClass("fa-angle-double-down").removeClass("fa-angle-double-up");
+        _toggleItems('collapse');
+        _toggleExpanderTitle('collapse');
+        return false;        
     });
 
-    function _toggleFirstLevelItems(act) {
+    function _toggleItems(act) {
         if(act === 'expand') {
-            $('article > aside .menu > li.dd-item.active > ul').addClass('active-menu-expanded');
-            $('article > aside .menu > li.dd-item.active > ul .fa.fa-angle-right').addClass('fa-angle-down').removeClass('fa-angle-right');
+            $('article > aside .menu > li.dd-item.parent.root-item').addClass('expanded').removeClass('collapsed');
+            $('article > aside .menu > li.dd-item.parent.root-item .fa.fa-angle-right').addClass('fa-angle-down').removeClass('fa-angle-right');
             return;
         }
 
-        $('article > aside .menu > li.dd-item.active > ul').removeClass('active-menu-expanded');
-        $('article > aside .menu > li.dd-item.active > ul .fa.fa-angle-down').addClass('fa-angle-right');
-        $('article > aside .menu > li.dd-item.active > ul .fa.fa-angle-down').removeClass('fa-angle-down');
+        $('article > aside .menu > li.dd-item.parent.root-item').addClass('collapsed').removeClass('expanded');
+        $('article > aside .menu > li.dd-item.parent.root-item .fa.fa-angle-down').addClass('fa-angle-right');
+        $('article > aside .menu > li.dd-item.parent.root-item .fa.fa-angle-down').removeClass('fa-angle-down');
     }
 
     function _toggleExpanderTitle(act) {        
+        var $toggle = jQuery('.menu .parent .SideMenuToggle');
         if(act === 'expand') {
-            var $e = jQuery('.parent .SideMenuExpanderTitle.--expander');
+            var $e = jQuery('.menu .parent .SideMenuToggle.--expander .SideMenuExpanderTitle');
             $e[0].innerText = 'Collapse all';
-            $e.addClass('--collapser').removeClass('--expander')
+            $toggle.addClass('--collapser').removeClass('--expander')
             return;
         }
 
-        var $e = jQuery('.parent .SideMenuExpanderTitle.--collapser');
+        var $e = jQuery('.menu .parent .SideMenuToggle.--collapser .SideMenuExpanderTitle');
         $e[0].innerText = 'Expand all';
-        $e.addClass('--expander').removeClass('--collapser')
-    }
-
-    jQuery('.SideMenuExpanderTitle').on('mouseenter', function() {
-        jQuery('.expand-all-icon').addClass('--hovered');
-    });
-
-    jQuery('.SideMenuExpanderTitle').on('mouseleave', function() {
-        jQuery('.expand-all-icon').removeClass('--hovered');
-    });
-
-    jQuery('.expand-all-icon').on('mouseenter', function() {
-        jQuery('.SideMenuExpanderTitle').addClass('--hovered');
-    });
-
-    jQuery('.expand-all-icon').on('mouseleave', function() {
-        jQuery('.SideMenuExpanderTitle').removeClass('--hovered');
-    });   
-
+        $toggle.addClass('--expander').removeClass('--collapser')
+    }  
 
     // Images
     // Execute actions on images generated from Markdown pages

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -4,14 +4,14 @@ jQuery(document).ready(function() {
             return;
         }
 
-        $( this ).toggleClass("fa-angle-down fa-angle-right") ;
+        $( this ).toggleClass("fa-angle-down fa-angle-right");
         $( this ).parent().parent().children('ul').toggle();
         return false;
     });
 
     jQuery('.parent .expand-all-icon').on('click', function() {
         $( this ).toggleClass("fa-angle-double-up fa-angle-double-down") ;
-        $( this ).parent().parent().children('ul').toggle() ;
+        _toggleFirstLevelItems();
         _toggleExpanderTitle();
         return false;
     });  
@@ -19,10 +19,14 @@ jQuery(document).ready(function() {
     jQuery('.SideMenuExpanderTitle').on('click', function() {
         var $i = jQuery( '.parent .expand-all-icon' );
         $i.toggleClass("fa-angle-double-up fa-angle-double-down") ;
-        $i.parent().parent().children('ul').toggle() ;
+        _toggleFirstLevelItems();
         _toggleExpanderTitle();
         return false;
     });
+
+    function _toggleFirstLevelItems() {
+        $('.menu .root-item.parent').children('ul').children('li').children('ul').toggleClass('--open');
+    }
 
     function _toggleExpanderTitle() {
         $e = jQuery('.parent .SideMenuExpanderTitle');


### PR DESCRIPTION
This change adds a toggle for showing and hiding of menu items with single click.
The default state when the page is loaded to `/rs`, `/rv` or `/rc`, ie. the root page of each section, is that the menu is collapsed and the toggle text is "Expand All" with the appropriate icon.

The change should be visible [here](https://docs.redislabs.com/staging/expand-collapse) but for some reason it is returning 404 even though builds in CircleCI have been successful.