### PR TITLE
Fixes for hugo version 0.69.0

### DIFF
--- a/content/_footer.md
+++ b/content/_footer.md
@@ -1,1 +1,2 @@
+#
 <a href="https://twitter.com/redislabs" target="_blank" class="social-twitter"><i class="fa fa-twitter"></i></a> | <a href="https://www.linkedin.com/company/redis-labs-inc/" target="_blank" class="social-linkedin">  <i class="fa fa-linkedin"></i></a> | <a href="https://github.com/RedisLabs/" target="_blank" class="social-github"><i class="fa fa-github"></i></a> | <a href="https://www.youtube.com/channel/UCD78lHSwYqMlyetR0_P4Vig" target="_blank" class="social-youtube"><i class="fa fa-youtube"></i></a> | © 2018 Redis Labs

--- a/content/platforms/kubernetes/kubernetes-cluster-recovery.md
+++ b/content/platforms/kubernetes/kubernetes-cluster-recovery.md
@@ -23,7 +23,7 @@ The cluster recovery for Kubernetes automates these recovery steps:
 ## Prerequisites
 
 - For cluster recovery, the cluster must be [deployed with persistence]({{< relref "/platforms/kubernetes/kubernetes-persistent-volumes.md" >}}).
-- For data recovery, the databases must be [configured with persistence]({{< relref "//rs/concepts/data-access/persistence.md" >}}).
+- For data recovery, the databases must be [configured with persistence]({{< relref "/rs/concepts/data-access/persistence.md" >}}).
 
 ## Recovering a Cluster on Kubernetes
 

--- a/content/rs/installing-upgrading/_index.md
+++ b/content/rs/installing-upgrading/_index.md
@@ -10,7 +10,7 @@ aliases: /rs/administering/installing-upgrading/
 To install Redis Enterprise Software (RS), you must first choose the [supported platform]({{< relref "/rs/installing-upgrading/supported-platforms.md" >}}) that you want to deploy on.
 In addition to Linux operating systems (Ubuntu, RHEL/CentOS, Oracle Linux), you can also deploy RS with:
 
-- [Amazon AWS AMI]({{< relref "/rs/installing-upgrading/configuring-aws-instances.md" >}})
+- [Amazon AWS AMI]({{< relref "configuring-aws-instances.md" >}})
 - [Docker container]({{< relref "/rs/getting-started/docker/getting-started-docker.md" >}}) (for development and testing only)
 - [Pivotal Cloud Foundry]({{ relref "/platforms/pcf/using-pcf.md" }})
 - [Kubernetes]({{< relref "/platforms/kubernetes/_index.md.md" >}})
@@ -24,7 +24,7 @@ To access the installation package for any of these platforms:
 {{% note %}}
 Before you install the Linux package or AWS AMI on an AWS instance,
 review the [configuration requirements for AWS instances]
-({{< relref "/rs/installing-upgrading/configuring-aws-instances.md" >}}).
+({{< relref "configuring-aws-instances.md" >}}).
 {{% /note %}}
 
 In this article we walk you through the process for installing the RS installation package for Linux.


### PR DESCRIPTION
There were a couple minor tweaks necessary to get the documentation to work with the latest version of Hugo. It wouldn't accept the _footer.md file without some minimal amount of Markdown in the file. Also, there were a couple of relative references to sibling files that had to be made simpler (i.e., without the path).