### PR TITLE
Add detail to mount point backup explanation

### DIFF
--- a/content/rs/administering/database-operations/importing-data.md
+++ b/content/rs/administering/database-operations/importing-data.md
@@ -105,7 +105,7 @@ To specify to import from a local mount point on a node:
 
 1. In the path for the backup location, enter the mount point.
 
-    For example: `/mnt/Public/backup.rbd`
+    For example: `/mnt/Public/backup.rdb`
 
 In order to use this option, the storage needs to be mounted in the same path on all cluster nodes.
 The import source folder needs to be owned by the redislabs user with write permissions.

--- a/content/rs/administering/database-operations/importing-data.md
+++ b/content/rs/administering/database-operations/importing-data.md
@@ -90,6 +90,9 @@ Before you specify to import from a local mount point, make sure that:
 - The node has network connectivity to the destination server of the mount point.
 - The `redislabs:redislabs` user has read priviledges on the local mount point
 and on the destination server.
+- You must mount the storage in the same path on all cluster nodes.
+    You can also use local storage but you must copy the imported files manually to all nodes
+    because the import source folders on the nodes are not synchronised.
 
 To specify to import from a local mount point on a node:
 
@@ -106,11 +109,6 @@ To specify to import from a local mount point on a node:
 1. In the path for the backup location, enter the mount point.
 
     For example: `/mnt/Public/backup.rdb`
-
-In order to use this option, the storage needs to be mounted in the same path on all cluster nodes.
-The import source folder needs to be owned by the redislabs user with write permissions.
-
-Local storage can also be used, however, since the import source folders on various nodes are not synchronised, the imported files need to be copied manually to all nodes.
 
 ### OpenStack Swift
 

--- a/content/rs/administering/database-operations/importing-data.md
+++ b/content/rs/administering/database-operations/importing-data.md
@@ -107,6 +107,11 @@ To specify to import from a local mount point on a node:
 
     For example: `/mnt/Public/backup.rbd`
 
+In order to use this option, the storage needs to be mounted in the same path on all cluster nodes.
+The import source folder needs to be owned by the redislabs user with write permissions.
+
+Local storage can also be used, however, since the import source folders on various nodes are not synchronised, the imported files need to be copied manually to all nodes.
+
 ### OpenStack Swift
 
 Before you specify to import from OpenStack Swift, make sure that you have:


### PR DESCRIPTION
Added clarifications on how to use mount point import.
These are required in order to use that option.