### PR TITLE
Prevent OS from using Redis ports

### DIFF
--- a/content/rs/installing-upgrading/_index.md
+++ b/content/rs/installing-upgrading/_index.md
@@ -61,7 +61,9 @@ sudo lsblk
 1. Run: `sudo ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf`
 1. Run: `sudo service systemd-resolved restart`
     {{% /expand %}}
-- By default, Redis can utilize local ports up to port 29999 (see [Network Port Configurations]({{< relref "/rs/administering/designing-production/networking/port-configurations.md" >}})). To prevent a possible port conflict during services startup where the OS might use one of the Redis ports, it's recommended to restrict the OS from using Redis ports range. This can be done by setting net.ipv4.ip_local_port_range to have a value of '30000 65535' in /etc/sysctl.conf.
+
+- Make sure that the OS is not using ports in the [range that Redis assigns to databases]({{< relref "/rs/administering/designing-production/networking/port-configurations.md" >}})).
+    We recommend that you restrict the OS from using Redis ports range in `/etc/sysctl.conf` with `net.ipv4.ip_local_port_range = 30000 65535'.
 
 ## Installing RS on Linux
 

--- a/content/rs/installing-upgrading/_index.md
+++ b/content/rs/installing-upgrading/_index.md
@@ -61,6 +61,7 @@ sudo lsblk
 1. Run: `sudo ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf`
 1. Run: `sudo service systemd-resolved restart`
     {{% /expand %}}
+- By default, Redis can utilize local ports up to port 29999 (see [Network Port Configurations]({{< relref "/rs/administering/designing-production/networking/port-configurations.md" >}})). To prevent a possible port conflict during services startup where the OS might use one of the Redis ports, it's recommended to restrict the OS from using Redis ports range. This can be done by setting net.ipv4.ip_local_port_range to have a value of '30000 65535' in /etc/sysctl.conf.
 
 ## Installing RS on Linux
 


### PR DESCRIPTION
In Pre-Requisites, added a new bullet with a recommendation for setting the OS local port usage as we had few tickets where Redis services couldn't start due to port conflict.
As a result, customers asked why this is not showing in our documentation.
Rlcheck which runs post-installation also checks for the configured port range but it doesn't do more than a warning that can easily be overlooked.

I thought this page would be the best place but if there's a better place, we can move it there.
Please verify that I added it as a bullet and didn't mess up the page's formatting.