### PR TITLE
Update link to SIP limits

### DIFF
--- a/content/rc/administration/configure/security.md
+++ b/content/rc/administration/configure/security.md
@@ -16,8 +16,8 @@ notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_nota
 ![Source
 IP/Subnet](/images/rc/source_ip_subnet-1.png?width=600&height=102)
 
-IF you need more source IP rules than your current REC
-plan entitles you to, consider changing to [a plan with more source IP rules](https://redislabs.com/redis-enterprise-cloud/essentials-pricing/).
+If you need more source IP rules than your current REC plan includes,
+consider [changing to a plan](https://redislabs.com/redis-enterprise-cloud/essentials-pricing/) with more source IP rules.
 
 You may change your subscription at any time by going to Databases =\>
 Configuration =\> Edit =\> Access Control & Security.

--- a/content/rc/administration/configure/security.md
+++ b/content/rc/administration/configure/security.md
@@ -18,7 +18,7 @@ IP/Subnet](/images/rc/source_ip_subnet-1.png?width=600&height=102)
 
 In case you require more source IP rules than your current REC
 plan entitles you to, you can see the different plans and the maximum
-number of source IP rules that they support [here](https://redislabs.com/pricing).
+number of source IP rules that they support [here](https://redislabs.com/redis-enterprise-cloud/essentials-pricing/).
 
 You may change your subscription at any time by going to Databases =\>
 Configuration =\> Edit =\> Access Control & Security.

--- a/content/rc/administration/configure/security.md
+++ b/content/rc/administration/configure/security.md
@@ -16,9 +16,8 @@ notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_nota
 ![Source
 IP/Subnet](/images/rc/source_ip_subnet-1.png?width=600&height=102)
 
-In case you require more source IP rules than your current REC
-plan entitles you to, you can see the different plans and the maximum
-number of source IP rules that they support [here](https://redislabs.com/redis-enterprise-cloud/essentials-pricing/).
+IF you need more source IP rules than your current REC
+plan entitles you to, consider changing to [a plan with more source IP rules](https://redislabs.com/redis-enterprise-cloud/essentials-pricing/).
 
 You may change your subscription at any time by going to Databases =\>
 Configuration =\> Edit =\> Access Control & Security.


### PR DESCRIPTION
I suggest changing the link to the SIP limit per plan as the current link (https://redislabs.com/pricing), doesn't have the information.
In the following link, you can change the plan and see how many SIPs are supported - 
https://redislabs.com/redis-enterprise-cloud/essentials-pricing/