### PR TITLE
Update getting-started-crdbs.md

### DIFF
--- a/content/rs/getting-started/getting-started-crdbs.md
+++ b/content/rs/getting-started/getting-started-crdbs.md
@@ -88,7 +88,7 @@ Now we have two Redis Enterprise Software clusters with FQDNs
     1. For the **endpoint port number**, enter: `12000`
     1. In the **participating clusters** list, add the address and admin credentials for:
         - `https://cluster1.local:9443` - the cluster you are currently connected to
-        - `https://cluster2.local:9445` - the other cluster
+        - `https://cluster2.local:9443` - the other cluster
     <!-- Also in create-crdb.md -->
     1. In the **Database clustering** option, either:
 


### PR DESCRIPTION
The creation of the CRDB database is executed locally on cluster1.local and uses the docker network to connect to cluster2.local.  The API is available on 9443, not 9445.  The API is mapped to 9445 on the host machine only.  Attempting to connect with the 9445 address gave me a connection refused error. 9443 completes successfully.