### PR TITLE
Openshift 4 via the CLI

### DIFF
--- a/content/platforms/kubernetes/db-controller.md
+++ b/content/platforms/kubernetes/db-controller.md
@@ -241,11 +241,11 @@ The value is a keyword with the values:
 | Value | Description |
 | ----- | ----------- |
 | disabled | Data is not persisted (default) |
-| AofEverySecond | Data is synced to disk every second |
-| AofAlways | Data is synced to disk with every write. |
-| SnapshotEveryHour | A snapshot of the database is created every hour |
-| SnapshotEvery6Hour | A snapshot of the database is created every 6 hours. |
-| SnapshotEvery12Hour | A snapshot of the database is created every 12 hours. |
+| aofEverySecond | Data is synced to disk every second |
+| aofAlways | Data is synced to disk with every write. |
+| snapshotEvery1Hour | A snapshot of the database is created every hour |
+| snapshotEvery6Hour | A snapshot of the database is created every 6 hours. |
+| snapshotEvery12Hour | A snapshot of the database is created every 12 hours. |
 
 ### `rackAware`
 

--- a/content/platforms/openshift/getting-started-cli.md
+++ b/content/platforms/openshift/getting-started-cli.md
@@ -1,6 +1,7 @@
 ---
-Title: Getting Started for 3.x and CLI tools
-description:
+Title: Getting Started with the CLI tools
+description: The operator and cluster can be installed via CLI tools
+  OpenShift 3.x or 4.x.
 weight: 60
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/platforms/openshift/getting-started-operatorhub.md
+++ b/content/platforms/openshift/getting-started-operatorhub.md
@@ -1,7 +1,8 @@
 ---
-Title: Getting Started for 4.x and the OperatorHub
+Title: Getting Started with the OperatorHub on OpenShift 4.x
 description: OpenShift 4.x provides the OperatorHub where you can install the
- Redis Enterprise Operator from the administrator user interface.
+ Redis Enterprise Operator from the administrator user interface. Alternatively,
+ can install the operator and cluster with the CLI.
 weight: 10
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/platforms/openshift/quick-start.md
+++ b/content/platforms/openshift/quick-start.md
@@ -21,16 +21,26 @@ workloads can use:
 
 1. The operator automatically exposes the new database as a K8s service.
 
-We currently support OpenShift 3.x and 4.x clusters but the process for deployment is different for each.
+We currently support OpenShift 3.x and 4.x clusters. If you install via the CLI,
+the process is essentially the same. OpenShift 4.x also has the OperatorHub that
+vastly simplifies the deployment of the operator.
 
-## For OpenShift 3.x
+## For OpenShift 3.x via the CLI
 
-To [create a database on an OpenShift 3.x cluster]({{< relref "getting-started-cli.md" >}}) you need:
+To [create a database on an OpenShift 3.x cluster via the CLI]({{< relref "getting-started-cli.md" >}}) you need:
 
 1. An [OpenShift 3.x cluster installed](https://docs.openshift.com/container-platform/3.11/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}})
 1. The [kubectl package installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/) at version 1.9 or higher
 1. The [OpenShift cli installed](https://docs.openshift.com/online/starter/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands)
 
-## For OpenShift 4.x
+## For OpenShift 4.x via the OperatorHub
 
-To [create a database on an OpenShift 4.x cluster]({{< relref "getting-started-operatorhub.md" >}}) you need the [OpenShift 4.x cluster installed](https://docs.openshift.com/container-platform/4.3/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}).
+To [create a database on an OpenShift 4.x cluster via the OperatorHub]({{< relref "getting-started-operatorhub.md" >}}) you only need the [OpenShift 4.x cluster installed](https://docs.openshift.com/container-platform/4.3/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}).
+
+## For OpenShift 4.x via the CLI
+
+To [create a database on an OpenShift 4.x cluster via the CLI]({{< relref "getting-started-cli.md" >}}) you need:
+
+1. An [OpenShift 4.x cluster installed](https://docs.openshift.com/container-platform/4.3/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}).
+1. The [kubectl package installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/) at version 1.9 or higher
+1. The [OpenShift cli installed](https://docs.openshift.com/online/starter/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands)


### PR DESCRIPTION
Minor adjustments to make sure it is clear that you can install via the CLI for OpenShift 4.x