### PR TITLE
Add list of backup parameters for RC API

### DIFF
--- a/content/rc/api/how-to/backup-and-import-databases.md
+++ b/content/rc/api/how-to/backup-and-import-databases.md
@@ -77,3 +77,5 @@ In the example above, that JSON document is stored in the `import-database-s3.js
 ```shell
 {{% embed-code "rv/api/import-database-s3.json" %}}
 ```
+
+<<Valid Values - "sourceType" & "importFromUri">>

--- a/content/rc/api/how-to/backup-and-import-databases.md
+++ b/content/rc/api/how-to/backup-and-import-databases.md
@@ -78,4 +78,13 @@ In the example above, that JSON document is stored in the `import-database-s3.js
 {{% embed-code "rv/api/import-database-s3.json" %}}
 ```
 
-<<Valid Values - "sourceType" & "importFromUri">>
+You can specify the backup location with the `sourceType` and `importFromUri` values for these sources:
+
+|Data location|sourceType|importFromUri|
+|---|---|---|
+|Amazon AWS S3|aws-s3|s3://bucketname/[path/]filename.rdb[.gz]|
+|FTP|ftp|ftp://[username][:password]@[:port]/[path/]filename.rdb[.gz]|
+|Google Blob Storage|google-blob-storage|gs://bucketname/[path/]filename.rdb[.gz]|
+|Microsoft Azure Blob Storage|azure-blob-storage|abs://:storage_account_access_key@storage_account_name/[container/]filename.rdb[.gz]|
+|Redis server|redis|redis://[db_password]@[host]:[port]|
+|Web server|HTTP|HTTP://[username][:password]@[:port]/[path/]filename.rdb[.gz]|


### PR DESCRIPTION
In the last section, Database import JSON body, the JSON body only includes an example of an import from AWS S3 bucket.
I think we should specify below it the valid values for both "sourceType" & "importFromUri" parameters.
I marked the place with "<<Valid Values - "sourceType" & "importFromUri">>" but the suggested details are below.

"sourceType" & "importFromUri" valid values:
aws-s3 - s3://bucketname/[path/]filename.rdb[.gz] 
ftp - ftp://[username][:password]@[:port]/[path/]filename.rdb[.gz]
HTTP - HTTP://[username][:password]@[:port]/[path/]filename.rdb[.gz] 
azure-blob-storage - abs://:storage_account_access_key@storage_account_name/[container/]filename.rdb[.gz]
redis - redis://[db_password]@[host]:[port]
google-blob-storage - gs://bucketname/[path/]filename.rdb[.gz]