### PR TITLE
Update developing-hashes-crdb.md

### DIFF
--- a/content/rs/developing/crdbs/developing-hashes-crdb.md
+++ b/content/rs/developing/crdbs/developing-hashes-crdb.md
@@ -9,9 +9,9 @@ Hashes are great for structured data that contain a map of fields and
 values. They are used for managing distributed user or app session
 state, user preferences, form data and so on. Hash fields contain string
 type and string types operate just like the standard Redis string types
-when it comes to CRDTs. Fields in hashes can be initialized as a string
+when it comes to CRDTs. **Fields in hashes can be initialized as a string
 using HSET or HMSET or can be used to initialize counter types that are
-numeric integers using HINCRBY or floats using HINCRBYFLOAT.
+numeric integers using HINCRBY or floats using HINCRBYFLOAT**. 
 
 Hashes in CRDBs behave the same and maintain additional metadata to
 achieve an "OR-Set" behavior to handle concurrent conflicting writes.


### PR DESCRIPTION
The line "Fields in hashes can be initialized as a string using HSET or HMSET or can be used to initialize counter types that are numeric integers using HINCRBY or floats using HINCRBYFLOAT." is outdated.

As per release notes for version 5.4.2 - 
"The string data-type in CRDB is now implicitly and dynamically typed, just like open source Redis."

This means that it is no longer significant how the hash is initialized. If the value is numeric, Redis will be able to use it as a counter.
I only highlighted the line and haven't done any changes to it since I'm not sure if it should be removed or changed.
It will need to be consulted with PM/R&D.