### PR TITLE
Add warning on using Swagger examples as-is

### DIFF
--- a/content/rc/api/how-to/using-curl.md
+++ b/content/rc/api/how-to/using-curl.md
@@ -80,9 +80,9 @@ you can enter the values for the parameters.
 
         ![swagger-post-edit-body](/images/rv/api/swagger-post-edit-body.png)
 
-{{% note %}}
-The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You can reference these examples and modify them to fit your specific needs and account settings. The examples will fail if used as-is.
-{{% /note %}}
+{{% warning %}}
+The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You can reference these examples and modify them to fit your specific needs and account settings. The examples will fail if used as-is. You should refer to the examples provided in the documentation, and use them instead.
+{{% /warning %}}
 
 ## Using the `cURL` HTTP client
 

--- a/content/rc/api/how-to/using-curl.md
+++ b/content/rc/api/how-to/using-curl.md
@@ -81,7 +81,7 @@ you can enter the values for the parameters.
         ![swagger-post-edit-body](/images/rv/api/swagger-post-edit-body.png)
 
 {{% warning %}}
-The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You can reference these examples and modify them to fit your specific needs and account settings. The examples will fail if used as-is. You should refer to the examples provided in the documentation, and use them instead.
+The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You can reference these examples and modify them to fit your specific needs and account settings. The examples will fail if used as-is. Use the [how-to articles]({{< relref "https://docs.redislabs.com/latest/rc/how-to.md" >}}) for more  examples of Cloud API operations.
 {{% /warning %}}
 
 ## Using the `cURL` HTTP client

--- a/content/rc/api/how-to/using-curl.md
+++ b/content/rc/api/how-to/using-curl.md
@@ -81,7 +81,7 @@ you can enter the values for the parameters.
         ![swagger-post-edit-body](/images/rv/api/swagger-post-edit-body.png)
 
 {{% warning %}}
-The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You can reference these examples and modify them to fit your specific needs and account settings. The examples will fail if used as-is. Use the [how-to articles]({{< relref "https://docs.redislabs.com/latest/rc/how-to.md" >}}) for more  examples of Cloud API operations.
+The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You can reference these examples and modify them to fit your specific needs and account settings. The examples will fail if used as-is. Use the [how-to articles]({{< relref "https://docs.redislabs.com/latest/rc/api/how-to/_index.md" >}}) for more  examples of Cloud API operations.
 {{% /warning %}}
 
 ## Using the `cURL` HTTP client


### PR DESCRIPTION
Using Swagger examples as-is for POST / PUT operations will  generate an error.
Modified an info message into a warning message.