### PR TITLE
Added link to Platforms docs landing

### DIFF
--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -5,10 +5,15 @@ weight: $weight
 alwaysopen: false
 categories: ["RS"]
 ---
-Redis Enterprise Software (RS) is supported on several operating
-systems, cloud environments, and virtual environments.
+Redis Enterprise Software (RS) is supported on several operating systems, cloud environments, and virtual environments.
 
- {{% note %}}Only 64-bit operating systems are supported.{{% /note %}}
+{{% note %}}
+Make sure your system meets these requirements:
+
+- Only 64-bit operating systems are supported.
+- You must install Redis Enterprise Software directly on the host, not through system cloning.
+- You must install on a clean host with no other applications running so that all RAM is allocated to the OS and RS only.
+{{% /note %}}
 
 | **Platform** | **Versions/Information** |
 |------------|-----------------|
@@ -18,15 +23,4 @@ systems, cloud environments, and virtual environments.
 | Oracle Linux | 6.7, 6.8, 6.9; 7.0, 7.1, 7.2, 7.3, 7.4, 7.5 |
 | Amazon Linux | All 64-bit Versions |
 | Docker | Redis Enterprise Software Docker images are certified for Development and Testing only. |
-
-No other applications should be running on the same server that is
-running RS. The RS software's resource consumption assumes that all RAM
-on the server is exclusively allocated to the OS and RS; thus, other
-applications running on the same server can interfere with RS's proper
-functioning.
-
-Note: Cloning of servers/VMs/instances with Redis Enterprise Software
-already install/deployed, is **NOT** supported. It must be a fresh
-install of RS each time.
-
-{{% note %}}For Kubernetes, Pivotal Platform (PCF) and other orchestration and cloud environments see the [Platform documentation page]({{< relref "/platforms" >}}). {{% /note %}}
+| Kubernetes, Pivotal Platform (PCF) and other orchestration and cloud environments | See the [Platform documentation]({{< relref "/platforms" >}}) |

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -28,3 +28,5 @@ functioning.
 Note: Cloning of servers/VMs/instances with Redis Enterprise Software
 already install/deployed, is **NOT** supported. It must be a fresh
 install of RS each time.
+
+{{% note %}}For Kubernetes, Pivotal Platform (PCF) and other orchestration and cloud environments see the [Platform documentation page]({{< relref "/platforms" >}}). {{% /note %}}


### PR DESCRIPTION
For customers looking for orchestration and cloud platforms, as highlighted by the SA team:

Hey all - I noticed that there is nothing on this page about K8s platform support: https://docs.redislabs.com/latest/rs/administering/designing-production/supported-platforms/
Amiram Mizne 11:20 AM
The term “platform” is probably not the best in this context but in the intended context, K8s is not a “platform”. PCF isn’t mentioned either. This isn’t the place we chose to list these orchestration/operational environments that we operate in.
This is our “platforms” landing page https://docs.redislabs.com/latest/platforms/
new messages
Jane Paek 2:07 PM
@Amiram can we still add a link to the "Platforms" landing page from our "supported-platforms" page? If I were a customer, I wouldn't know to distinguish one platform intent vs another.