### PR TITLE
Reflect NET_RAW and priv. escalation change, persistence default behavior

### DIFF
--- a/content/platforms/faqs/_index.md
+++ b/content/platforms/faqs/_index.md
@@ -234,12 +234,11 @@ RLEC PSP definitions are controlled with role-based access control (RBAC).
 A cluster role allowing the RLEC PSP is granted to the redis-enterprise-operator service account
 and allows that account to create pods with the PSP shown above.
 
-Note that the NET_RAW capability requirement in PSP has been removed as of release 5.4.6-1183. 
-Note that the allowPrivilegeEscalation is set to 'false' by default as of release 5.4.6-1183.
-These changes better align the deployment with container and Kubernetes security best practices.
-
 {{% note %}}
-Removing NET_RAW blocks 'ping' from being used on the solution containers.
+- Removing NET_RAW blocks 'ping' from being used on the solution containers.
+- These changes were made as of release 5.4.6-1183 to better align the deployment with container and Kubernetes security best practices:
+    - The NET_RAW capability requirement in PSP was removed.
+    - The allowPrivilegeEscalation is set to 'false' by default.
 {{% /note %}}
 
 {{% /expand%}}

--- a/content/platforms/faqs/_index.md
+++ b/content/platforms/faqs/_index.md
@@ -238,8 +238,8 @@ Note that the NET_RAW capability requirement in PSP has been removed as of relea
 Note that the allowPrivilegeEscalation is set to 'false' by default as of release 5.4.6-1183.
 These changes better align the deployment with container and Kubernetes security best practices.
 
-{{% note% }}
+{{% note %}}
 Removing NET_RAW blocks 'ping' from being used on the solution containers.
-{{% /note% }}
+{{% /note %}}
 
 {{% /expand%}}

--- a/content/platforms/faqs/_index.md
+++ b/content/platforms/faqs/_index.md
@@ -176,26 +176,20 @@ The scc.yaml file is defined like this:
 
 ```yaml
 kind: SecurityContextConstraints
-
-apiVersion: v1
-
+apiVersion: security.openshift.io/v1
 metadata:
-
-name: redis-enterprise-scc
-
+  name: redis-enterprise-scc
 allowPrivilegedContainer: false
-
 allowedCapabilities:
-
-- SYS_RESOURCE
-
+  - SYS_RESOURCE
 runAsUser:
-
-type: RunAsAny
-
+  type: MustRunAs
+  uid: 1001
+FSGroup:
+  type: MustRunAs
+  ranges: 1001,1001
 seLinuxContext:
-
-type: RunAsAny
+  type: RunAsAny
 ```
 
 ([latest version on GitHub](https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/master/scc.yaml))
@@ -209,10 +203,9 @@ metadata:
   name: redis-enterprise-psp
 spec:
   privileged: false
-  allowPrivilegeEscalation: true
+  allowPrivilegeEscalation: false
   allowedCapabilities:
     - SYS_RESOURCE
-    - NET_RAW
   runAsUser:
     rule: MustRunAsNonRoot
   fsGroup:
@@ -240,4 +233,13 @@ The RLEC SCC definitions are only applied to the project namespace when you appl
 RLEC PSP definitions are controlled with role-based access control (RBAC).
 A cluster role allowing the RLEC PSP is granted to the redis-enterprise-operator service account
 and allows that account to create pods with the PSP shown above.
+
+Note that the NET_RAW capability requirement in PSP has been removed as of release 5.4.6-1183. 
+Note that the allowPrivilegeEscalation is set to 'false' by default as of release 5.4.6-1183.
+These changes better align the deployment with container and Kubernetes security best practices.
+
+{{% note% }}
+Removing NET_RAW blocks 'ping' from being used on the solution containers.
+{{% /note% }}
+
 {{% /expand%}}

--- a/content/platforms/kubernetes/kubernetes-persistent-volumes.md
+++ b/content/platforms/kubernetes/kubernetes-persistent-volumes.md
@@ -19,6 +19,10 @@ spec should include a *persistentSpec* section, in the
 
 Persistence storage is a requirement for this deployment type.
 
+{{% note %}}
+For *production* deployment of Redis Enterprise Cluster on Kubenetes, the Redis Enterprise Cluster (REC) must be deployed with persistence enabled. The REC deployment files on ([GitHub K8s Documentation repository](https://github.com/RedisLabs/redis-enterprise-k8s-docs)) contain this declaration by default. 
+{{% /note %}}
+
 ## Volume Size
 
 *volumeSize* is an optional definition. By default, if the definition is
@@ -29,6 +33,10 @@ requirements]({{< relref "/rs/administering/designing-production/hardware-requir
 
 To explicitly specify the persistent storage size, use the *volumeSize*
 property as described in the example above.
+
+{{% note %}}
+It is highly recommeded that the Redis Enterprise Cluster deployment on Kubenetes use the default volume size by omitting the definition from the REC declaration unless a bigger than default volume is required.
+{{% /note %}}
 
 ## Storage Class Name
 

--- a/content/platforms/kubernetes/kubernetes-persistent-volumes.md
+++ b/content/platforms/kubernetes/kubernetes-persistent-volumes.md
@@ -20,7 +20,9 @@ spec should include a *persistentSpec* section, in the
 Persistence storage is a requirement for this deployment type.
 
 {{% note %}}
-For *production* deployment of Redis Enterprise Cluster on Kubenetes, the Redis Enterprise Cluster (REC) must be deployed with persistence enabled. The REC deployment files on ([GitHub K8s Documentation repository](https://github.com/RedisLabs/redis-enterprise-k8s-docs)) contain this declaration by default. 
+For **production deployments** of Redis Enterprise Cluster on Kubenetes,
+the Redis Enterprise Cluster (REC) must be deployed with persistence enabled.
+The REC deployment files in the [Kubernetes documentation](https://github.com/RedisLabs/redis-enterprise-k8s-docs) contain this declaration by default.
 {{% /note %}}
 
 ## Volume Size
@@ -35,7 +37,8 @@ To explicitly specify the persistent storage size, use the *volumeSize*
 property as described in the example above.
 
 {{% note %}}
-It is highly recommeded that the Redis Enterprise Cluster deployment on Kubenetes use the default volume size by omitting the definition from the REC declaration unless a bigger than default volume is required.
+We recommed that you omit the volumeSize definition from the REC declaration
+so that the Redis Enterprise Cluster deployment on Kubenetes use the default volume size.
 {{% /note %}}
 
 ## Storage Class Name


### PR DESCRIPTION
FAQ now correctly reflects security enhancements:
NET_RAW capability is no longer required by PSP.
allowPrivilegeEscalaltion is set to 'false' by PSP.
Added note about the impact on ping.
Addressed RED-33428: Document spec default persistence behavior