### PR TITLE
Fix typo for importing data from Redis

### DIFF
--- a/content/rc/how-to/importing-data.md
+++ b/content/rc/how-to/importing-data.md
@@ -25,7 +25,7 @@ To import a dataset from any publicly available Redis server:
 
 1. In the Redis Cloud management console, go to the database that you want to import into.
 1. Click ![Import](/images/rc/icon_import.png#no-click "Import").
-1. Enter the details for the RDB file:
+1. Enter the source database details:
     - Source Type - Select **Redis**.
     - Redis Hostname/IP Address - Enter the hostname or the public IP address of the source Redis server.
     - Redis port - Enter the port of the source Redis server if it is not the default value of `6379`.


### PR DESCRIPTION
In the import from a Redis server, fixed a typo indicating that a user should put RDB details to source DB details [see edited line].

Another point is that the section mentions "import a dataset from any publicly available Redis server" but this is not accurate.
As far as I know, import from a Redis Labs DB is not allowed. I'm not sure if there are other restrictions.
Need to check with PM to clarify that point.
I tried importing from both RS and Essentials (both publicly available) and I couldn't.