### PR TITLE
Fix url for adding database programmatically

### DIFF
--- a/content/ri/using-redisinsight/api.md
+++ b/content/ri/using-redisinsight/api.md
@@ -22,7 +22,7 @@ future releases. Do not rely on this API for production.
 
 Used to add Redis databases to RedisInsight.
 
-**URL** : `/api/db/`
+**URL** : `/api/instance/`
 
 **Method** : `POST`
 


### PR DESCRIPTION
I have to manage several instances of Redis/RedisInsight with dynamically uris and wanted to have the process of adding the Redis instances to RedisInsight automated through the api. I drove me crazy that it didn' work like described in the docs. In the end I checked the normal workflow in the RI frontend and the history of the docs page. It stated out that instead of `/api/db/` you have to call `/api/instance/`. So in hope to help other SRE/DevOps with this