### PR TITLE
node_available_memory not documented for prometheus

### DIFF
--- a/content/rs/administering/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-integration.md
@@ -5282,7 +5282,7 @@ These are the metrics available:
 |  node_egress_bytes_min | Lowest value of rate of outgoing network traffic to node (bytes/sec) |
 |  node_ephemeral_storage_avail | Disk space available to RLEC processes on configured ephemeral disk (bytes) |
 |  node_ephemeral_storage_free | Free disk space on configured ephemeral disk (bytes) |
-|  node_free_memory | Free memory in node (bytes) |
+|  node_free_memory  |  Free memory in node (bytes) |
 |  node_ingress_bytes | Rate of incoming network traffic to node (bytes/sec) |
 |  node_ingress_bytes_max | Highest value of rate of incoming network traffic to node (bytes/sec) |
 |  node_ingress_bytes_median | Average value of rate of incoming network traffic to node (bytes/sec) |

--- a/content/rs/administering/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-integration.md
@@ -5262,6 +5262,7 @@ These are the metrics available:
 | Metric | Description |
 |  ------ | :------ |
 |  node_avg_latency | Average latency of requests handled by endpoints on node (micro-sec); returned only when there is traffic |
+|  node_available_memory | Amount of free memory in node (bytes) that is available for database provisioning |
 |  node_conns | Number of clients connected to endpoints on node |
 |  node_cpu_idle | CPU idle time portion (0-1, multiply by 100 to get percent) |
 |  node_cpu_idle_max | Highest value of CPU idle time portion (0-1, multiply by 100 to get percent) |
@@ -5282,7 +5283,7 @@ These are the metrics available:
 |  node_egress_bytes_min | Lowest value of rate of outgoing network traffic to node (bytes/sec) |
 |  node_ephemeral_storage_avail | Disk space available to RLEC processes on configured ephemeral disk (bytes) |
 |  node_ephemeral_storage_free | Free disk space on configured ephemeral disk (bytes) |
-|  node_free_memory  |  Free memory in node (bytes) |
+|  node_free_memory | Free memory in node (bytes) |
 |  node_ingress_bytes | Rate of incoming network traffic to node (bytes/sec) |
 |  node_ingress_bytes_max | Highest value of rate of incoming network traffic to node (bytes/sec) |
 |  node_ingress_bytes_median | Average value of rate of incoming network traffic to node (bytes/sec) |


### PR DESCRIPTION
A customer pointed out that they see two node metrics (node_free_memory & node_available_memory) that show almost the same details but only one is mentioned in the documentation, node_free_memory.
They can't tell the difference between the two.

Can we add the missing metric to the page and add explanation that will cover the differences between the two metrics?

Here's the snippet provided by the customer showing the metrics:

# HELP node_free_memory 
# TYPE node_free_memory gauge 
node_free_memory{cluster="pcfrdssbx.isus.emc.com",node="1"} 5972951040.0 
node_free_memory{cluster="pcfrdssbx.isus.emc.com",node="2"} 5309752206.222 
node_free_memory{cluster="pcfrdssbx.isus.emc.com",node="3"} 13918007751.111

# HELP node_available_memory 
# TYPE node_available_memory gauge 
node_available_memory{cluster="pcfrdssbx.isus.emc.com",node="1"} 5383443201.778 
node_available_memory{cluster="pcfrdssbx.isus.emc.com",node="2"} 5147263729.556 
node_available_memory{cluster="pcfrdssbx.isus.emc.com",node="3"} 13183055096.889