### PR TITLE
Change "node" to "slave" where applicable

### DIFF
--- a/content/rs/concepts/high-availability/replication.md
+++ b/content/rs/concepts/high-availability/replication.md
@@ -6,11 +6,11 @@ alwaysopen: false
 categories: ["RS"]
 ---
 Database replication provides a mechanism to ensure high availability.
-When replication is enabled, your dataset is replicated to a slave node,
-which is constantly synchronized with the master node. If the master
-node fails, an automatic failover happens and the slave node is promoted
-to be the new master node. When the old master node recovers, it becomes
-the slave node of the new master node. This auto-failover mechanism
+When replication is enabled, your dataset is replicated to a slave shard (or shards),
+which is constantly synchronized with the master shard. If the master
+shard fails, an automatic failover happens and the slave shard is promoted
+to be the new master shard. When the old master shard recovers, it becomes
+the slave shard of the new master shard. This auto-failover mechanism
 guarantees that data is served with minimal to no interruption.
 
 You can tune your high availability configuration with:


### PR DESCRIPTION
Might as well remove "shard" in most of the paragraph and only mention it once.
The reasoning: the dataset is actually stored on the shards, and when a node fails which contains master shards, a failover happens.

A dataset is not actually replicated to a slave node, but a slave shard. A *node* failover only occurs if the master node fails. There is one master node in a cluster and the rest are slaves.