### PR TITLE
improve description of accumulated latency

### DIFF
--- a/content/rs/administering/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-integration.md
@@ -256,7 +256,7 @@ These are the metrics available:
 
 | Metric | Description |
 |  ------ | :------ |
-|  listener_acc_latency | Accumulative latency of all types of commands on DB. This is the sum of the latencies of all commands, in order to get the (average) latency, it should be divided by listener_total_res. |
+|  listener_acc_latency | Sum of the latencies of all types of commands on DB. For the average latency, divide this statistic by listener_total_res. |
 |  listener_acc_latency_max | Highest value of accumulative latency of all types of commands on DB |
 |  listener_acc_other_latency | Accumulative latency of commands that are classified as "other" type on DB |
 |  listener_acc_other_latency_max | Highest value of accumulative latency of commands that are classified as "other" type on DB |

--- a/content/rs/administering/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-integration.md
@@ -256,14 +256,14 @@ These are the metrics available:
 
 | Metric | Description |
 |  ------ | :------ |
-|  listener_acc_latency | Sum of the latencies of all types of commands on DB. For the average latency, divide this statistic by listener_total_res. |
+|  listener_acc_latency | Accumulative latency (sum of the latencies) of all types of commands on DB. For the average latency, divide this value by listener_total_res. |
 |  listener_acc_latency_max | Highest value of accumulative latency of all types of commands on DB |
-|  listener_acc_other_latency | Accumulative latency of commands that are classified as "other" type on DB |
-|  listener_acc_other_latency_max | Highest value of accumulative latency of commands that are classified as "other" type on DB |
-|  listener_acc_read_latency | Accumulative latency of read type of commands on DB |
-|  listener_acc_read_latency_max | Highest value of accumulative latency of read type of commands on DB |
-|  listener_acc_write_latency | Accumulative latency of write type of commands on DB |
-|  listener_acc_write_latency_max | Highest value of accumulative latency of write type of commands on DB |
+|  listener_acc_other_latency | Accumulative latency (sum of the latencies) of commands that are type "other" on DB. For the average latency, divide this value by listener_other_res. |
+|  listener_acc_other_latency_max | Highest value of accumulative latency of commands that are type "other" on DB |
+|  listener_acc_read_latency | Accumulative latency (sum of the latencies) of commands that are type "read" on DB. For the average latency, divide this value by listener_read_res. |
+|  listener_acc_read_latency_max | Highest value of accumulative latency of commands that are type "read" on DB |
+|  listener_acc_write_latency | Accumulative latency (sum of the latencies) of commands that are type "write" on DB. For the average latency, divide this value by listener_write_res. |
+|  listener_acc_write_latency_max | Highest value of accumulative latency of commands that are type "write" on DB |
 |  listener_auth_cmds | Number of memcached AUTH commands sent to the DB |
 |  listener_auth_cmds_max | Highest value of number of memcached AUTH commands sent to the DB |
 |  listener_auth_errors | Number of error responses to memcached AUTH commands  |

--- a/content/rs/administering/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-integration.md
@@ -256,7 +256,7 @@ These are the metrics available:
 
 | Metric | Description |
 |  ------ | :------ |
-|  listener_acc_latency | Accumulative latency of all types of commands on DB |
+|  listener_acc_latency | Accumulative latency of all types of commands on DB. This is the sum of the latencies of all commands, in order to get the (average) latency, it should be divided by listener_total_res. |
 |  listener_acc_latency_max | Highest value of accumulative latency of all types of commands on DB |
 |  listener_acc_other_latency | Accumulative latency of commands that are classified as "other" type on DB |
 |  listener_acc_other_latency_max | Highest value of accumulative latency of commands that are classified as "other" type on DB |


### PR DESCRIPTION
the same change should be applied on all acc_latency metrics (read/write/other).
and should also be put in other docs we have about this metrics (rest api?).
also note that the acc_latency_max metric is completely useless IMHO, since the second with the highest latency is not necessarily the one with the highest response time, so any division attempt to get the real latency would be wrong.
not sure if we should mention that it is useless, or trim it from the docs.