### PR TITLE
RED-36193 Fix the kubectl example commands

### DIFF
--- a/content/platforms/kubernetes/kubernetes-logs.md
+++ b/content/platforms/kubernetes/kubernetes-logs.md
@@ -32,6 +32,6 @@ sideContainersSpec:
 
 Now the logs can be accessed from in the sidecar. For example by running
 
-```kubectl exec -it -c busybox <pod-name> tail home/logs/supervisord.log```
+```kubectl exec -it <pod-name> -c busybox tail home/logs/supervisord.log```
 
 The sidecar container is user determined and can be used to format, process and share logs in a specified format and protocol.


### PR DESCRIPTION
from kubectl exec -it   busybox -c <pod-name>   tail home/logs/supervisord.log tokubectl exec -it  <pod-name> -c busybox  tail home/logs/supervisord.log