### PR TITLE
Add context text for search results (#147)

### DIFF
--- a/resources/_gen/assets/css/theme-flex/style.css_8848f55d07695b7ff7188138f23d69e3.json
+++ b/resources/_gen/assets/css/theme-flex/style.css_8848f55d07695b7ff7188138f23d69e3.json
@@ -1,0 +1,1 @@
+{"Target":"theme-flex/style.520add223337f14a787e3003e65b69e043c45d6beab503a6c84838a788ce5339.css","MediaType":"text/css","Data":{"Integrity":"sha256-UgrdIjM38Up4fjAD5ltp4EPEXWvqtQOmyEg4p4jOUzk="}}

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -2589,4 +2589,10 @@ i.icon-icons_plus, i.icon-icons_minus {
 
 .main-content ol > li > ol > li > ol > li > ol  {list-style-type: lower-alpha;}
 
-/* test */
+.autocomplete-suggestions {
+  overflow-y: auto !important;
+}
+
+.autocomplete-suggestion > .context {
+  display: block !important;
+}

--- a/themes/docdock/static/js/search.js
+++ b/themes/docdock/static/js/search.js
@@ -70,21 +70,23 @@ $( document ).ready(function() {
         },
         /* renderItem displays individual search results */
         renderItem: function(item, term) {
-            var numContextWords = 2;
+            var numContextWords = 3;
+            var regEx = "(?:\\s?(?:[\\w\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~]+)\\s?){0";
             var text = item.content.match(
-                "(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}" +
-                    term+"(?:\\s?(?:[\\w]+)\\s?){0,"+numContextWords+"}");
-            item.context = text;
+                regEx+numContextWords+"}" +
+                    term+regEx+numContextWords+"}");
+            if(text && text.length > 0) {
+                var len = text[0].split(' ').length;
+                item.context = len > 1? '...' + text[0].trim() + '...' : null;
+            }
             item.cat = (item.categories && item.categories.length > 0)? item.categories[0] : '';
             return '<div class="autocomplete-suggestion" ' +
                 'data-term="' + term + '" ' +
                 'data-title="' + item.title + '" ' +
                 'data-uri="'+ item.uri + '" ' +
                 'data-context="' + item.context + '">' +
-                '' + item.title +
-                '<div class="context">' +
-                (item.context || '') +'</div>' +
-                '<strong class="category">' + item.cat + '</strong>' +
+                    '<div>' + item.title + '<strong class="category">' + item.cat + '</strong> </div>' +
+                    '<div class="context">' + (item.context || '') +'</div>' +
                 '</div>';
         },
         /* onSelect callback fires when a search suggestion is chosen */


### PR DESCRIPTION
* Reduce line spacing around code snippets

* Add context text to search results

* Prepend and append three dots to context of search result

* Do not show search result context if there is only one word.
Add vertical scroller to search results.

* Tweak regex pattern for search term matching to include more characters