### PR TITLE
Fix expand shortcode after upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for staging branches that excludes Google Tag Manager
     build-staging:
         docker:
-            - image: cibuilds/hugo:0.48
+            - image: cibuilds/hugo:0.55.5
         working_directory: ~/project
         steps:
             # Checkout the code from the branch into the working_directory
@@ -32,7 +32,7 @@ jobs:
     # The build job for production branches that includes Google Tag Manager
     build-prod:
         docker:
-            - image: cibuilds/hugo:0.48
+            - image: cibuilds/hugo:0.55.5
         working_directory: ~/project
         steps:
             # Checkout the code from the branch into the working_directory

--- a/content/rs/administering/designing-production/security/account-management.md
+++ b/content/rs/administering/designing-production/security/account-management.md
@@ -25,10 +25,10 @@ To add a user to the cluster:
     - internal - Authenticates with RS
     - external - Authenticates with an external LDAP server
 
-{{%expand "How do I create an external user?" %}}
-  To have a user authenticate with LDAP, you must have [LDAP integration enabled]({{< relref "/rs/administering/designing-production/security/ldap-integration.md" >}}).
-  Then, create a user with the user type **external**.
-{{% /expand%}}
+    {{%expand "How do I create an external user?" %}}
+To have a user authenticate with LDAP, you must have [LDAP integration enabled]({{< relref "/rs/administering/designing-production/security/ldap-integration.md" >}}).
+Then, create a user with the user type **external**.
+    {{% /expand%}}
 
 {{% comment %}}
 You can also create an external with the REST API with this syntax:
@@ -44,7 +44,7 @@ For the user role, enter either:
 - `cluster_viewer` - Cluster viewer
 - `cluster_member` - Cluster member
 - `admin` - Admin
-{{% /comment %}}    
+{{% /comment %}}
 
 1. For the email alerts, click **Edit** and select the alerts that the user receives.
     You can select:

--- a/content/rs/administering/designing-production/security/account-management.md
+++ b/content/rs/administering/designing-production/security/account-management.md
@@ -25,10 +25,10 @@ To add a user to the cluster:
     - internal - Authenticates with RS
     - external - Authenticates with an external LDAP server
 
-    {{% expand "How do I create an external user?" %}}
-To have a user authenticate with LDAP, you must have [LDAP integration
-enabled]({{< relref "/rs/administering/designing-production/security/ldap-integration.md" >}}).
-Then, create a user with the user type **external**.
+{{%expand "How do I create an external user?" %}}
+  To have a user authenticate with LDAP, you must have [LDAP integration enabled]({{< relref "/rs/administering/designing-production/security/ldap-integration.md" >}}).
+  Then, create a user with the user type **external**.
+{{% /expand%}}
 
 {{% comment %}}
 You can also create an external with the REST API with this syntax:
@@ -44,8 +44,7 @@ For the user role, enter either:
 - `cluster_viewer` - Cluster viewer
 - `cluster_member` - Cluster member
 - `admin` - Admin
-{{% /comment %}}
-    {{% /expand %}}
+{{% /comment %}}    
 
 1. For the email alerts, click **Edit** and select the alerts that the user receives.
     You can select:

--- a/content/rs/installing-upgrading/downloading-installing.md
+++ b/content/rs/installing-upgrading/downloading-installing.md
@@ -45,13 +45,13 @@ instances]({{< relref "/rs/installing-upgrading/configuring-aws-instances.md" >}
     To workaround this issue, change the system configuration to make this port available
     before running RS installation.
 
-    {{% expand "Example steps to resolve the port 53 conflict:" %}}
+{{% expand "Example steps to resolve the port 53 conflict:" %}}
 1. Run: `sudo vi /etc/systemd/resolved.conf`
 1. Add `DNSStubListener=no` as the last line in the file and save the file.
 1. Run: `sudo mv /etc/resolv.conf /etc/resolv.conf.orig`
 1. Run: `sudo ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf`
 1. Run: `sudo service systemd-resolved restart`
-    {{% /expand %}}
+{{% /expand %}}
 
 ## Installation Procedure
 

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,6 +1,6 @@
 {{define "breadcrumb"}}
 {{ if .page.Parent}}
-{{$value := (printf "<a href='%s'>%s</a> <span>></span> %s" .page.Parent.URL .page.Parent.Title .value)}}
+{{$value := (printf "<a href='%s'>%s</a> <span>></span> %s" .page.Parent.Permalink .page.Parent.Title .value)}}
 {{ template "breadcrumb" dict "page" .page.Parent "value" $value }} 
 {{else}}
  {{.value|safeHTML}}

--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -4,7 +4,7 @@
             {{- partial "noindex" . | safeHTML -}}
       {{ end }}
       {{- partial "canonical-url" . | safeHTML -}}
-      {{ .Hugo.Generator }}
+      {{ hugo.Generator }}
       <title>{{ .Title }} | {{ .Site.Title }}</title>
       <link rel="shortcut icon" href="{{"/images/icon_logo/favicon-32x32.png" | relURL}}" type="image/x-icon" />
       <link href="{{"css/font-awesome.min.css" | relURL}}" rel="stylesheet">

--- a/layouts/partials/flex/selectnavigation.html
+++ b/layouts/partials/flex/selectnavigation.html
@@ -15,7 +15,7 @@
 {{- $level := .level }}
  {{- with .sect}}
   {{- if .IsSection}}
-    <option value="{{ .Permalink}}" {{if eq .URL $currentNode.URL}} selected{{end}}>
+    <option value="{{ .Permalink}}" {{if eq .Permalink $currentNode.Permalink}} selected{{end}}>
   {{if gt $level 1 }}
     {{- range after 1 (seq $level)}}-{{ end }} 
   {{end}} {{.Title}}</option>
@@ -50,7 +50,7 @@
   {{end}}
   {{- else}}
     {{- if not .Params.Hidden }}
-      <option value="{{ .Permalink}}" {{if eq .URL $currentNode.URL}} selected{{end}}> 
+      <option value="{{ .Permalink}}" {{if eq .Permalink $currentNode.Permalink}} selected{{end}}> 
 {{- range after 1 (seq $level)}}-{{ end }} {{.Title}}</option>
     {{- end}}
   {{- end}}

--- a/layouts/partials/language-selector.html
+++ b/layouts/partials/language-selector.html
@@ -1,0 +1,18 @@
+{{- if and .Site.IsMultiLingual (not .Site.Params.DisableLanguageSwitchingButton)}}
+<select id="select-language" onchange="location = this.value;">
+	{{ $siteLanguages := .Site.Languages}}
+	{{ $pageLang := .Page.Lang}}
+	{{ range .Page.AllTranslations }}
+	  {{ $translation := .}}
+	  {{ range $siteLanguages }}
+	    {{ if eq $translation.Lang .Lang }}
+	      {{ if eq $pageLang .Lang}}
+	        <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}" selected>{{ .LanguageName }}</option>
+	      {{ else }}
+	        <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}">{{ .LanguageName }}</option>
+	      {{ end }}
+	    {{ end }}
+	  {{ end }}
+	{{ end }}
+</select>
+{{- end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -3,15 +3,16 @@
 {{- $isParentRoot := eq .Parent .FirstSection -}}
 {{- $numOfChildren := (add (len .Pages) (len .Sections)) -}}
 {{- $shouldCollapse := and $isParentRoot (eq $numOfChildren 0) -}}
-{{- $isCollapsed := (or $shouldCollapse (or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") (eq .URL "/platforms/"))) -}}
+{{- $isCollapsed := (or $shouldCollapse (or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") (eq .RelPermalink "/platforms/"))) -}}
+{{- $currentURL := .Permalink -}}
 
 {{- if eq .Site.Params.ordersectionsby "title"}}
   {{- range .Site.Home.Sections.ByTitle}}
-  {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed}}
+  {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed "currentURL" $currentURL}}
   {{- end}}
 {{- else}}
   {{- range .Site.Home.Sections.ByWeight}}
-  {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed}}
+  {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed "currentURL" $currentURL}}
   {{- end}}
 {{- end}}
 
@@ -19,32 +20,33 @@
 {{- define "section-tree-nav"}}
 {{- $showvisitedlinks := .showvisitedlinks }}
 {{- $isCollapsed := .isCollapsed }}
+{{- $currentURL := .currentURL }}
 {{- $currentNode := .currentnode }}
  {{- with .sect}}
   {{- if and .IsSection (or (not .Params.hidden) $.showhidden)}}
     {{- $numberOfPages := (add (len .Pages) (len .Sections)) }}
-    {{- safeHTML .Params.head}}    
-    <li data-nav-id="{{.URL}}" class="dd-item
+    {{- safeHTML .Params.head}}
+    <li data-nav-id="{{.RelPermalink}}" class="dd-item
         {{- if .IsAncestor $currentNode}} parent{{end -}}
-        {{- if eq .URL $currentNode.URL}} active{{end -}}
+        {{- if eq $currentURL .Permalink}} active{{end -}}
         {{- if .Params.alwaysopen}} alwaysopen{{end -}}
         {{- if ne $numberOfPages 0 }} haschildren{{end -}}
         {{- if $isCollapsed}} menu-collapsed {{else}} menu-expanded{{end -}}
-        {{- if (or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") (eq .URL "/platforms/"))}} menu-root {{end}}
+        {{- if (or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") (eq .RelPermalink "/platforms/"))}} menu-root {{end}}
         ">
         {{- if or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") (eq .RelPermalink "/platforms/") }}
           <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>          
         {{- end}}
 
-        {{- if eq .URL .RelPermalink }}
+        {{- if eq .RelPermalink .RelPermalink }}
           <!-- Child items -->          
-          {{if or (eq .URL "/rs/") }}
+          {{if or (eq .RelPermalink "/rs/") }}
             <div class="children has-version-selector">
           {{else}}
             <div class="children">
           {{end}}
 
-              {{- if or (eq .URL "/rs/") (eq .URL "/rc/") (eq .URL "/rv/") (eq .URL "/platforms/") }}          
+              {{- if or (eq .RelPermalink "/rs/") (eq .RelPermalink "/rc/") (eq .RelPermalink "/rv/") (eq .RelPermalink "/platforms/") }}          
                 <div class="menu-divider"></div>
                 
                 <span class="SideMenuToggle expander">
@@ -84,14 +86,14 @@
           {{- range $pages.ByTitle }}
             {{- if and .Params.hidden (not $.showhidden) }}
             {{- else}}
-            {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed }}
+            {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed "currentURL" $currentURL }}
             {{- end}}
           {{- end}}
         {{- else}}
           {{- range $pages.ByWeight }}
             {{- if and .Params.hidden (not $.showhidden) }}
             {{- else}}
-            {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed }}
+            {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks "isCollapsed" $isCollapsed "currentURL" $currentURL }}
             {{- end}}
           {{- end}}
         {{- end}}
@@ -100,8 +102,8 @@
     </li>
   {{- else}}
     {{- if not .Params.Hidden }}
-      <li data-nav-id="{{.URL}}" class="dd-item
-     {{- if eq .URL $currentNode.URL}} active{{end -}}
+      <li data-nav-id="{{.RelPermalink}}" class="dd-item
+     {{- if eq $currentURL .Permalink}} active{{end -}}
       ">
         <div>
           <a href="{{ .RelPermalink}}">

--- a/layouts/partials/next-prev-page.html
+++ b/layouts/partials/next-prev-page.html
@@ -7,7 +7,7 @@
 {{- define "menu-nextprev" -}}
     {{- $currentNode := .currentnode -}}
     {{- if ne .menu.Params.hidden true -}}
-        {{- if hasPrefix $currentNode.URL .menu.URL -}}
+        {{- if hasPrefix $currentNode.Permalink .menu.Permalink -}}
             {{- $currentNode.Scratch.Set "NextPageOK" "OK" -}}
             {{- $currentNode.Scratch.Set "prevPage" ($currentNode.Scratch.Get "prevPageTmp") -}}
         {{- else -}}
@@ -34,14 +34,16 @@
 
     
 {{- if not $.Site.Params.disableNavChevron -}}
+        {{ if .File }}
         <div class="edit-link"><a href="{{ .Site.Params.editURL }}{{ replace .File.Dir "\\" "/" }}{{ .File.LogicalName }}" class="github-link" target="blank"><i class="icon-Edit"></i>
             <span>{{T "Edit-this-page"}}</span></a></div>
         <!--<a class="nav-spacer"></a>-->
+        {{ end }}
     {{- with ($.Scratch.Get "prevPage") -}}
-        <div class="nav-links"><a class="nav-prev-next" href="{{.URL}}" title="{{.Title}}"><i class="icon-ArrowLeft"></i></a>
+        <div class="nav-links"><a class="nav-prev-next" href="{{.Permalink}}" title="{{.Title}}"><i class="icon-ArrowLeft"></i></a>
     {{ end -}}
     {{- with ($.Scratch.Get "nextPage") -}}
-        <a class="nav-prev-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><i class="icon-ArrowRight"></i></a></div>
+        <a class="nav-prev-next" href="{{.Permalink}}" title="{{.Title}}" style="margin-right: 0px;"><i class="icon-ArrowRight"></i></a></div>
     {{- end }}
 {{- end -}}
 </div>

--- a/layouts/partials/original/body-beforecontent.html
+++ b/layouts/partials/original/body-beforecontent.html
@@ -41,7 +41,7 @@
             {{- range sort . "Weight"}}
                 <li class="" role="">
                     {{- .Pre -}}
-                    <a href="{{.URL}}" target="_blank" rel="noopener">{{safeHTML .Name}}</a>
+                    <a href="{{.Permalink}}" target="_blank" rel="noopener">{{safeHTML .Name}}</a>
                     {{- .Post -}}
                 </li>
             {{- end}}
@@ -120,7 +120,7 @@
 
 {{define "breadcrumb"}}
 {{ if .page.Parent}}
-{{$value := (printf "<a href='%s'>%s</a> <span>></span> %s" .page.Parent.URL .page.Parent.Title .value)}}
+{{$value := (printf "<a href='%s'>%s</a> <span>></span> %s" .page.Parent.Permalink .page.Parent.Title .value)}}
 {{ template "breadcrumb" dict "page" .page.Parent "value" $value }} 
 {{else}}
  {{.value|safeHTML}}

--- a/layouts/partials/post-bottom.html
+++ b/layouts/partials/post-bottom.html
@@ -1,9 +1,11 @@
 <div class="post-bottom">
 {{- if not $.Site.Params.disableNavChevron -}}
     <div class="extra-links-gooter">
-        <div class="edit-link"><a href="{{ .Site.Params.editURL }}{{ replace .File.Dir "\\" "/" }}{{ .File.LogicalName }}" class="github-link" target="blank"><i class="icon-Edit"></i>
-            <span>{{T "Edit-this-page"}}</span></a>
-        </div>
+        {{ if .File }}
+            <div class="edit-link"><a href="{{ .Site.Params.editURL }}{{ replace .File.Dir "\\" "/" }}{{ .File.LogicalName }}" class="github-link" target="blank"><i class="icon-Edit"></i>
+                <span>{{T "Edit-this-page"}}</span></a>
+            </div>
+        {{ end }}
         <div class="go-top-link">
                 <a href="#top" class="got-to-top">Top&nbsp;<i class="icon-Top"></i></a>
         </div>
@@ -12,12 +14,12 @@
     {{- with ($.Scratch.Get "prevPage") -}}
         <div class="nav-links-footer">
             <div class="nav-links-footer-left">
-                <a class="nav-prev-next" href="{{.URL}}" title="{{.Title}}"><i class="icon-ArrowLeft"></i><span>Previous:</span>{{.Title}}</a>
+                <a class="nav-prev-next" href="{{.Permalink}}" title="{{.Title}}"><i class="icon-ArrowLeft"></i><span>Previous:</span>{{.Title}}</a>
             </div>
     {{ end -}}
     {{- with ($.Scratch.Get "nextPage") -}}
             <div class="nav-links-footer-right">
-                <a class="nav-prev-next" href="{{.URL}}" title="{{.Title}}"><span>Next:</span>&nbsp;{{.Title}}&nbsp;&nbsp;&nbsp;<i class="icon-ArrowRight"></i></a>
+                <a class="nav-prev-next" href="{{.Permalink}}" title="{{.Title}}"><span>Next:</span>&nbsp;{{.Title}}&nbsp;&nbsp;&nbsp;<i class="icon-ArrowRight"></i></a>
             </div>
         </div>
     {{- end }}

--- a/layouts/shortcodes/allchildren.html
+++ b/layouts/shortcodes/allchildren.html
@@ -49,11 +49,11 @@
 	{{- $numn := add $num $.count }}
 
 	{{- (printf "<h%d>" $numn)|safeHTML}}
-		<a href="{{.URL}}" >{{ .Title }}</a>
+		<a href="{{.Permalink}}" >{{ .Title }}</a>
 	{{- (printf "</h%d>" $numn)|safeHTML}}
 {{- else}}
 	{{- (printf "<%s>" $.style)|safeHTML}}
-		<a href="{{.URL}}" >{{ .Title }}</a>
+		<a href="{{.Permalink}}" >{{ .Title }}</a>
 	{{- (printf "</%s>" $.style)|safeHTML}}
 {{- end}}
 

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -50,11 +50,11 @@
 	{{- $numn := add $num $.count }}
 
 	{{- (printf "<h%d>" $numn)|safeHTML}}
-		<a href="{{.URL}}" >{{ .Title }}</a>
+		<a href="{{.Permalink}}" >{{ .Title }}</a>
 	{{- (printf "</h%d>" $numn)|safeHTML}}
 {{- else}}
 	{{- (printf "<%s>" $.style)|safeHTML}}
-		<a href="{{.URL}}" >{{ .Title }}</a>
+		<a href="{{.Permalink}}" >{{ .Title }}</a>
 	{{- (printf "</%s>" $.style)|safeHTML}}
 {{- end}}
 

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;"
         onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'icon-icons_minus' : 'icon-icons_plus';});});">
@@ -12,6 +13,6 @@
         </span>
     </div>
     <div class="expand-content" style="display: none;">
-        {{.Inner | safeHTML}}
+        {{.Inner}}
     </div>
 </div>

--- a/layouts/shortcodes/relref.html
+++ b/layouts/shortcodes/relref.html
@@ -7,7 +7,7 @@
 	{{- end -}}
 {{- else -}}
 	{{- with .Site.GetPage "section" (.Get 0) }}
-		{{- .URL -}}
+		{{- .Permalink -}}
 	{{- else -}}
 		{{- .Get 0 | relref .Page -}}
 	{{- end -}}


### PR DESCRIPTION
This PR fixes issues that occured with **expand** shortcode after upgrading Hugo to 0.55.5.
It also upgrades Hugo to the latest available version - 0.55.6.