### PR TITLE
Fixed Typo

### DIFF
--- a/content/rs/installing-upgrading/upgrading.md
+++ b/content/rs/installing-upgrading/upgrading.md
@@ -148,7 +148,7 @@ When you upgrade an Active-Active (CRDB) database, you can also upgrade:
     it automatically receives any missing write-operations.
 
 - **Feature set version** - RS 5.6.0 and higher include a new feature set version to support new Active-Active features.
-    When you update the feature set version for an Actvie-Active database, the feature set version is updated for all of the database instances.
+    When you update the feature set version for an Active-Active database, the feature set version is updated for all of the database instances.
 
 To upgrade a CRDB instance:
 


### PR DESCRIPTION
Fixed typo in 'active-active' section on word 'active'