### PR TITLE
TCP port 1968 missing from ports list

### DIFF
--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -20,10 +20,11 @@ update your firewall with the port for that new database endpoint.
 | Protocol | Port | Description |
 |------------|-----------------|-----------------|
 | ICMP | * | For connectivity checking between nodes |
+| TCP | 1968 | Internal proxy usage. Ports are bound to loopback adapter. |
 | TCP | 3333, 3334, 3335, 3336, 3337, 3338, 3339, 36379, 36380 | Internal cluster usage |
 | TCP | 8001 | For application to access the RS [Discovery Service]({{< relref "/rs/concepts/data-access/discovery-service.md" >}}) |
 | TCP | 8443 | For secure (https) access to the management web UI |
-| TCP | 8444, 9080 | For nginx \<-\>cnm_http/cm communications on the same host only. Ports are bound to loopback adapter. |
+| TCP | 8444, 9080 | For nginx <->cnm_http/cm communications on the same host only. Ports are bound to loopback adapter. |
 | TCP | 9081 | For CRDB management |
 | TCP | 8070, 8071 | For metrics exported and managed by nginx |
 | TCP | 8080, 9443 | Used to expose the REST API, including cluster management and node bootstrap |

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -31,7 +31,7 @@ update your firewall with the port for that new database endpoint.
 | TCP | 10000-19999 | For exposing databases externally |
 | TCP | 20000-29999 | For internal communications with database shards |
 | UDP | 53, 5353 | For accessing DNS/mDNS functionality in the cluster |
- 
+
 ## Changing the Management Web UI Port
 
 If for any reason you want to use a custom port for the RS Web UI

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -30,7 +30,7 @@ update your firewall with the port for that new database endpoint.
 | TCP | 10000-19999 | For exposing databases externally |
 | TCP | 20000-29999 | For internal communications with database shards |
 | UDP | 53, 5353 | For accessing DNS/mDNS functionality in the cluster |
-
+ 
 ## Changing the Management Web UI Port
 
 If for any reason you want to use a custom port for the RS Web UI


### PR DESCRIPTION
** I didn't make modifications to the page **

The page is missing TCP port 1968 which seems to be used internally by the DMC management thread.
It's not clear if it's used only locally within the node or also between nodes in the cluster. It doesn't look like it is accessed externally.

I think it should be added to the page.
Please confirm the use with R&D.