### PR TITLE
Proposing to reference location for socket files in "File Locations"

### DIFF
--- a/content/rs/installing-upgrading/file-locations.md
+++ b/content/rs/installing-upgrading/file-locations.md
@@ -28,6 +28,7 @@ The default directories that Redis Enterprise Software uses for data and metadat
 |------------|-----------------|
 | /var/opt/redislabs | Default storage location for the cluster data, system logs, backups and ephemeral, persisted data |
 | /var/opt/redislabs/log | System logs for Redis Enterprise Software |
+| /var/opt/redislabs/run | Socket files for Redis Enterprise Software |
 | /etc/opt/redislabs | Default location for cluster manager configuration and certificates |
 | /tmp | Temporary files |
 


### PR DESCRIPTION
Socket files are not getting listed in "File Locations" (https://docs.redislabs.com/latest/rs/installing-upgrading/file-locations/) docs and cen be found only in the document about how to change the default location for socket files (https://docs.redislabs.com/latest/rs/installing-upgrading/configuring/change-location-socket-files/) 
