### PR TITLE
Update upgrading-kubernetes-with-operator.md

### DIFF
--- a/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
+++ b/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
@@ -46,11 +46,15 @@ If you have made changes to the role, role binding, rbac or crd in the previous 
 
 The rolling upgrade of the cluster nodes' statefulSet starts.
 
-To see the status of the current rolling upgrade, run:
+To see the status of the current rolling upgrade (replace redis-enterprise with the name in your RedisEnterpriseCluster object, run:
 
 ```src
-kubectl rollout status sts
+kubectl rollout status sts redis-enterprise
 ```
+
+If the rollout is not happening, take a look at the logs output from the operator
+```src
+
 
 ## How Does the Upgrade Work?
 


### PR DESCRIPTION
kubectl rollout status sts

doesn't work with my client:

Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-
03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"14+", GitVersion:"v1.14.10-gke.27", GitCommit:"145f9e21a4515947d6fb10819e5a336aff1b6959", GitTreeState:"clean", BuildDa
te:"2020-02-21T18:01:40Z", GoVersion:"go1.12.12b4", Compiler:"gc", Platform:"linux/amd64"}