### PR TITLE
added more detail upgrade of module

### DIFF
--- a/content/rs/release-notes/rs-5-4-december-2018.md
+++ b/content/rs/release-notes/rs-5-4-december-2018.md
@@ -71,7 +71,7 @@ RS 5.4 expands the high availability capabilities by adding the ability to autom
 
 ### Upgrade
 
--   Before you upgrade a database with the RediSearch module to Redis 5.0, you must upgrade the RediSearch module to 1.4.2 or higher. We recommend that you upgrade the RediSearch module before you upgrade the cluster to RS 5.4.
+-   Before you upgrade a database with the RediSearch module to Redis 5.0, you must [upgrade the RediSearch module on that DB](https://docs.redislabs.com/latest/rs/developing/modules/upgrading/) to 1.4.2 or higher. We recommend that you upgrade the RediSearch module before you upgrade the cluster to RS 5.4.
 -   Node upgrade fails if SSL certificates were configured in version 5.0.2 and above by updating the certificates on the disk instead of using the new API. For assistance with this issue, please contact support. 
 
 ### Cluster API

--- a/content/rs/release-notes/rs-5-4-december-2018.md
+++ b/content/rs/release-notes/rs-5-4-december-2018.md
@@ -71,7 +71,7 @@ RS 5.4 expands the high availability capabilities by adding the ability to autom
 
 ### Upgrade
 
--   Before you upgrade a database with the RediSearch module to Redis 5.0, you must [upgrade the RediSearch module on that DB](https://docs.redislabs.com/latest/rs/developing/modules/upgrading/) to 1.4.2 or higher. We recommend that you upgrade the RediSearch module before you upgrade the cluster to RS 5.4.
+-   Before you upgrade a database with the RediSearch module to Redis 5.0, you must [upgrade the RediSearch module on that DB]({{< relref "/rs/developing/modules/upgrading.md" >}}) to 1.4.2 or higher. We recommend that you upgrade the RediSearch module before you upgrade the cluster to RS 5.4.
 -   Node upgrade fails if SSL certificates were configured in version 5.0.2 and above by updating the certificates on the disk instead of using the new API. For assistance with this issue, please contact support. 
 
 ### Cluster API


### PR DESCRIPTION
we specify that the module version should be upgraded. Customers don't know at which level the upgrade of the module needs to be done i.e. just at the cluster level or at the DB level as well. So just added that details and also a link on how to upgrade a module.