### PR TITLE
Remove Services Rigger from Kubernetes upgrade

### DIFF
--- a/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
+++ b/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
@@ -62,16 +62,16 @@ These diagrams show how a rolling update works:
 - Each hexagon represents a node
 - Each box represents a pod
 
-![kubernetes-rolling-updates]( /images/rs/kubernetes-rolling-updates.png )
+![kubernetes-rolling-updates](/images/rs/kubernetes-rolling-updates.png?width=500)
 
 The pods are updated one by one in the diagram, starting from left to right.
 Each pod is updated after the last one completes successfully.
 
-![kubernetes-rolling-updates-newapp]( /images/rs/kubernetes-rolling-updates-newapp.png )
+![kubernetes-rolling-updates-newapp](/images/rs/kubernetes-rolling-updates-newapp.png?width=500)
 
-![kubernetes-rolling-updates-newcluster]( /images/rs/kubernetes-rolling-updates-newcluster.png )
+![kubernetes-rolling-updates-newcluster](/images/rs/kubernetes-rolling-updates-newcluster.png?width=500)
 
-![kubernetes-rolling-updates-done]( /images/rs/kubernetes-rolling updates-done.png )
+![kubernetes-rolling-updates-done](/images/rs/kubernetes-rolling updates-done.png?width=500)
 
 The pods in the StatefulSet are updated in reverse ordinal order.
 The Kubernetes controller terminates each pod and waits for it to transition to `Running` and then to `Ready`.

--- a/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
+++ b/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
@@ -12,23 +12,23 @@ Redis Labs implements rolling updates for software upgrades in Kubernetes deploy
 
 1. Clone this repository, which contains the deployment files:
 
-```src
-git clone https://github.com/RedisLabs/redis-enterprise-k8s-docs
-```
+    ```src
+    git clone https://github.com/RedisLabs/redis-enterprise-k8s-docs
+    ```
 
-Example response:
+    Example response:
 
-```src
-Cloning into 'redis-enterprise-k8s-docs'...
-remote: Enumerating objects: 37, done.
-remote: Counting objects: 100% (37/37), done.
-remote: Compressing objects: 100% (30/30), done.
-remote: Total 168 (delta 19), reused 9 (delta 7), pack-reused 131
-Receiving objects: 100% (168/168), 45.32 KiB | 7.55 MiB/s, done.
-Resolving deltas: 100% (94/94), done.
-```
+    ```src
+    Cloning into 'redis-enterprise-k8s-docs'...
+    remote: Enumerating objects: 37, done.
+    remote: Counting objects: 100% (37/37), done.
+    remote: Compressing objects: 100% (30/30), done.
+    remote: Total 168 (delta 19), reused 9 (delta 7), pack-reused 131
+    Receiving objects: 100% (168/168), 45.32 KiB | 7.55 MiB/s, done.
+    Resolving deltas: 100% (94/94), done.
+    ```
 
-1. Apply the [bundle.yaml] file (https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/master/bundle.yaml) - (or openshift.bundle.yaml file if running OpenShift)
+1. Apply the [bundle.yaml](https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/master/bundle.yaml), or the openshift.bundle.yaml file if you are running OpenShift.
 
     {{% note %}}
 If you are not pulling images from Docker Hub, update the operator Image spec to point to your private repository.

--- a/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
+++ b/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
@@ -75,4 +75,6 @@ Each pod is updated after the last one completes successfully.
 
 The pods in the StatefulSet are updated in reverse ordinal order.
 The Kubernetes controller terminates each pod and waits for it to transition to `Running` and then to `Ready`.
-The it updates the next pod until all pods are updated and the upgrade process is completed.
+
+After a pod is updated, the next pod is terminated and updated.
+After all of the pods are updated, the upgrade process is complete.

--- a/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
+++ b/content/platforms/kubernetes/upgrading-kubernetes-with-operator.md
@@ -35,7 +35,7 @@ If you are not pulling images from Docker Hub, update the operator Image spec to
 If you have made changes to the role, role binding, rbac or crd in the previous version you must merge them with the updated declarations in the new version files.
     {{% /note %}}
 
-1. After the Operator and Services Rigger upgrades are complete:
+1. After the Operator upgrade is complete:
     1. Run `kubectl edit rec` in the namespace your Redis Enterprise Cluster is deployed in.
     1. Replace the `image:` declaration under `redisEnterpriseImageSpec` with the new version tag provided in the release documentation.
 


### PR DESCRIPTION
Unless I misunderstand something, the services rigger is upgraded with the REC, not when applying the bundle.