### PR TITLE
Update download link in rs-5-6-0-april-2020

### DIFF
--- a/content/rs/release-notes/rs-5-6-0-april-2020.md
+++ b/content/rs/release-notes/rs-5-6-0-april-2020.md
@@ -5,7 +5,7 @@ weight: 81
 alwaysopen: false
 categories: ["RS"]
 ---
-[Redis Enterprise Software (RS) 5.6.0](https://redislabs.com/download-center.md#downloads" >}}) is now available. This major version release includes:
+[Redis Enterprise Software (RS) 5.6.0](https://redislabs.com/download-center.md#downloads" >}}) <<LINK DOESN'T WORK - GIVES 404>>> is now available. This major version release includes:
 
 - Improved installation process to be customizable
 - Support for the HyperLogLog data type in Active-Active databases

--- a/content/rs/release-notes/rs-5-6-0-april-2020.md
+++ b/content/rs/release-notes/rs-5-6-0-april-2020.md
@@ -5,7 +5,7 @@ weight: 81
 alwaysopen: false
 categories: ["RS"]
 ---
-[Redis Enterprise Software (RS) 5.6.0](https://redislabs.com/download-center.md#downloads" >}}) <<LINK DOESN'T WORK - GIVES 404>>> is now available. This major version release includes:
+[Redis Enterprise Software (RS) 5.6.0](https://redislabs.com/download-center/" >}}) is now available. This major version release includes:
 
 - Improved installation process to be customizable
 - Support for the HyperLogLog data type in Active-Active databases


### PR DESCRIPTION
The link to the download location at the top of the page gives a 404 (not found) response.
Please update the link to the proper location.