### PR TITLE
Add a link to the configuration page

### DIFF
--- a/content/ri/using-redisinsight/troubleshooting.md
+++ b/content/ri/using-redisinsight/troubleshooting.md
@@ -17,6 +17,8 @@ To get detailed information about errors in RedisInsight, you can review the log
 - **Windows**: In the `C:\Users\<your-username>\.redisinsight` directory.
 - **Linux**: In the `/home/<your-username>/.redisinsight` directory.
 
+For additional configuration options, such as changing the default port, please see the following page:https://docs.redislabs.com/latest/ri/installing/configurations/
+
 {{% note %}}
 For not supported operating system version, you can install RedisInsight for the operating system, but it may have unexpected behavior.
 We are happy to receive any feedback at redisinsight@redislabs.com.

--- a/content/ri/using-redisinsight/troubleshooting.md
+++ b/content/ri/using-redisinsight/troubleshooting.md
@@ -8,6 +8,10 @@ nextStep:
     Title: Memory Analysis
     href: /docs/features/troubleshooting/
 ---
+When RedisInsight doesn't behave as expected, use these steps to see what the problem is.
+
+For additional configuration options, such as changing the default port, go to: https://docs.redislabs.com/latest/ri/installing/configurations/
+
 ## Logs
 
 To get detailed information about errors in RedisInsight, you can review the log files with the `.log` extension in:
@@ -17,9 +21,8 @@ To get detailed information about errors in RedisInsight, you can review the log
 - **Windows**: In the `C:\Users\<your-username>\.redisinsight` directory.
 - **Linux**: In the `/home/<your-username>/.redisinsight` directory.
 
-For additional configuration options, such as changing the default port, please see the following page:https://docs.redislabs.com/latest/ri/installing/configurations/
-
 {{% note %}}
-For not supported operating system version, you can install RedisInsight for the operating system, but it may have unexpected behavior.
-We are happy to receive any feedback at redisinsight@redislabs.com.
+You can install RedisInsight on operating systems that are not officially supported, but it may not behave as expected.
 {{% /note %}}
+
+We are happy to receive your feedback at redisinsight@redislabs.com.


### PR DESCRIPTION
It's not immediately obvious that you can customize redisInsight to change things like the default port. If I were a customer, I would look under 'troubleshooting' for how to do this. Therefore, I think a link should be added to the 'configuring RedisInsight' page. I've now had several customers ask if this was possible so I think this would be a great addition!