### PR TITLE
lets use account number rather then account name to authenticate S3 b…

### DIFF
--- a/content/rc/how-to/importing-dataset-redis-cloud.md
+++ b/content/rc/how-to/importing-dataset-redis-cloud.md
@@ -67,7 +67,7 @@ To share and import an RDB file that is stored in an AWS S3 bucket:
 1. Navigate to the file, select the RDB file and click **Permissions**.
 1. Add access permissions to our service:
     1. Click **Add account**.
-    1. In the Account field, enter: `service@garantiadata.com`
+    1. In the Account field, enter: `fd1b05415aa5ea3a310265ddb13b156c7c76260dbc87e037a8fc290c3c86b614`
     1. In the Read object column, select **Yes**.
     1. Click **Save**.
 1. In the RC management console, go to the database that you want to import into.

--- a/content/rc/how-to/importing-dataset-redis-cloud.md
+++ b/content/rc/how-to/importing-dataset-redis-cloud.md
@@ -127,6 +127,3 @@ To import an RDB file that is stored in an ABS container:
         - `url` - URL of the storage account
         - `container` - Name of the container, if needed
         - `filename` - Filename of the RDB file, including the .gz suffix if the file is compressed
-        
- lets use account number rather then account name to authenticate S3 bucket , for the purpose of uniformity
-        

--- a/content/rc/how-to/importing-dataset-redis-cloud.md
+++ b/content/rc/how-to/importing-dataset-redis-cloud.md
@@ -127,3 +127,6 @@ To import an RDB file that is stored in an ABS container:
         - `url` - URL of the storage account
         - `container` - Name of the container, if needed
         - `filename` - Filename of the RDB file, including the .gz suffix if the file is compressed
+        
+ lets use account number rather then account name to authenticate S3 bucket , for the purpose of uniformity
+        


### PR DESCRIPTION
…ucket , for the purpose of uniformity

this doc "https://docs.redislabs.com/latest/rc/how-to/importing-dataset-redis-cloud/" explains how to add permission for a specific file in S3 bucket by adding account "service@garantiadata.com" to the file

this doc "https://docs.redislabs.com/latest/rc/administration/configure/backups/" explains how to add permission for the entire bucket by adding account "fd1b05415aa5ea3a310265ddb13b156c7c76260dbc87e037a8fc290c3c86b614" to the bucket

lets use account number rather then account name to authenticate S3 bucket , for the purpose of uniformity