### PR TITLE
Changed the title of the IOPS panel

### DIFF
--- a/static/code/rs/database.json
+++ b/static/code/rs/database.json
@@ -1865,7 +1865,7 @@
         "thresholds": [],
         "timeFrom": null,
         "timeShift": null,
-        "title": "IOPS",
+        "title": "Flash disk IOs",
         "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
IOPS is confusing. This panel is only applicable for RedisOnFlash and relates to IOs. Customers who don't see any data and who expect the metrics to show instantaneous operations per second are wondering why the graph as no data. Changing the title to indicate that 1) it is for RoF, and 2) it is disk I/Os seems like a good change.