### PR TITLE
Add redisinsight docker volume helper info.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,6 +45,7 @@ mac_dl_link = "https://downloads.redisinsight.redislabs.com/latest/redisinsight-
 linux_dl_link = "https://downloads.redisinsight.redislabs.com/latest/redisinsight-linux64"
 windows_dl_link = "https://downloads.redisinsight.redislabs.com/latest/redisinsight-win.msi"
 docker_command = "docker run -v redisinsight:/db -p 8001:8001 redislabs/redisinsight"
+docker_db_volume_permission = "chown -R 1001 redisinsight"
 
 siteURL = "http://127.0.0.1:8001"
 

--- a/content/ri/installing/install-docker.md
+++ b/content/ri/installing/install-docker.md
@@ -29,6 +29,12 @@ Next, run the RedisInsight container. The easiest way is to run the following co
 
 and then point your browser to [http://localhost:8001](http://localhost:8001).
 
+**Note:** Make sure the directory you pass as a volume to the container has necessary permissions for the container to access it. For example, if you have run the previous command and got a permission error, run the following command:
+
+```bash
+{{< param docker_db_volume_permission >}}
+```
+
 In addition, you can add some additional flags to the docker run command:
 
 1. You can add the `-it` flag to see the logs and view the progress

--- a/content/ri/installing/install-docker.md
+++ b/content/ri/installing/install-docker.md
@@ -9,19 +9,23 @@ nextStep:
     href: /docs/install/activating/
 aliases: /ri/install/install-docker/
 ---
-This tutorial shows how to install RedisInsight on [Docker](https://www.docker.com/). Note that this installation is for developer machines. We have a separate guide for installing [RedisInsight on AWS]({{< relref "/ri/installing/install-ec2.md" >}}).
+This tutorial shows how to install RedisInsight on [Docker](https://www.docker.com/) so you can use RedisInsight in development.
+We have a separate guide for installing [RedisInsight on AWS]({{< relref "/ri/installing/install-ec2.md" >}}).
 
-## I. Install Docker
+## Install Docker
 
-The first step is to [install docker for your operating system](https://docs.docker.com/install/). You should be able to run the `docker version` command in a terminal window without any errors.
+The first step is to [install docker for your operating system](https://docs.docker.com/install/).
+Run the `docker version` command in a terminal window to make sure that docker is installed correctly.
 
 {{< note >}}
-On Windows and Mac, please install docker version 18.03 or higher. You can `docker version` to find out your docker version.
+On Windows and Mac, install docker version 18.03 or higher.
+You can run `docker version` to find out your docker version.
 {{< /note >}}
 
-## II. Run RedisInsight Docker Image
+## Run RedisInsight Docker Image
 
-Next, run the RedisInsight container. The easiest way is to run the following command:
+Next, run the RedisInsight container.
+The easiest way is to run the following command:
 
 ```bash
 {{< param docker_command >}}
@@ -30,7 +34,8 @@ Next, run the RedisInsight container. The easiest way is to run the following co
 and then point your browser to [http://localhost:8001](http://localhost:8001).
 
 {{< note >}}
-Make sure the directory you pass as a volume to the container has necessary permissions for the container to access it. For example, if you have run the previous command and got a permission error, run the following command:
+Make sure the directory you pass as a volume to the container has necessary permissions for the container to access it.
+For example, if the previous command returns a permissions error, run the following command:
 
 ```bash
 {{< param docker_db_volume_permission >}}
@@ -38,9 +43,11 @@ Make sure the directory you pass as a volume to the container has necessary perm
 
 In addition, you can add some additional flags to the docker run command:
 
-1. You can add the `-it` flag to see the logs and view the progress
+1. You can add the `-it` flag to see the logs and view the progress.
 1. On Linux, you can add `--network host`. This makes it easy to work with redis running on your local machine.
-1. To analyze RDB Files stored in S3, you can add the access key and secret access key as environment variables using the `-e` flag. For example: `-e AWS_ACCESS_KEY=<aws access key> -e AWS_SECRET_KEY=<aws secret access key>`
+1. To analyze RDB files stored in S3, you can add the access key and secret access key as environment variables using the `-e` flag.
+
+    For example: `-e AWS_ACCESS_KEY=<aws access key> -e AWS_SECRET_KEY=<aws secret access key>`
 
 If everything worked, you should see the following output in the terminal:
 

--- a/content/ri/installing/install-docker.md
+++ b/content/ri/installing/install-docker.md
@@ -29,7 +29,8 @@ Next, run the RedisInsight container. The easiest way is to run the following co
 
 and then point your browser to [http://localhost:8001](http://localhost:8001).
 
-**Note:** Make sure the directory you pass as a volume to the container has necessary permissions for the container to access it. For example, if you have run the previous command and got a permission error, run the following command:
+{{< note >}}
+Make sure the directory you pass as a volume to the container has necessary permissions for the container to access it. For example, if you have run the previous command and got a permission error, run the following command:
 
 ```bash
 {{< param docker_db_volume_permission >}}
@@ -48,3 +49,4 @@ Starting webserver...
 Visit http://0.0.0.0:8001 in your web browser.
 Press CTRL-C to exit.
 ```
+{{< /note >}}


### PR DESCRIPTION
RedisInsight docker container from `v1.6.0` starts with non-root user by default and redisinsight users who are migrating from previous versions should be notified on how to proceed.

Fix: https://github.com/RedisLabs/redislabs-docs/issues/886

CC: @slemeur @nishantgeorge 