### PR TITLE
Add k8s cluster recovery workaround to cluster recovery article

### DIFF
--- a/content/embeds/force-delete-pods.md
+++ b/content/embeds/force-delete-pods.md
@@ -1,8 +1,10 @@
 In some cases, pods do not terminate when the statefulSet is scaled down as part of the cluster recovery.
-If pods are stuck in `terminating` or `crashLoopBack` and do not terminate gracefully, cluster recovery can stop.
+If pods are stuck in `terminating` or `crashLoopBack` and do not terminate gracefully, cluster recovery can pause.
 
-In that case, delete the pods manually with:
+To work around this, delete the pods manually with:
 
 ```src
 kubectl delete pods <pod> --grace-period=0 --force
 ```
+
+When the last pod is manually deleted, the recovery process resumes.

--- a/content/embeds/force-delete-pods.md
+++ b/content/embeds/force-delete-pods.md
@@ -1,0 +1,8 @@
+In some cases, pods do not terminate when the statefulSet is scaled down as part of the cluster recovery.
+If pods are stuck in `terminating` or `crashLoopBack` and do not terminate gracefully, cluster recovery can stop.
+
+In that case, delete the pods manually with:
+
+```src
+kubectl delete pods <pod> --grace-period=0 --force
+```

--- a/content/platforms/kubernetes/cluster-recovery.md
+++ b/content/platforms/kubernetes/cluster-recovery.md
@@ -59,3 +59,13 @@ To recover a cluster on Kubernetes:
     ```src
     supervisorctl restart sentinel_service
     ```
+
+## Known Limitations
+
+In some cases, pods do not terminate when the statefulSet is scaled down as part of Cluster Recovery. If pods are stuck in `terminating` or `crashLoopBack` and will not terminate gracefully, cluster recovery may not proceed.
+
+In that case, force delete (kubectl delete pods <pod> --grace-period=0 --force) the pods manually by running:
+
+```bash
+kubectl delete pods <pod> --grace-period=0 --force
+```

--- a/content/platforms/kubernetes/kubernetes-cluster-recovery.md
+++ b/content/platforms/kubernetes/kubernetes-cluster-recovery.md
@@ -4,10 +4,9 @@ description:
 weight: 70
 alwaysopen: false
 categories: ["Platforms"]
-aliases: /rs/concepts/kubernetes/cluster-recovery
+aliases: /rs/concepts/kubernetes/cluster-recovery/
+        /platforms/kubernetes/cluster-recovery/
 ---
-## Overview
-
 When a Redis Enterprise cluster loses contact with more than half of its nodes either because of failed nodes or network split,
 the cluster stops responding to client connections.
 When this happens, you must recover the cluster to restore the connections.
@@ -21,10 +20,12 @@ The cluster recovery for Kubernetes automates these recovery steps:
 1. Recovers the cluster configuration on the first node in the new cluster
 1. Joins the remaining nodes to the new cluster.
 
-{{% note %}}
-To support cluster recovery, the cluster must have been [deployed using persistence]({{< relref "/platforms/kubernetes/kubernetes-persistent-volumes.md" >}}).<br>
-To support database data recovery, databases must have been [configured using persistence]({{< relref "//rs/concepts/data-access/persistence.md" >}}).
-{{% /note %}}
+## Prerequisites
+
+To support cluster recovery with data recovery:
+
+- The cluster must be [deployed with persistence]({{< relref "/platforms/kubernetes/kubernetes-persistent-volumes.md" >}}).
+- The databases must be [configured with persistence]({{< relref "//rs/concepts/data-access/persistence.md" >}}).
 
 ## Recovering a Cluster on Kubernetes
 
@@ -35,6 +36,10 @@ To recover a cluster on Kubernetes:
     ```src
     kubectl patch rec <cluster-name> --type merge --patch '{"spec":{"clusterRecovery":true}}'
     ```
+
+    {{% note %}}
+    {{< embed-md "force-delete-pods.md" >}}
+    {{% /note %}}
 
 1. Wait for the cluster to recover until it is in the Running state.
 
@@ -59,13 +64,3 @@ To recover a cluster on Kubernetes:
     ```src
     supervisorctl restart sentinel_service
     ```
-
-## Known Limitations
-
-In some cases, pods do not terminate when the statefulSet is scaled down as part of Cluster Recovery. If pods are stuck in `terminating` or `crashLoopBack` and will not terminate gracefully, cluster recovery may not proceed.
-
-In that case, force delete (kubectl delete pods <pod> --grace-period=0 --force) the pods manually by running:
-
-```bash
-kubectl delete pods <pod> --grace-period=0 --force
-```

--- a/content/platforms/kubernetes/kubernetes-cluster-recovery.md
+++ b/content/platforms/kubernetes/kubernetes-cluster-recovery.md
@@ -22,10 +22,8 @@ The cluster recovery for Kubernetes automates these recovery steps:
 
 ## Prerequisites
 
-To support cluster recovery with data recovery:
-
-- The cluster must be [deployed with persistence]({{< relref "/platforms/kubernetes/kubernetes-persistent-volumes.md" >}}).
-- The databases must be [configured with persistence]({{< relref "//rs/concepts/data-access/persistence.md" >}}).
+- For cluster recovery, the cluster must be [deployed with persistence]({{< relref "/platforms/kubernetes/kubernetes-persistent-volumes.md" >}}).
+- For data recovery, the databases must be [configured with persistence]({{< relref "//rs/concepts/data-access/persistence.md" >}}).
 
 ## Recovering a Cluster on Kubernetes
 

--- a/content/platforms/kubernetes/kubernetes-cluster-recovery.md
+++ b/content/platforms/kubernetes/kubernetes-cluster-recovery.md
@@ -52,7 +52,7 @@ To recover a cluster on Kubernetes:
 1. To recover the cluster data, once the cluster is in Running state, for any cluster pod run:
 
     ```src
-    kubeclt exec -it <pod-name> rladmin recover all
+    kubectl exec -it <pod-name> rladmin recover all
     ```
 
     This command recovers the data for all nodes in the cluster based on the cluster configuration in pod-0.

--- a/content/platforms/release-notes/k8s-5-4-10-8-january-2020.md
+++ b/content/platforms/release-notes/k8s-5-4-10-8-january-2020.md
@@ -53,10 +53,4 @@ For legacy Kubernetes versions, deployment files are available in the documentat
 
 ### Cluster Recovery
 
-In some cases, pods do not terminate when the statefulSet is scaled down as part of Cluster Recovery. If pods are stuck in `terminating` or `crashLoopBack` and will not terminate gracefully, cluster recovery may not proceed.
-
-In that case, force delete (kubectl delete pods <pod> --grace-period=0 --force) the pods manually by running:
-
-```bash
-kubectl delete pods <pod> --grace-period=0 --force
-```
+{{< embed-md "force-delete-pods.md" >}}

--- a/content/platforms/release-notes/k8s-5-4-10-8-january-2020.md
+++ b/content/platforms/release-notes/k8s-5-4-10-8-january-2020.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Enterprise for Kubernetes - Release Notes 5.4.10-8 (January 2019)
+Title: Redis Enterprise for Kubernetes Release Notes 5.4.10-8 (January 2020)
 description:
 weight: 84
 alwaysopen: false

--- a/content/rs/administering/troubleshooting/cluster-recovery.md
+++ b/content/rs/administering/troubleshooting/cluster-recovery.md
@@ -9,7 +9,7 @@ When a cluster fails,
 you must use the cluster configuration file and database data to recover the cluster.
 
 {{% note %}}
-For cluster recovery in a Kubernetes Operator deployment, go to: [Redis Enterprise Cluster Recovery for Kubernetes]({{< relref "/platforms/kubernetes/cluster-recovery.md" >}}).
+For cluster recovery in a Kubernetes Operator deployment, go to: [Redis Enterprise Cluster Recovery for Kubernetes]({{< relref "/platforms/kubernetes/kubernetes-cluster-recovery.md" >}}).
 {{% /note %}}
 
 Cluster failure can be caused by:


### PR DESCRIPTION
I think that the known limitation should be added to this page and moved out of the 5.4.10 release notes. This is not an issue that pertains to 5.4.10 and customers who are going to do a recovery are more likely to check the recovery documentation than the release notes.
I copied the text straight from the 5.4.10 release notes (and I left it there but I don't like duplicate information since it's hard to maintain. We should remove the next from the release notes IMO).