### PR TITLE
New cert update method through RLADMIN

### DIFF
--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -41,8 +41,10 @@ The below command syntax can be used to replace certificates substituting the be
 - certificate-file-name - The name of your certificate file
 
     ```bash
+    
  rladmin cluster certificate set <certificate-type> certificate_file <certificate-file-name>.pem key_file <key-file-name>.pem
-    ```
+   
+   ```
 
 For example, the following command would replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem"
 

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -40,19 +40,17 @@ The below command syntax can be used to replace certificates substituting the be
 - key-file-name - The name of your non-password protected key file.
 - certificate-file-name - The name of your certificate file
 
-    ```bash
-    
+
+```src
  rladmin cluster certificate set <certificate-type> certificate_file <certificate-file-name>.pem key_file <key-file-name>.pem
-   
-   ```
+```
 
 For example, the following command would replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem"
 
-   ```bash
-   
-rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
 
-   ```
+```src
+rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
+```
    
    When you upgrade RS, the upgrade process copies the certificates on the first upgraded node to all of the nodes in the cluster.
 

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -26,7 +26,7 @@ future sessions.{{% /note %}}
 
 You can replace an existing certificate on the cluster leveraging the rladmin command-line utility.
 
-There are 5 different types of certificates that can be replaced starting in RS version 5.4.x. These may be replaced leveraging the below command.
+There are 5 different types of certificates that can be replaced starting in RS version 5.4.x. These may be replaced leveraging the below commands where the below certificate types are availible to change:
 
 - API - This is the certificate used by the API
 - CM  - This is the certificate used by the management user interface or the cluster manager. It is also used for the sentinel discovery service if you are using sentinel

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -5,55 +5,85 @@ weight: $weight
 alwaysopen: false
 categories: ["RS"]
 ---
-Redis Enterprise Software (RS) uses self-signed certificates to encrypt
-the following traffic:
+Redis Enterprise Software (RS) uses self-signed certificates out-of-the-box to make sure that the product is secure by default.
+The self-signed certificates is used to establish encryption-in-transit for the following traffic:
 
-- Management UI
+- Management User Interface (UI)
 - REST API
-- Connections between clients and the database endpoint
+- Connections between clients and database endpoints
 - Synchronization between databases for ReplicaOf and CRDB
+- Discovery Services
 
-These self-signed certificates are generated on the first node of each RS installation. These certificates are then copied to all other nodes added to the cluster.
+These self-signed certificates are generated on the first node of each RS installation and are copied to all other nodes added to the cluster.
 
-{{% note %}}When using the default self-signed certificates, an untrusted
-connection notification will appear in the management UI. If you do not
-update the self-signed certificate with your own certificate, depending
-on the browser you use, you might be able to allow the connection for
-this specific session, or add an exception to make this site trusted in
-future sessions.{{% /note %}}
+When you use the default self-signed certificates, an untrusted connection notification is shown in the web UI.
+Depending on the browser you use, you can allow the connection for each session or add an exception to make the site trusted in future sessions.
+
+{{% warning %}}
+When you update the certificates, the new certificate replaces the same certificates on all nodes in the cluster.
+{{% /warning %}}
 
 ## How to update TLS certificates
 
-You can replace an existing certificate on the cluster leveraging the rladmin command-line utility.
+The certificates that you can replace are:
 
-There are 5 different types of certificates that can be replaced starting in RS version 5.4.x. These may be replaced leveraging the below commands where the below certificate types are availible to change:
+- API - The certificate used by the API
+- CM - The certificate used by the management user interface or the cluster manager and the Sentinel discovery service
+- Proxy - The certificate used to establish communication between a client and the databases
+- Syncer - The certificate used to encrypt replication traffic between clusters
+- Metrics exporter - The certificate used by Prometheus
 
-- API - This is the certificate used by the API
-- CM  - This is the certificate used by the management user interface or the cluster manager. It is also used for the sentinel discovery service if you are using sentinel
-- Proxy  - This is the certificate used to establish communication between a client and the databases
-- Syncer  - This is the certificate used to encrypt replication between clusters
-- Metrics_Exporter - This is the certificate used by Prometheus.
+### Using the CLI
 
-The below command syntax can be used to replace certificates substituting the below variables:
-
-- certificate-type - The type of certificate you want to replace
-- key-file-name - The name of your non-password protected key file.
-- certificate-file-name - The name of your certificate file
-
+To replace certificates using the rladmin CLI, run:
 
 ```src
- rladmin cluster certificate set <certificate-type> certificate_file <certificate-file-name>.pem key_file <key-file-name>.pem
+ rladmin cluster certificate set <cert-name> certificate_file <cert-file-name>.pem key_file <key-file-name>.pem
 ```
 
-For example, the following command would replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem"
+Where:
 
+- cert-type - The type of certificate you want to replace:
+    - For management UI: `cm`
+    - For REST API: `api`
+    - For database endpoint: `proxy`
+    - For syncer: `syncer`
+    - For metrics exporter: `metrics_exporter`
+- cert-file-name - The name of your certificate file
+- key-file-name - The name of your non-password protected key file
+
+For example, to replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem":
 
 ```src
 rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
 ```
-   
-   When you upgrade RS, the upgrade process copies the certificates on the first upgraded node to all of the nodes in the cluster.
 
+### Using the REST API
+
+To replace a certificate using the REST API, run:
+
+```src
+curl -k -X PUT -u "<username>:<password>" -H "Content-Type: application/json" -d '{ "name": "<cert_type>", "key": "<key>", "certificate": "<cert>" }' https://<cluster_address>:9443/v1/cluster/update_cert
+```
+
+Where:
+
+- cert_type - The name of the certificate to replace:
+    - For management UI: `cm`
+    - For REST API: `api`
+    - For database endpoint: `proxy`
+    - For syncer: `syncer`
+    - For metrics exporter: `metrics_exporter`
+- key - The contents of the *_key.pem file
+
+    {{% tip %}}
+    The key file contains `\n` end of line characters (EOL) that you cannot paste into the API call.
+    You can use `sed -z 's/\n/\\\n/g'` to escape the EOL characters.
+    {{% /tip %}}
+
+- certificate - The contents of the *_cert.pem file
+
+When you upgrade RS, the upgrade process copies the certificates on the first upgraded node to all of the nodes in the cluster.
 
 ## TLS Protocol and Ciphers
 

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -8,11 +8,11 @@ categories: ["RS"]
 Redis Enterprise Software (RS) uses self-signed certificates out-of-the-box to make sure that the product is secure by default.
 The self-signed certificates is used to establish encryption-in-transit for the following traffic:
 
-- Management User Interface (UI)
-- REST API
-- Connections between clients and database endpoints
-- Synchronization between databases for ReplicaOf and CRDB
-- Discovery Services
+- Management Web UI (CM) - The certificate for connections to the management web UI
+- REST API - The certificate for REST API calls
+- Proxy - The certificate for connections between clients and database endpoints
+- Syncer - The certificate for synchronization between databases for ReplicaOf and CRDB
+- Metrics exporter - The certificate to export metrics to Prometheus
 
 These self-signed certificates are generated on the first node of each RS installation and are copied to all other nodes added to the cluster.
 
@@ -25,13 +25,7 @@ When you update the certificates, the new certificate replaces the same certific
 
 ## How to update TLS certificates
 
-The certificates that you can replace are:
-
-- API - The certificate used by the API
-- CM - The certificate used by the management user interface or the cluster manager and the Sentinel discovery service
-- Proxy - The certificate used to establish communication between a client and the databases
-- Syncer - The certificate used to encrypt replication traffic between clusters
-- Metrics exporter - The certificate used by Prometheus
+You can use either the rladmin CLI or the REST API to update the certificates.
 
 ### Using the CLI
 
@@ -50,7 +44,7 @@ Where:
     - For syncer: `syncer`
     - For metrics exporter: `metrics_exporter`
 - cert-file-name - The name of your certificate file
-- key-file-name - The name of your non-password protected key file
+- key-file-name - The name of your key file
 
 For example, to replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem":
 
@@ -81,7 +75,7 @@ Where:
     You can use `sed -z 's/\n/\\\n/g'` to escape the EOL characters.
     {{% /tip %}}
 
-- certificate - The contents of the *_cert.pem file
+- cert - The contents of the *_cert.pem file
 
 When you upgrade RS, the upgrade process copies the certificates on the first upgraded node to all of the nodes in the cluster.
 

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -22,36 +22,38 @@ on the browser you use, you might be able to allow the connection for
 this specific session, or add an exception to make this site trusted in
 future sessions.{{% /note %}}
 
-## How to update SSL/TLS certificates
+## How to update TLS certificates
 
-**For versions 5.2.0 and above:** ([Procedures for previous releases](https://docs.redislabs.com/5.2/rs/references/procedures-previous-releases/))
+You can replace an existing certificate on the cluster leveraging the rladmin command-line utility.
 
-{{% warning %}}The new certificate replaces the equivalent certificate on all nodes in the cluster. Existing certificates are overwritten.{{% /warning %}}
+There are 5 different types of certificates that can be replaced starting in RS version 5.4.x. These may be replaced leveraging the below command.
 
-- Use the REST API to replace the certificate:
+- API - This is the certificate used by the API
+- CM  - This is the certificate used by the management user interface or the cluster manager. It is also used for the sentinel discovery service if you are using sentinel
+- Proxy  - This is the certificate used to establish communication between a client and the databases
+- Syncer  - This is the certificate used to encrypt replication between clusters
+- Metrics_Exporter - This is the certificate used by Prometheus.
 
-    ```src
+The below command syntax can be used to replace certificates substituting the below variables:
 
-    curl -k -X PUT -u "<username>:<password>" -H "Content-Type: application/json" -d '{ "name": "<cert_name>", "key": "<key>", "certificate": "<cert>" }' https://<cluster_address>:9443/v1/cluster/update_cert
+- certificate-type - The type of certificate you want to replace
+- key-file-name - The name of your non-password protected key file.
+- certificate-file-name - The name of your certificate file
 
+    ```bash
+ rladmin cluster certificate set <certificate-type> certificate_file <certificate-file-name>.pem key_file <key-file-name>.pem
     ```
 
-    Where:
+For example, the following command would replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem"
 
-    - cert_name - The name of the certificate to replace:
-        - For management UI: `cm`
-        - For REST API: `api`
-        - For database endpoint: `proxy`
-        - For syncer: `syncer`
-    - key - The contents of the *_key.pem file
+   ```bash
+   
+rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
 
-    {{% tip %}}The key file contains `\n` end of line characters (EOL) that you cannot paste into the API call. You can use `sed -z 's/\n/\\\n/g'` to escape the EOL characters.{{% /tip %}}
+   ```
+   
+   When you upgrade RS, the upgrade process copies the certificates on the first upgraded node to all of the nodes in the cluster.
 
-    - cert - The contents of the *_cert.pem file
-
-    The certificate is copied automatically to all nodes in the cluster.
-
-When you upgrade RS, the upgrade process copies the certificates on the first upgraded node to all of the nodes in the cluster.
 
 ## TLS Protocol and Ciphers
 


### PR DESCRIPTION
This pull request updates our certificate update procedure to use rladmin instead of the rest API. This makes the procedure cleaner and easily consumable for users. 

Changes include:
1. Update certificate instructions now reference rladmin
2. REST API method moved to the previous version, however, is still available.