### PR TITLE
RED-36146 Support for Oracle Linux 7.6

### DIFF
--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -13,7 +13,7 @@ Make sure your system meets these requirements:
 - Only 64-bit operating systems are supported.
 - You must install Redis Enterprise Software directly on the host, not through system cloning.
 - You must install on a clean host with no other applications running so that all RAM is allocated to the OS and RS only.
-- Linux distributions must be installed with "Minimal Install" configuration.
+- Linux distributions must be installed with at least "Minimal Install" configuration.
 {{% /note %}}
 
 | **Platform** | **Versions/Information** |

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -13,13 +13,14 @@ Make sure your system meets these requirements:
 - Only 64-bit operating systems are supported.
 - You must install Redis Enterprise Software directly on the host, not through system cloning.
 - You must install on a clean host with no other applications running so that all RAM is allocated to the OS and RS only.
+- Linux distributions must be installed with: "Minimal Install" configuration, OpenSSL 1.0.2, [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}})
 {{% /note %}}
 
 | **Platform** | **Versions/Information** |
 |------------|-----------------|
 | Ubuntu | 14.04, 16.04, 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
-| RHEL/CentOS 6 |  6.7, 6.8, 6.9<br>Requires at least "Minimal Install" configuration. |
-| RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires at least "Minimal Install" configuration, OpenSSL 1.0.2, and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}}). |
+| RHEL/CentOS 6 |  6.7, 6.8, 6.9 |
+| RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6 |
 | Oracle Linux | 6.7, 6.8, 6.9; 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6 |
 | Amazon Linux | Version 1 |
 | Docker | Redis Enterprise Software Docker images are certified for Development and Testing only. |

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -20,7 +20,7 @@ Make sure your system meets these requirements:
 | Ubuntu | 14.04, 16.04, 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
 | RHEL/CentOS 6 |  6.7, 6.8, 6.9<br>Requires at least "Minimal Install" configuration. |
 | RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires at least "Minimal Install" configuration, OpenSSL 1.0.2, and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}}). |
-| Oracle Linux | 6.7, 6.8, 6.9; 7.0, 7.1, 7.2, 7.3, 7.4, 7.5 |
+| Oracle Linux | 6.7, 6.8, 6.9; 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6 |
 | Amazon Linux | All 64-bit Versions |
 | Docker | Redis Enterprise Software Docker images are certified for Development and Testing only. |
 | Kubernetes, Pivotal Platform (PCF) and other orchestration and cloud environments | See the [Platform documentation]({{< relref "/platforms" >}}) |

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -13,15 +13,16 @@ Make sure your system meets these requirements:
 - Only 64-bit operating systems are supported.
 - You must install Redis Enterprise Software directly on the host, not through system cloning.
 - You must install on a clean host with no other applications running so that all RAM is allocated to the OS and RS only.
-- Linux distributions must be installed with: "Minimal Install" configuration, OpenSSL 1.0.2, [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}})
+- Linux distributions must be installed with "Minimal Install" configuration
 {{% /note %}}
 
 | **Platform** | **Versions/Information** |
 |------------|-----------------|
 | Ubuntu | 14.04, 16.04, 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
 | RHEL/CentOS 6 |  6.7, 6.8, 6.9 |
-| RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6 |
-| Oracle Linux | 6.7, 6.8, 6.9; 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6 |
+| RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}})|
+| Oracle Linux 6 | 6.7, 6.8, 6.9
+| Oracle Linux 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}})|
 | Amazon Linux | Version 1 |
 | Docker | Redis Enterprise Software Docker images are certified for Development and Testing only. |
 | Kubernetes, Pivotal Platform (PCF) and other orchestration and cloud environments | See the [Platform documentation]({{< relref "/platforms" >}}) |

--- a/content/rs/administering/designing-production/supported-platforms.md
+++ b/content/rs/administering/designing-production/supported-platforms.md
@@ -13,16 +13,16 @@ Make sure your system meets these requirements:
 - Only 64-bit operating systems are supported.
 - You must install Redis Enterprise Software directly on the host, not through system cloning.
 - You must install on a clean host with no other applications running so that all RAM is allocated to the OS and RS only.
-- Linux distributions must be installed with "Minimal Install" configuration
+- Linux distributions must be installed with "Minimal Install" configuration.
 {{% /note %}}
 
 | **Platform** | **Versions/Information** |
 |------------|-----------------|
 | Ubuntu | 14.04, 16.04, 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
 | RHEL/CentOS 6 |  6.7, 6.8, 6.9 |
-| RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}})|
+| RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}}) |
 | Oracle Linux 6 | 6.7, 6.8, 6.9
-| Oracle Linux 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}})|
+| Oracle Linux 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}}) |
 | Amazon Linux | Version 1 |
 | Docker | Redis Enterprise Software Docker images are certified for Development and Testing only. |
 | Kubernetes, Pivotal Platform (PCF) and other orchestration and cloud environments | See the [Platform documentation]({{< relref "/platforms" >}}) |


### PR DESCRIPTION
@bmansheim - in addition, we need to check (probably with Alon, maybe Uri) whether Oracle Linux also "requires at least "Minimal Install" configuration _[- what does it mean????]_, OpenSSL 1.0.2, and firewall configuration." _[- maybe it's relevant only for the Oracle Linux 7 installations....?]_