### PR TITLE
Add expand/collapse all shortcode for FAQ pages

### DIFF
--- a/content/modules/redisearch/release-notes/v1.4/_index.md
+++ b/content/modules/redisearch/release-notes/v1.4/_index.md
@@ -5,6 +5,17 @@ weight: 97
 alwaysopen: false
 categories: ["Modules"]
 ---
+## RediSearch 1.4.25 Release Notes
+
+Headlines:
+
+- This release improves overall stability and provides fixes for issues found after the previous release.
+
+Details:
+- Features:
+    - #[1051](https://github.com/RediSearch/RediSearch/issues/1051) Added support for updating tag fields on document updates with [`NOINDEX`](https://oss.redislabs.com/redisearch/Commands.html#field_options) fields.
+- Bugfixes:
+    - #[1051](https://github.com/RediSearch/RediSearch/issues/1051) `FORK GC` was not updating the unique sum of the numeric index.
 
 ## RediSearch 1.4.24 Release Notes
 

--- a/content/platforms/faqs/_index.md
+++ b/content/platforms/faqs/_index.md
@@ -7,7 +7,6 @@ categories: ["Platforms"]
 ---
 Here are some frequently asked questions about Redis Enterprise on integration platforms.
 
-<div class="expand-parent">
 {{< expand-control >}}
 
 ## RS on Kubernetes

--- a/content/platforms/faqs/_index.md
+++ b/content/platforms/faqs/_index.md
@@ -7,10 +7,11 @@ categories: ["Platforms"]
 ---
 Here are some frequently asked questions about Redis Enterprise on integration platforms.
 
-{{< expand-control >}}
+
 
 ## RS on Kubernetes
 
+{{< expand-control >}}
 {{%expand "What is an Operator?" %}}
 An Operator is a [Kubernetes custom controller]( https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources#custom-controllers) which extends the native K8s API. Please refer to the article [Redis Enterprise K8s Operator-based deployments – Overview]({{< relref "/platforms/kubernetes/kubernetes-with-operator.md" >}}).
 {{% /expand%}}
@@ -244,3 +245,5 @@ and allows that account to create pods with the PSP shown above.
 {{% /note %}}
 
 {{% /expand%}}
+
+{{< /expand-control >}}

--- a/content/rc/faqs/_index.md
+++ b/content/rc/faqs/_index.md
@@ -8,7 +8,6 @@ aliases: /rv/faqs/
 ---
 Here are some frequently asked questions about Redis Cloud.
 
-<div class="expand-parent">
 {{< expand-control >}}
 
 {{% expand "What exactly is Redis Enterprise?" %}}

--- a/content/rc/faqs/_index.md
+++ b/content/rc/faqs/_index.md
@@ -10,17 +10,17 @@ Here are some frequently asked questions about Redis Cloud.
 
 {{< expand-control >}}
 
-{{% expand "What exactly is Redis Enterprise?" %}}
+{{< expand "What exactly is Redis Enterprise?" >}}
 {{< embed-md "what-is-redis-enterprise.md"  >}}
-{{% /expand %}}
+{{< /expand >}}
 
-{{%expand "Are you fully compatible with open source Redis?" %}}
+{{< expand "Are you fully compatible with open source Redis?" >}}
 {{< embed-md "compatible-with-oss.md"  >}}
-{{% /expand %}}
+{{< /expand >}}
 
-{{%expand "How many Redis databases can I create and manage?" %}}
+{{< expand "How many Redis databases can I create and manage?" >}}
 {{< embed-md "how-many-databases-cloud.md"  >}}
-{{% /expand%}}
+{{< /expand >}}
 
 {{%expand "How can I control access to my resources?" %}}
 Redis Cloud features the following access control mechanisms:
@@ -82,4 +82,5 @@ The economic benefit is dramatic:
 - As your data grows, and your processing needs increase, you can achieve cost-effective high speed operational and analytic processing with the versatility of Redis and the cost efficiency of Flash memory.
 - If your dataset is larger than 500GB, running Redis in a fully-automated manner with 24/7 expert support over Redis Cloud is lower in cost than managing your own Redis instances on the cloud.
 {{% /expand%}}
-</div>
+
+{{< /expand-control >}}

--- a/content/rc/faqs/_index.md
+++ b/content/rc/faqs/_index.md
@@ -8,6 +8,9 @@ aliases: /rv/faqs/
 ---
 Here are some frequently asked questions about Redis Cloud.
 
+<div class="expand-parent">
+{{< expand-control >}}
+
 {{% expand "What exactly is Redis Enterprise?" %}}
 {{< embed-md "what-is-redis-enterprise.md"  >}}
 {{% /expand %}}
@@ -80,3 +83,4 @@ The economic benefit is dramatic:
 - As your data grows, and your processing needs increase, you can achieve cost-effective high speed operational and analytic processing with the versatility of Redis and the cost efficiency of Flash memory.
 - If your dataset is larger than 500GB, running Redis in a fully-automated manner with 24/7 expert support over Redis Cloud is lower in cost than managing your own Redis instances on the cloud.
 {{% /expand%}}
+</div>

--- a/content/ri/faqs.md
+++ b/content/ri/faqs.md
@@ -7,7 +7,6 @@ categories: ["RI"]
 ---
 Here are some frequently asked questions about Redis Enterprise Software.
 
-<div class="expand-parent">
 {{< expand-control >}}
 
 ## General

--- a/content/ri/faqs.md
+++ b/content/ri/faqs.md
@@ -7,10 +7,10 @@ categories: ["RI"]
 ---
 Here are some frequently asked questions about Redis Enterprise Software.
 
-{{< expand-control >}}
 
 ## General
 
+{{< expand-control >}}
 {{% expand "What is RedisInsight?" %}}
 RedisInsight is a browser based GUI for Redis. It lets you do the following -
 
@@ -49,8 +49,11 @@ Yes, RedisInsight is fully compatible with Redis Labs Enterprise version.
 We support Redis Cloud, Redis Cloud Pro, AWS Elasticache and Azure Redis Cache. That said, RedisInsight should work with any cloud provider as long as you run it on a host that has network access to your cloud based redis server. Send us an email at redisinsight@redislabs.com if you would like to use RedisInsight on a cloud provider that we haven't listed.
 {{% /expand %}}
 
+{{< /expand-control >}}
+
 ## Memory Analysis
 
+{{< expand-control >}}
 {{% expand "How long does the memory analysis take?" %}}
 This depends on how large your dataset and the host on which you are running your docker container. Empirically, expect 30s per GB of RAM analyzed.
 {{% /expand %}}
@@ -87,7 +90,11 @@ Key pattern is a grouping of related keys, for example users:*. RedisInsight can
 We assume that you use colon as a separator. If you use a non-standard separator, you have to add key patterns manually.
 {{% /expand %}}
 
+{{< /expand-control >}}
+
 ## Connecting to Redis
+
+{{< expand-control >}}
 
 {{% expand "How do I connect to redis-server running on localhost?" %}}
 First, this works only if you have RedisInsight running on your local computer. Depending on your docker version, you can use one of these host names instead of localhost - docker.for.mac.localhost, docker.for.win.localhost or host.docker.internal. If none of those host names work, find the ip address of your computer (usually starts with 192.x.x.x), and use that ip address instead of localhost.
@@ -101,7 +108,11 @@ You must install RedisInsight inside your VPC, either on an EC2 instance, or usi
 Our licensing works on the sum of used memory on the redis instances you have added to RedisInsight. So if your license allows 15GB, you can add 5 redis instances using 3 GB RAM, or 1 redis server using 15 GB.
 {{% /expand %}}
 
+{{< /expand-control >}}
+
 ## License and Support
+
+{{< expand-control >}}
 
 {{% expand "How do you calculate used memory?" %}}
 We run the `info` command and look at used_memory to determine the memory used by redis.
@@ -115,7 +126,11 @@ Once you buy a license, you can use RedisInsight forever as long as you are with
 Once you complete payment, you receive an email with your license key.
 {{% /expand %}}
 
+{{< /expand-control >}}
+
 ## Privacy and Security
+
+{{< expand-control >}}
 
 {{% expand "Who has access to my redis servers?" %}}
 We provide RedisInsight as a docker container that you install and run on your hardware or cloud account. We do not have any ability to connect to your installation of RedisInsight or look at data within your redis servers.
@@ -128,3 +143,5 @@ We recommend installing HTTPS, whitelisting IP addresses that have access to Red
 {{% expand "What information do you collect about my installation?" %}}
 We use google analytics so that we can understand how customers use the software. Per google analytics terms and conditions, we do not track any personally identifiable information.
 {{% /expand %}}
+
+{{< /expand-control >}}

--- a/content/rs/faqs/_index.md
+++ b/content/rs/faqs/_index.md
@@ -7,7 +7,6 @@ categories: ["RS"]
 ---
 Here are some frequently asked questions about Redis Enterprise Software.
 
-<div class="expand-parent">
 {{< expand-control >}}
 
 ## Features and Terminology

--- a/content/rs/faqs/_index.md
+++ b/content/rs/faqs/_index.md
@@ -7,18 +7,17 @@ categories: ["RS"]
 ---
 Here are some frequently asked questions about Redis Enterprise Software.
 
-{{< expand-control >}}
-
 ## Features and Terminology
 
+{{< expand-control >}}
 <!-- Also in RC -->
-{{% expand "What exactly is Redis Enterprise?" %}}
+{{< expand "What exactly is Redis Enterprise?" >}}
 {{< embed-md "what-is-redis-enterprise.md"  >}}
-{{% /expand %}}
+{{< /expand >}}
 
-{{%expand "Are you fully compatible with open source Redis?" %}}
+{{< expand "Are you fully compatible with open source Redis?" >}}
 {{< embed-md "compatible-with-oss.md"  >}}
-{{% /expand %}}
+{{< /expand >}}
 
 {{%expand "Can I keep my data safe and always available?" %}}
 Redis Enterprise Software offers a comprehensive suite of
@@ -60,12 +59,14 @@ RS cluster. You point your existing standard Redis client and code
 connection string at the RS cluster, then scale on the RS cluster as
 you need.
 {{% /expand%}}
+{{< /expand-control >}}
 
 ## Technical Capabilities
 
-{{%expand "How many Redis databases can I create and manage?" %}}
+{{< expand-control >}}
+{{< expand "How many Redis databases can I create and manage?" >}}
 {{< embed-md "how-many-databases-software.md"  >}}
-{{% /expand%}}
+{{< /expand >}}
 
 {{%expand "What happens when my database fills up?" %}}
 As explained in the open source [Redis FAQ](https://redis.io/topics/faq),
@@ -83,3 +84,4 @@ the management UI using the **Memory limit** property, as well as
 configure an eviction policy by setting it to any of the standard Redis
 behaviors, without interrupting database operations.
 {{% /expand%}}
+{{< /expand-control >}}

--- a/layouts/shortcodes/expand-control.html
+++ b/layouts/shortcodes/expand-control.html
@@ -1,0 +1,4 @@
+<span class="expand-shortcode-control" onclick="toggleExpand(this)">
+    <i class="fa fa-angle-double-down fa-lg"></i>
+    <span>Expand all</span>
+</span>

--- a/layouts/shortcodes/expand-control.html
+++ b/layouts/shortcodes/expand-control.html
@@ -1,5 +1,8 @@
-<div class="expand-parent"></div>
-<span class="expand-shortcode-control" onclick="toggleExpand(this)">
+<div class="expand-parent">
+  <span class="expand-shortcode-control" onclick="toggleExpand(this)">
     <i class="fa fa-angle-double-down fa-lg"></i>
     <span>Expand all</span>
-</span>
+  </span>
+
+  {{.Inner|safeHTML}}
+</div>

--- a/layouts/shortcodes/expand-control.html
+++ b/layouts/shortcodes/expand-control.html
@@ -1,3 +1,4 @@
+<div class="expand-parent"></div>
 <span class="expand-shortcode-control" onclick="toggleExpand(this)">
     <i class="fa fa-angle-double-down fa-lg"></i>
     <span>Expand all</span>

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,6 +1,6 @@
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;"
-        onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'icon-icons_minus' : 'icon-icons_plus';});});">
+        onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'icon-icons_minus' : 'icon-icons_plus';});}); var t = this; setTimeout(function() {handleToggleExpandItem(t)}, 200)">
         <i class="icon-icons_plus"></i>
         <span>
             {{$expandMessage := T "Expand-title"}}

--- a/static/theme-flex/script.js
+++ b/static/theme-flex/script.js
@@ -306,3 +306,94 @@ $(function() {
         showPageFeedback();
     }
 });
+
+// Expand and collapse control for expand shortcode
+function toggleExpand(el) {
+    if(!el || !el.parentElement || el.parentElement.className !== 'expand-parent') {
+        return;
+    }
+
+    var newIconClass, newLabel = null;
+    if(el.children[1].innerText === 'Expand all') {
+        newIconClass = 'fa fa-angle-double-up fa-lg';
+        newLabel = 'Collapse all';
+    } else {
+        newIconClass = 'fa fa-angle-double-down fa-lg';
+        newLabel = 'Expand all';
+    }
+
+    el.children[0].className = newIconClass; // Update the root control icon
+    el.children[1].innerText = newLabel; // Update the text of root control label
+    
+    var exNodes = el.parentElement.getElementsByClassName('expand');
+    if(!exNodes || exNodes.length === 0) {
+        return;
+    }    
+
+    var exNodesArr = Array.from(exNodes);
+
+    // Toggle expand items and update their icons
+    exNodesArr.forEach(function(element) {
+        var elChildren = element.children;
+        if(!elChildren || elChildren.length === 0) {
+            return;
+        }
+
+        // Update item control icon
+        if(elChildren[0] && elChildren[0].children && elChildren[0].children[0]) {
+            elChildren[0].children[0].className = (newLabel === 'Collapse all')? 'icon-icons_minus': 'icon-icons_plus';
+        }
+
+        // Update item control label
+        if(elChildren[1]) {
+            elChildren[1].style.display = (newLabel === 'Collapse all')? 'block' : 'none';
+        }
+    });    
+}
+
+function handleToggleExpandItem(el) {    
+    if(!el || !el.parentElement || !el.parentElement.parentElement || el.parentElement.parentElement.className !== 'expand-parent') {
+        return;
+    }
+
+    var exNodes = el.parentElement.parentElement.getElementsByClassName('expand');
+    if(!exNodes || exNodes.length === 0) {
+        return;
+    }    
+    
+    var exNodesArr = Array.from(exNodes);
+    var totalCount = exNodesArr.length;
+    var expandedCount = 0;
+    
+    // Count the number of expanded items
+    exNodesArr.forEach(function(element) {
+        var elChildren = element.children;
+        if(!elChildren || elChildren.length === 0) {
+            return;
+        }
+
+        if(elChildren[1] && elChildren[1].style.display !== 'none') {
+            expandedCount++;
+        }
+    });
+
+    var iconClass, label = null;
+    if(expandedCount === totalCount) {
+        iconClass = 'fa fa-angle-double-up fa-lg';
+        label = 'Collapse all';
+    }
+    if(expandedCount === 0) {
+        iconClass = 'fa fa-angle-double-down fa-lg';
+        label = 'Expand all';
+    }
+    
+    if(label) {
+        var elControl = el.parentElement.parentElement.querySelector('.expand-shortcode-control');
+        if(!elControl) {
+            return;
+        }
+
+        elControl.children[0].className = iconClass;
+        elControl.children[1].innerText = label;
+    }
+}

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -3290,3 +3290,19 @@ a[href*="#no-click"], img[src*="#no-click"] {
 	top: 0;
 	transform: rotate(45deg);
 }
+
+/* Expand shortcode control */
+.expand-shortcode-control {
+  display: inline-block;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.expand-shortcode-control:hover {
+  cursor: pointer;
+  color: #c82f0e;
+}
+
+.expand-shortcode-control i.fa-lg {
+  vertical-align: -2px;
+}

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -3294,7 +3294,6 @@ a[href*="#no-click"], img[src*="#no-click"] {
 /* Expand shortcode control */
 .expand-shortcode-control {
   display: inline-block;
-  font-weight: 700;
   margin-bottom: 10px;
 }
 
@@ -3304,5 +3303,6 @@ a[href*="#no-click"], img[src*="#no-click"] {
 }
 
 .expand-shortcode-control i.fa-lg {
+  font-size: 20px;
   vertical-align: -2px;
 }


### PR DESCRIPTION
- Added a new _expand-control_ shortcode which can be used along with existing _expand_ shortcode to show "Expand/Collapse All" button (like in the left side menu).
- Example added on _rc/faqs_ page.