### PR TITLE
Extended Apple installation instructions

### DIFF
--- a/content/ri/installing/install-redis-desktop.md
+++ b/content/ri/installing/install-redis-desktop.md
@@ -36,6 +36,7 @@ To install RedisInsight:
     ```
 
     - For Windows and Mac - Run the installer.
+    - On Mac, if you see a warning saying that '"redisinsight" can't be opened because Apple cannot check it for malicious software' and you still wish to run Redisinsight then you can use [this article from Apple](https://support.apple.com/en-gb/HT202491) to open it (in particular, the section saying "How to open an app that hasn’t been notarized or is from an unidentified developer" is likely most appropriate).
 
 1. Run RedisInsight:
 

--- a/content/ri/installing/install-redis-desktop.md
+++ b/content/ri/installing/install-redis-desktop.md
@@ -35,8 +35,9 @@ To install RedisInsight:
     chmod +x redisinsight-<platform>-<version>
     ```
 
-    - For Windows and Mac - Run the installer.
-    - On Mac, if you see a warning saying that '"redisinsight" can't be opened because Apple cannot check it for malicious software' and you still wish to run Redisinsight then you can use [this article from Apple](https://support.apple.com/en-gb/HT202491) to open it (in particular, the section saying "How to open an app that hasn’t been notarized or is from an unidentified developer" is likely most appropriate).
+    - For Windows and MacOS - Run the installer.
+    
+        For MacOS - If the operating system warns you that RedisInsight cannot be checked for malicious software, follow the instructions from [Apple support](https://support.apple.com/en-gb/HT202491) about how to open an app from an unidentified developer.
 
 1. Run RedisInsight:
 

--- a/content/ri/installing/install-redis-desktop.md
+++ b/content/ri/installing/install-redis-desktop.md
@@ -19,10 +19,10 @@ We are happy to receive any feedback at redisinsight@redislabs.com.
 
 RedisInsight offers the following features -
 
-* Easy to use browser based interface to search keys, view and edit data
-* Only GUI tool to support Redis Cluster
-* Supports SSL/TLS based connections
-* Run Memory Analysis
+- Easy to use browser based interface to search keys, view and edit data
+- Only GUI tool to support Redis Cluster
+- Supports SSL/TLS based connections
+- Run Memory Analysis
 
 To install RedisInsight:
 
@@ -31,13 +31,14 @@ To install RedisInsight:
 
     - For Ubuntu - To make the downloaded file executable, run:
 
-    ```src
-    chmod +x redisinsight-<platform>-<version>
-    ```
+        ```src
+        chmod +x redisinsight-<platform>-<version>
+        ```
 
     - For Windows and MacOS - Run the installer.
-    
-        For MacOS - If the operating system warns you that RedisInsight cannot be checked for malicious software, follow the instructions from [Apple support](https://support.apple.com/en-gb/HT202491) about how to open an app from an unidentified developer.
+
+        If MacOS warns you that RedisInsight cannot be checked for malicious software,
+        follow the instructions from [Apple support](https://support.apple.com/en-gb/HT202491) about how to open an app from an unidentified developer.
 
 1. Run RedisInsight:
 


### PR DESCRIPTION
Added instructions explaining how to open Redisinsight even when Mac OS X (Catalina) won't open it up because its from an unidentified developer.