### PR TITLE
Update link in redis-flash.md

### DIFF
--- a/content/rs/concepts/memory-architecture/redis-flash.md
+++ b/content/rs/concepts/memory-architecture/redis-flash.md
@@ -147,5 +147,5 @@ additional details, refer to [Creating a new
 database]({{< relref "/rs/administering/database-operations/creating-database.md" >}}).
 
 When Redis on Flash is enabled, additional settings and
-[metrics]( redis-enterprise-documentation/administering/monitoring-metrics/definitions/#redis-flash-metrics )
+[metrics](/rs/administering/monitoring-metrics/definitions.md#redis-flash-metrics)
 are available in the system.

--- a/content/rs/concepts/memory-architecture/redis-flash.md
+++ b/content/rs/concepts/memory-architecture/redis-flash.md
@@ -147,5 +147,5 @@ additional details, refer to [Creating a new
 database]({{< relref "/rs/administering/database-operations/creating-database.md" >}}).
 
 When Redis on Flash is enabled, additional settings and
-[metrics](redis-enterprise-documentation/administering/monitoring-metrics/definitions/#redis-flash-metrics)
+[metrics]( redis-enterprise-documentation/administering/monitoring-metrics/definitions/#redis-flash-metrics )
 are available in the system.

--- a/content/rs/concepts/memory-architecture/redis-flash.md
+++ b/content/rs/concepts/memory-architecture/redis-flash.md
@@ -147,5 +147,5 @@ additional details, refer to [Creating a new
 database]({{< relref "/rs/administering/database-operations/creating-database.md" >}}).
 
 When Redis on Flash is enabled, additional settings and
-[metrics](/rs/administering/monitoring-metrics/definitions.md#redis-flash-metrics)
+[metrics]({{< relref "/rs/administering/monitoring-metrics/definitions.md#redis-flash-metrics" >}})
 are available in the system.


### PR DESCRIPTION
The metrics link at the bottom of the page leads to a 404 (not found) error.
Need to check what is the proper link for it and update the page accordingly.