### PR TITLE
Update to include cloud provider info for import

### DIFF
--- a/content/rv/how-to/importing-data-database.md
+++ b/content/rv/how-to/importing-data-database.md
@@ -60,3 +60,19 @@ Where:
 - *path*: the path to the file, if needed.
 - *filename*: the filename of the RDB file, optionally compressed and
     with the *.gz* suffix.
+    
+##Import a Dataset From Cloud Storage
+
+Redis Labs offers support to import datasets from cloud object storage options in Google Cloud Platform, Amazon Web Services, and Microsoft Azure.
+
+Note: In order to successfully authenticate to to Azure, you must provide an account access key and account name.
+
+In order to import from Azure Blob Storage use the following standard pattern:
+`abs://:storage_account_access_key@storage_account_name/container_name/blob_name.rdb`
+
+In order to import from Google Cloud Storage, use the following standard pattern:
+`gs://bucket-name/path/filename.rdb`
+
+In order to import from Amazon's S3 Service, use the following standard pattern:
+
+`s3://bucketname/foldername/filename.rdb`

--- a/content/rv/how-to/importing-data-database.md
+++ b/content/rv/how-to/importing-data-database.md
@@ -61,18 +61,75 @@ Where:
 - *filename*: the filename of the RDB file, optionally compressed and
     with the *.gz* suffix.
     
-##Import a Dataset From Cloud Storage
+### RDB File From an Amazon Simple Storage Service (AWS S3) Bucket
 
-Redis Labs offers support to import datasets from cloud object storage options in Google Cloud Platform, Amazon Web Services, and Microsoft Azure.
+Before you import the RDB file through the Redis Cloud Essentials management console, you must go to the AWS
+management console and share the file.
 
-Note: In order to successfully authenticate to to Azure, you must provide an account access key and account name.
+To share and import an RDB file that is stored in an AWS S3 bucket:
 
-In order to import from Azure Blob Storage use the following standard pattern:
-`abs://:storage_account_access_key@storage_account_name/container_name/blob_name.rdb`
+1. Go to the AWS console and click **S3** from the Services menu.
+1. Click on the bucket where the RDB file is stored.
+1. Navigate to the file, select the RDB file and click **Permissions**.
+1. Add access permissions to our service:
+    1. Click **Add account**.
+    1. In the Account field, enter: `fd1b05415aa5ea3a310265ddb13b156c7c76260dbc87e037a8fc290c3c86b614`
+    1. In the Read object column, select **Yes**.
+    1. Click **Save**.
+1. In the Redis Cloud Essentials management console, go to the database that you want to import into.
+1. Click **Import**.
+1. Enter the details for the RDB file:
+    - Source Type - Select **AWS S3**.
+    - RDB file path - Enter the URL for RDB file: `s3://bucketname/[path/]filename.rdb[.gz]`
 
-In order to import from Google Cloud Storage, use the following standard pattern:
-`gs://bucket-name/path/filename.rdb`
+        Where:
 
-In order to import from Amazon's S3 Service, use the following standard pattern:
+        - `bucketname` - Name of the S3 bucket
+        - `path` - Path to the file, if needed
+        - `filename` - Filename of the RDB file, including the .gz suffix if the file is compressed
 
-`s3://bucketname/foldername/filename.rdb`
+### RDB File from a Google Cloud Storage (GCS) Bucket
+
+Before you import the RDB file through the Redis Cloud Essentials console, you must go to the Google
+Cloud Platform (GCP) console and share the file.
+
+To share and import an RDB file that is stored in a GCS bucket:
+
+1. Go to the GCP console and click on your GCP project.
+1. Click on the menu to open it, and select **Storage** to open the Storage browser and view your buckets.
+1. Click on the bucket where the RDB file is stored.
+1. Edit the file permissions:
+    1. Click on the RDB file menu to open it, and click **Edit permissions**.
+    1. Click **Add item**.
+    1. Enter the user details and access:
+       - In the Entity field of the new item, select **User**.
+       - In the Name field of the new item, enter: `service@redislabs-prod-clusters.iam.gserviceaccount.com`
+       - In the Access field of the new item, select **Reader**.
+    1. Click **Save**.
+1. In the Redis Cloud Essentials management console, go to the database that you want to import into.
+1. Click **Import**.
+1. Enter the details for the RDB file:
+    - Source Type - Select **Google Cloud Storage**.
+    - RDB file path - Enter the URL for RDB file: `gs://bucketname/[path/]filename.rdb[.gz]`
+
+        Where:
+        - `bucketname` - Name of the GCS bucket
+        - `path` - Path to the file
+        - `filename` - Filename of the RDB file, including the .gz suffix if the file is compressed
+
+### RDB File from an Azure Blob Storage (ABS) Container
+
+To import an RDB file that is stored in an ABS container:
+
+1. In the Redis Cloud Essentials management console, go to the database that you want to import into.
+1. Click **Import**.
+1. Enter the details for the RDB file:
+    - Source Type - Select **Azure Blob Storage**.
+    - RDB file path - Enter the URL for RDB file: `abs://:storage_account_access_key@storage_account_name/[container/]filename.rdb[.gz]`
+
+        Where:
+        - `storage_account_access_key` - Primary access key to the storage account
+        - `storage_account_name` - Name of the storage account
+        - `url` - URL of the storage account
+        - `container` - Name of the container, if needed
+        - `filename` - Filename of the RDB file, including the .gz suffix if the file is compressed


### PR DESCRIPTION
This PR closes #518

@mikhailredis - I'm cherry-picking the update you did to RC and moving it to RV as well. It was on our documentation in one place correctly but not the other.

@bmansheim - This is already published here correctly:
https://docs.redislabs.com/latest/rc/how-to/importing-dataset-redis-cloud/

But it is not published correctly at this location.

https://docs.redislabs.com/latest/rv/how-to/importing-data-database/

Its also completely duplicate. I'd motion to either merge this request or to completely remove rv/how-to/importing-data-database.md and link somewhere else in the docs.
