### PR TITLE
fix maintenance_mode flag names.

### DIFF
--- a/content/rs/administering/cluster-operations/maintenance-mode.md
+++ b/content/rs/administering/cluster-operations/maintenance-mode.md
@@ -85,7 +85,7 @@ If the maintenance node fails, the master shards will not have slave shards for 
 To turn maintenance mode on and prevent slave shard migration, on one of the nodes in the cluster run:
 
 ```src
-rladmin node <node_id> maintenance_mode on dont_migrate_slave_shards
+rladmin node <node_id> maintenance_mode on keep_slave_shards
 ```
 
 ## Turning Maintenance Mode OFF
@@ -111,7 +111,7 @@ If there are multiple snapshots, you can restore a specified snapshot when you t
 To specify a snapshot when you turn maintenance mode off, on one of the nodes in the cluster run:
 
 ```src
-rladmin node <node_id> maintenance_mode off restore_from_snapshot <snapshot_name>
+rladmin node <node_id> maintenance_mode off snapshot_name <snapshot_name>
 ```
 
 {{% note %}}
@@ -134,5 +134,5 @@ you can turn maintenance mode off and prevent the shards and endpoints from movi
 To skip shard restoration, on one of the nodes in the cluster run:
 
 ```src
-rladmin node <node_id> maintenance_mode off dont_restore_shards
+rladmin node <node_id> maintenance_mode off skip_shards_restore
 ```


### PR DESCRIPTION
do not backport to 5.4, as these flags were not updated in 5.4.2.