### PR TITLE
Correct syslog template

### DIFF
--- a/content/rs/administering/logging/rsyslog-logging.md
+++ b/content/rs/administering/logging/rsyslog-logging.md
@@ -50,8 +50,7 @@ Since rsyslog entries do not include the severity information by
 default, you can use the following instructions in order to log that
 information (in Ubuntu):
 Add the following line to /etc/rsyslog.conf
-$templateTraditionalFormatWithPRI,"%pri‐text%:%timegenerated%%HOSTNAME%
-%syslogtag%%msg:::drop‐last‐lf%n"
+$template TraditionalFormatWithPRI,"%pri-text%:%timegenerated%:%HOSTNAME%:%syslogtag%:%msg:::drop-last-lf%\n"
 
 And modify $ActionFileDefaultTemplate to use your new template
 $ActionFileDefaultTemplateTraditionalFormatWithPRI


### PR DESCRIPTION
Issue reported by the customer Charter Communications (Spectrum) in ZD 55573

Jonathan DeLanders -

I'm not sure if this was intentional or not but from my perspective it looks wrong. The rsyslog template appears to be missing the : ( colon ) separator between host, syslog tag and time generated. This leads to a log line where the host is mashed inbetween the syslogtag and the time and would make it difficult to parse the values.

Example from the documentation.
daemon.warning:Jun1414:49:20node1event_log[3464]:{"storage_util": 90.061643120001,"global_threshold":"70″,"object":"node:1″,"state": true,"time":1434282560,"type":"ephemeral_storage"}

You can see, "node1" is between event_log and an arbitrary time. Making it difficult to extract.
This is the suggested template from the documentation which is missing the colon separators.

$templateTraditionalFormatWithPRI,"%pri‐text%:%timegenerated%%HOSTNAME% %syslogtag%%msg:::drop‐last‐lf%n"

Here is the implementation I chose to allow our splunk admin to parse the fields easier.

$template TraditionalFormatWithPRI,"%pri-text%:%timegenerated%:%HOSTNAME%:%syslogtag%:%msg:::drop-last-lf%\n"