### PR TITLE
Improve certificate procedures

### DIFF
--- a/content/rs/administering/designing-production/security/client-connections.md
+++ b/content/rs/administering/designing-production/security/client-connections.md
@@ -46,8 +46,8 @@ significantly impact database throughput and latency.
 
 #### Installing CA signed certificates high-level steps
 
-1. Replace the RS server certificates on all nodes and key with the CA
-    signed certificate and restart proxy. Detailed guidelines on how to perform this step can be found [here](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/).
+1. [Replace the RS server certificates](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/) on all nodes and key
+    with the CA signed certificate and restart proxy.
 
     Note: A certificate for the databases' endpoint should be assigned
     for the same domain as the cluster name. For example, for a cluster

--- a/content/rs/administering/designing-production/security/client-connections.md
+++ b/content/rs/administering/designing-production/security/client-connections.md
@@ -47,12 +47,12 @@ significantly impact database throughput and latency.
 #### Installing CA signed certificates high-level steps
 
 1. Replace the RS server certificates on all nodes and key with the CA
-    signed certificate and restart proxy
+    signed certificate and restart proxy. Detailed guidelines on how to perform this step can be found [here](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/).
 
     Note: A certificate for the databases' endpoint should be assigned
     for the same domain as the cluster name. For example, for a cluster
     with the name "redislabs.com" the certificate should be for
-    "redis-\*.redislabs.com".
+    "*.redislabs.com".
 
 1. Add the TLS client certificates in the UI including CA
     certificates and any intermediate certificates by chaining the

--- a/content/rs/administering/designing-production/security/client-connections.md
+++ b/content/rs/administering/designing-production/security/client-connections.md
@@ -46,8 +46,8 @@ significantly impact database throughput and latency.
 
 #### Installing CA signed certificates high-level steps
 
-1. [Replace the RS server certificates](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/) on all nodes and key
-    with the CA signed certificate and restart proxy.
+1. [Replace the RS server certificates](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/) and key
+    on all nodes with the CA signed certificate, and restart the proxy.
 
     Note: A certificate for the databases' endpoint should be assigned
     for the same domain as the cluster name. For example, for a cluster


### PR DESCRIPTION
The process to update the proxy's certificate no longer require manual replacement of the certificate and a proxy restart.
It should utilize the API/rladmin capabilities.
Added a link to the detailed step for updating certificates.

Also, the common name for the certificate was incorrect so updated "redis-*.redislabs.com" to "*.redislabs.com".