### PR TITLE
Fix misuse of the word 'setup'

### DIFF
--- a/content/platforms/kubernetes/_index.md
+++ b/content/platforms/kubernetes/_index.md
@@ -27,7 +27,7 @@ Here are the 4 steps to set up our cluster with Redis Enterprise:
 
 - Step 1: Create a Kubernetes cluster on Google Cloud
 - Step 2: Deploy the Redis Enterprise containers to Kubernetes cluster
-- Step 3: Setup Redis Enterprise cluster
+- Step 3: Set up Redis Enterprise cluster
 - Step 4: Create a Redis database and test your connectivity
 
 ### Requirements
@@ -114,7 +114,7 @@ The output looks something like this;
 
     redispack-deployment-709212938-kcjd7 1/1 Running 0 7s
 
-## Step 3: Setup Redis Enterprise cluster
+## Step 3: Set up Redis Enterprise cluster
 
 We are now ready to create the Redis Enterprise cluster. There is one small change that needs to be done to the container to get networking to work properly: we need to change the css binding to 0.0.0.0. To do this, you need to run the following in each container with each iteration using the pods name from the _kubectl get po_ output above.
 

--- a/content/platforms/pks/_index.md
+++ b/content/platforms/pks/_index.md
@@ -439,7 +439,7 @@ In order to create your database, login to the Redis Enterprise UI.
     ```
 
 1. There are two primary options for accessing the Web UI
-    - If your PKS cluster has loadbalancer service setup with a public IP you have access to or otherwise a routable IP address from your machine:
+    - If your PKS cluster has loadbalancer service set up with a public IP you have access to or otherwise a routable IP address from your machine:
 
         1. Determine that IP address:
 
@@ -456,7 +456,7 @@ In order to create your database, login to the Redis Enterprise UI.
         1. Enter the IP address followed by port number 8443 into your browser address bar: `https://53.128.131.29:8443`
 
     - If your PKS cluster does not have a routable IP address from your machine:
-        1. Setup port forwarding for port 8443 to one of you cluster pods:
+        1. Set up port forwarding for port 8443 to one of you cluster pods:
 
             ```src
             kubectl port-forward rec-pks-0 8443
@@ -514,7 +514,7 @@ Changing the admin password impacts the proper operation of the K8s deployment.
         pks-test-headless   ClusterIP   None            <none>        14771/TCP   22m
         ```
 
-    1. Setup port forwarding for the database port to one of you database services
+    1. Set up port forwarding for the database port to one of you database services
 
         ```src
         kubectl port-forward service/pks-test 14771

--- a/content/rc/quick-setup-redis-cloud.md
+++ b/content/rc/quick-setup-redis-cloud.md
@@ -5,11 +5,11 @@ weight: 10
 alwaysopen: false
 categories: ["RC Essentials"]
 ---
-To quickly setup Redis Cloud Essentials:
+To quickly set up Redis Cloud Essentials:
 
 1. Sign up for a Redis Cloud Essentials account.
 1. Create a new subscription.
-1. Setup a database.
+1. Set up a database.
 1. Connect to your Database.
 
 {{< youtube I9sPna1OOUg >}}

--- a/content/ri/memory-optimizations/reclaim-expired-keys-memory-faster.md
+++ b/content/ri/memory-optimizations/reclaim-expired-keys-memory-faster.md
@@ -23,7 +23,7 @@ You can follow one of these three steps to reclaim the memory:
 
 1. Restart your redis-server
 1. Increase memorysamples in redis conf. (default is 5, max is 10) so that expired keys are reclaimed faster.
-1. You can setup a cron job that runs the scan command after an interval which helps in reclaiming the memory of the expired keys.
+1. You can set up a cron job that runs the scan command after an interval which helps in reclaiming the memory of the expired keys.
 1. Alternatively, Increasing the expiry of keys also helps.
 
 ## Trade Offs

--- a/content/rs/administering/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-integration.md
@@ -58,8 +58,8 @@ To get started with custom monitoring:
           - targets: ["<cluster_name>:8070"]
     ```
 
-1. Setup your Prometheus and Grafana servers.
-    To setup Prometheus and Grafana on Docker containers:
+1. Set up your Prometheus and Grafana servers.
+    To set up Prometheus and Grafana on Docker containers:
     1. Create a _docker-compose.yml_ file with this yaml contents:
 
         ```yml

--- a/content/rs/getting-started/creating-database/redis-flash.md
+++ b/content/rs/getting-started/creating-database/redis-flash.md
@@ -11,7 +11,7 @@ with a single node are simple and are as follows:
 
 - Step 1: Install Redis Enterprise Software or launch with Docker
     container
-- Step 2: Setup a Redis Enterprise Software cluster with Redis on
+- Step 2: Set up a Redis Enterprise Software cluster with Redis on
     Flash
 - Step 3: Create a new Redis on Flash database
 - Step 4: Connect to your new database
@@ -50,7 +50,7 @@ Docker container on Windows, MacOS, and Linux.
 docker run -d --cap-add sys_resource --name rp -p 8443:8443 -p 12000:12000 redislabs/redis:latest
 ```
 
-## Step 2: Setup a Cluster and Enable Redis on Flash
+## Step 2: Set up a Cluster and Enable Redis on Flash
 
 Direct your browser to https://localhost:8443/ on the host machine to
 see the Redis Enterprise Software web console. Simply click the

--- a/content/rs/getting-started/creating-database/redistimeseries.md
+++ b/content/rs/getting-started/creating-database/redistimeseries.md
@@ -26,7 +26,7 @@ click **Add configuration** and enter the optional custom configuration.
 
 ## Quick start with redis-cli
 
-After you setup RedisTimeSeries, you can interact with it using redis-cli.
+After you set up RedisTimeSeries, you can interact with it using redis-cli.
 
 Here we'll create a time series representing sensor temperature measurements.
 After you create the time series, you can send temperature measurements.

--- a/content/rs/getting-started/docker/getting-started-docker.md
+++ b/content/rs/getting-started/docker/getting-started-docker.md
@@ -24,7 +24,7 @@ To get started with a single Redis Enterprise Software container:
 
 - Step 1: Install Docker Engine for your operating system
 - Step 2: Run the RS Docker container
-- Step 3: Setup a cluster
+- Step 3: Set up a cluster
 - Step 4: Create a new database
 - Step 5: Connect to your database
 
@@ -54,7 +54,7 @@ You can publish other [ports]({{< relref "/rs/administering/designing-production
 with `-p <host_port>:<container_port>`.
 
 <!-- Also in quick-start.md -->
-## Step 3: Setup a Cluster
+## Step 3: Set up a Cluster
 
 1. In the web browser on the host machine, go to https://localhost:8443 to see
 the Redis Enterprise Software web console.

--- a/content/rs/getting-started/getting-started-crdbs.md
+++ b/content/rs/getting-started/getting-started-crdbs.md
@@ -11,15 +11,15 @@ replicated database) spanning across two Redis Enterprise Software
 clusters for test and development environments. Here are the steps:
 
 - Step 1: Run two RS Docker containers
-- Step 2: Setup each container as a cluster
+- Step 2: Set up each container as a cluster
 - Step 3: Create a new Redis Enterprise CRDB
 - Step 4: Test connectivity to the CRDB
 
 To run a CRDB on installations from the [RS download package]({{< relref "/rs/getting-started/quick-setup.md" >}}),
-setup two RS installations and continue from Step 2.
+set up two RS installations and continue from Step 2.
 
 Note: This getting started guide is for development or demonstration environments.
-To setup CRDB in a production environment, use the instuctions for
+To set up CRDB in a production environment, use the instructions for
 [creating a CRDB]({{< relref "/rs/administering/database-operations/create-crdb.md" >}}).
 
 ## Step 1: Run Two Containers

--- a/content/rs/getting-started/quick-setup.md
+++ b/content/rs/getting-started/quick-setup.md
@@ -12,7 +12,7 @@ The steps to set up a Redis Enterprise Software (RS) cluster with a
 single node are super simple and go as follows:
 
 - Step 1: Install Redis Enterprise Software
-- Step 2: Setup a Redis Enterprise Software cluster
+- Step 2: Set up a Redis Enterprise Software cluster
 - Step 3: Create a new Redis database
 - Step 4: Connect to your Redis database
 
@@ -49,7 +49,7 @@ before running RS installation.
 {{% /note %}}
 
 <!-- Also in getting-started-docker.md -->
-## Step 2: Setup a Cluster
+## Step 2: Set up a Cluster
 
 1. In the web browser on the host machine, go to https://localhost:8443 to see
 the Redis Enterprise Software web console.

--- a/content/rs/installing-upgrading/configuring-aws-instances.md
+++ b/content/rs/installing-upgrading/configuring-aws-instances.md
@@ -71,6 +71,6 @@ When configuring the Security Group:
     To limit the number of open ports, you can open just the [ports used by RS]
     ({{< relref "/rs/administering/designing-production/networking/port-configurations.md" >}}).
 
-After successfully launching the instances, setup the cluster as
+After successfully launching the instances, set up the cluster as
 described in [Initial setup - creating a new
 cluster]({{< relref "/rs/administering/cluster-operations/new-cluster-setup.md" >}}).

--- a/content/rs/installing-upgrading/downloading-installing.md
+++ b/content/rs/installing-upgrading/downloading-installing.md
@@ -8,7 +8,7 @@ aliases: /rs/administering/installing-upgrading/downloading-installing/
 ---
 The first thing you need to choose the platform to run Redis
 Enterprise Software on. If on-premise or in the cloud and you want to
-install it yourself, you need to download the package. For Amazon AWS, there are other instructions to setup an AMI image.
+install it yourself, you need to download the package. For Amazon AWS, there are other instructions to set up an AMI image.
 You can also run RS in a Docker container for testing purposes.
 Navigate to the [Redis Labs download
 page](https://app.redislabs.com/#/sign-up/software?direct=true) and

--- a/content/rs/installing-upgrading/offline-installation.md
+++ b/content/rs/installing-upgrading/offline-installation.md
@@ -25,7 +25,7 @@ attempted to install. Install all these dependency packages and then run
 the installation again.
 
 At the end of the installation, the process asks you whether you would
-like to setup NTP time synchronization. If you choose "Yes" while you
+like to set up NTP time synchronization. If you choose "Yes" while you
 are not connected to the Internet, the action fails and displays the
 appropriate error message, but the installation completes successfully.
 Despite the successful completion of the installation, you still have to

--- a/content/rs/references/memtier-benchmark.md
+++ b/content/rs/references/memtier-benchmark.md
@@ -40,7 +40,7 @@ For the test environment, you must:
 
 1. Create a three-node RS cluster.
 1. Prepare the flash memory.
-1. Setup the load generation tool.
+1. Set up the load generation tool.
 
 ### Creating a three-node RS cluster {#creating-a-threenode-rs-cluster}
 
@@ -108,7 +108,7 @@ $ memtier_benchmark -s $DB_HOST -p $DB_PORT --hide-histogram
 --key-maximum=$N -n allkeys -d 500 --key-pattern=P:P --ratio=1:0
 ```
 
-Setup a test database with these values:
+Set up a test database with these values:
 
 |  **Parameter** | **Description** |
 |  ------ | ------ |

--- a/content/rs/release-notes/rs-5-5-preview-april-2019.md
+++ b/content/rs/release-notes/rs-5-5-preview-april-2019.md
@@ -34,10 +34,10 @@ This preview version is not supported for networks that are isolated from the in
 
 ## Installation Instructions
 
-To setup a cluster with nodes that can host databases with multiple modules, you must follow this procedure on each node in the cluster:
+To set up a cluster with nodes that can host databases with multiple modules, you must follow this procedure on each node in the cluster:
 
 1. [Install RS 5.5]({{< relref "/rs/getting-started/quick-setup.md" >}}).
 1. To install the modules, run: `sudo ./install-modules.sh`
 1. Either:
-    - Setup the node as the [first node in the cluster]({{< relref "/rs/administering/cluster-operations/new-cluster-setup.md" >}}).
+    - Set up the node as the [first node in the cluster]({{< relref "/rs/administering/cluster-operations/new-cluster-setup.md" >}}).
     - [Join the node to an existing cluster]({{< relref "/rs/administering/cluster-operations/adding-node.md" >}}).

--- a/layouts/partials/flex/scripts.html
+++ b/layouts/partials/flex/scripts.html
@@ -28,9 +28,9 @@ function _setSelectedVersion(ver) {
     if(i) {
       i.classList.toggle('selected-version');
     }
-  }  
+  }
 }
-  
+
 function _openVersionSelector() {
     document.getElementById('versionSelector').classList.toggle('open');
 }
@@ -51,7 +51,7 @@ window.onclick = function(e) {
 <!-- /Version selector -->
 
 <script>
-  // Setup GA Event tracking
+  // Set up GA Event tracking
   setTimeout(function(){
     if(window.ga) {
       window.ga('create', 'UA-92003007-1', {


### PR DESCRIPTION
"Setup" is one word when used as a noun and two words when used as a verb ("set up"). This commit fixes all the cases I could find where the single-word form ("setup") was being used as a verb.