### PR TITLE
Only works for 5.6+

### DIFF
--- a/content/rs/installing-upgrading/uninstalling.md
+++ b/content/rs/installing-upgrading/uninstalling.md
@@ -15,3 +15,27 @@ To uninstall RS from a node, run:
 ```src
 rl_uninstall.sh
 ```
+
+For RS versions below 5.6 you will need to utilize the following methods:
+
+- In Ubuntu:	To uninstall RS from a node, run:
+
+
+    ```src	```src
+    sudo apt-get purge redislabs	rl_uninstall.sh
+    ```	```
+
+- In CentOS / RHEL:	
+
+    ```src	
+    sudo yum remove redislabs	
+    ```	
+
+After you confirm the uninstallation, the uninstall process runs and	
+removes the RS installation from the server.	
+
+Note: If you would like to uninstall RS, but keep the configuration and	
+persistence files intact, then you can use the apt-get remove command in	
+Ubuntu, or the rpm -e command in RHEL/CentOS/OEL. Note that you should	
+not try to reinstall RS on a node that still has the configuration files	
+on it as the installation might fail or end up corrupted.


### PR DESCRIPTION
If you don't have version 5.6 you won't be able to find rl_uninstall.sh.  There are a lot of people still on previous versions that are upgrading or administering and need to know how to uninstall using the older method.