### PR TITLE
Upgrade to Hugo 71.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     # The build job for staging branches that excludes Google Tag Manager
     build-staging:
         docker:
-            - image: cibuilds/hugo:0.68.3
+            - image: cibuilds/hugo:0.71.1
         working_directory: ~/project
         steps:
             # Checkout the code from the branch into the working_directory


### PR DESCRIPTION
Hugo features since 0.48:

- https://gohugo.io/content-management/archetypes/#directory-based-archetypes
- https://gohugo.io/hosting-and-deployment/hugo-deploy/
- https://gohugo.io/hugo-modules/
- Cascading Front Matter, Alphabetical Sorting, Resources Loading from Assets with Wildcards - https://github.com/gohugoio/hugo/releases/tag/v0.57.0
- .Page home will from 0.58 only return its immediate children (sections and regular pages) - https://github.com/gohugoio/hugo/releases/tag/v0.57.2
- https://gohugo.io/content-management/image-processing/#exif
- https://gohugo.io/content-management/image-processing/#image-processing-options
- https://gohugo.io/variables/pages/
- https://gohugo.io/getting-started/configuration-markup/
- https://gohugo.io/getting-started/configuration-markup/#markdown-render-hooks
- https://gohugo.io/content-management/page-bundles/#branch-bundles
- https://gohugo.io/getting-started/configuration/#configure-server
- https://gohugo.io/content-management/build-options/