### PR TITLE
Import style.css the standard way

### DIFF
--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -9,8 +9,7 @@
       <link rel="shortcut icon" href="{{"/images/icon_logo/favicon-32x32.png" | relURL}}" type="image/x-icon" />
       <link href="{{"css/font-awesome.min.css" | relURL}}" rel="stylesheet">
       <link href="{{"css/nucleus.css" | relURL}}" rel="stylesheet">
-      {{ $style := resources.Get "theme-flex/style.css"  | resources.Fingerprint }}
-      <link href="{{$style.RelPermalink}}" rel="stylesheet">      
+      <link href="{{"theme-flex/style.css" | relURL}}" rel="stylesheet">      
       <link href="{{"css/bootstrap.min.css" | relURL}}" rel="stylesheet">
       <link href="{{"css/foundation-icons.css" | relURL}}" rel="stylesheet">
       <script src="{{"theme-flex/modernizr-custom.js" | relURL}}"></script>


### PR DESCRIPTION
This change reverts the import of the main style file (style.css) to the standard way, ie. without Hugo's fingerprinting.