### PR TITLE
Update multi-key limitation for OSS cluster API

### DIFF
--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -8,8 +8,7 @@ categories: ["RS"]
 {{%excerpt-include filename="rs/concepts/data-access/oss-cluster-api.md" %}}
 For more information, see [Redis OSS Cluster API]({{< relref "/rs/concepts/data-access/oss-cluster-api.md" >}}).
 
-These multi-key commands are not allowed with OSS cluster API:
-DEL, MSET, MGET, EXISTS, UNLINK, TOUCH
+Multi-key commands are only allowed when all keys are mapped to the same slot. That is when `CLUSTER KEYSLOT` reply is the same for all keys in the multi-key commnad.
 
 Note: The OSS Cluster API setting is not cluster-wide.
 The setting only applies to the specified database.

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 For more information, see [Redis OSS Cluster API]({{< relref "/rs/concepts/data-access/oss-cluster-api.md" >}}).
 
 [Multi-key commands]({{< relref "/rc/concepts/clustering-redis-cloud.md#multikey-operations" >}}) are only allowed when all keys are mapped to the same slot.
-To verify this, make sure that the `CLUSTER KEYSLOT` reply is the same for all keys in the multi-key commnad.
+To verify this, make sure that the `CLUSTER KEYSLOT` reply is the same for all keys in the [multi-key command]({{< relref "/rs/concepts/high-availability/clustering.md#multikey-operations" >}}).
 
 Note: The OSS Cluster API setting is not cluster-wide.
 The setting only applies to the specified database.

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -8,7 +8,8 @@ categories: ["RS"]
 {{%excerpt-include filename="rs/concepts/data-access/oss-cluster-api.md" %}}
 For more information, see [Redis OSS Cluster API]({{< relref "/rs/concepts/data-access/oss-cluster-api.md" >}}).
 
-Multi-key commands are only allowed when all keys are mapped to the same slot. That is when `CLUSTER KEYSLOT` reply is the same for all keys in the multi-key commnad.
+[Multi-key commands]({{< relref "/rc/concepts/clustering-redis-cloud.md#multikey-operations" >}}) are only allowed when all keys are mapped to the same slot.
+To verify this, make sure that the `CLUSTER KEYSLOT` reply is the same for all keys in the multi-key commnad.
 
 Note: The OSS Cluster API setting is not cluster-wide.
 The setting only applies to the specified database.


### PR DESCRIPTION
Changed the multi-key disclaimer as the former was very wrong.