### PR TITLE
RED-26867 Clearly mark internal ports

### DIFF
--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -20,17 +20,17 @@ update your firewall with the port for that new database endpoint.
 | Protocol | Port | Description |
 |------------|-----------------|-----------------|
 | ICMP | * | For connectivity checking between nodes |
-| TCP | 1968 | Internal proxy usage. Ports are bound to loopback adapter. |
-| TCP | 3333, 3334, 3335, 3336, 3337, 3338, 3339, 36379, 36380 | Internal cluster usage |
-| TCP | 8001 | For application to access the RS [Discovery Service]({{< relref "/rs/concepts/data-access/discovery-service.md" >}}) |
-| TCP | 8443 | For secure (https) access to the management web UI |
-| TCP | 8444, 9080 | For nginx \<-> cnm_http/cm communications on the same host only. Ports are bound to loopback adapter. |
-| TCP | 9081 | For CRDB management |
+| TCP | 1968 | Proxy traffic (Internal use) |
+| TCP | 3333, 3334, 3335, 3336, 3337, 3338, 3339, 36379, 36380 | Cluster traffic (Internal use) |
+| TCP | 8001 | Traffic from application to RS [Discovery Service]({{< relref "/rs/concepts/data-access/discovery-service.md" >}}) |
+| TCP | 8443 | Secure (HTTPS) access to the management web UI |
+| TCP | 8444, 9080 | For nginx <-> cnm_http/cm traffic (Internal use) |
+| TCP | 9081 | For CRDB management (Internal use) |
 | TCP | 8070, 8071 | For metrics exported and managed by nginx |
-| TCP | 8080, 9443 | Used to expose the REST API, including cluster management and node bootstrap |
-| TCP | 10000-19999 | For exposing databases externally |
-| TCP | 20000-29999 | For internal communications with database shards |
-| UDP | 53, 5353 | For accessing DNS/mDNS functionality in the cluster |
+| TCP | 8080, 9443 | REST API traffic, including cluster management and node bootstrap |
+| TCP | 10000-19999 | Database traffic |
+| TCP | 20000-29999 | Database shards traffic (Internal use) |
+| UDP | 53, 5353 | DNS/mDNS traffic (Internal use) |
 
 ## Changing the Management Web UI Port
 
@@ -50,4 +50,4 @@ To change the default port for the RS Web UI, on any node in the cluster run:
 
 ```src
 rladmin cluster config cm_port <new-port>
-``` 
+```

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -50,4 +50,4 @@ To change the default port for the RS Web UI, on any node in the cluster run:
 
 ```src
 rladmin cluster config cm_port <new-port>
-```
+``` 


### PR DESCRIPTION
@bmansheim - I remember that we discussed this line with Yossi-
"| TCP | 9081 | For CRDB management |"
I understand that this port is used internally (in the node) and it should not be exposed outside the node. If it's correct, why did we decide to add it to this list? Do you remember?