### PR TITLE
Fix note styling

### DIFF
--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,6 +1,6 @@
 <!-- Information that prevents errors -->
 <div class="panel panel-primary panel-info"><i class="icon-Caution"></i>
-	<div class="panel-content"><span class="panel-heading">Note - </span>
+	<div class="panel-content">
 		<div class="panel-body">{{- .Inner | markdownify -}}</div>
 	</div>
 </div>

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -1320,6 +1320,7 @@ iframe {
 }
 .panel-body {
   display: inline;
+  font-style: normal;
 }
 .tooltipped {
   position: relative; }


### PR DESCRIPTION
Notes don't need a heading or italics. They're already sufficiently called out. This is more readable.