### PR TITLE
Add dropdown for Platforms

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -54,8 +54,8 @@
                 <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
               </button>
               <div class="menu__version-selector__list version-selector-control">                
-                <a href="https://docs.redislabs.com/6.0/platforms" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.0 (latest)')">v6.0 (latest)</a>
-                <a href="https://docs.redislabs.com/5.6/platforms" id="version-select-5.6" onclick="_setSelectedVersion('5.6', 'v5.6')">v5.6</a>
+                <a href="https://docs.redislabs.com/6.0/platforms" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.x (latest)')">v6.x (latest)</a>
+                <a href="https://docs.redislabs.com/5.6/platforms" id="version-select-5.6" onclick="_setSelectedVersion('5.6', 'v5.x')">v5.x</a>
               </div>
             </div>
           {{end}}          

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -45,6 +45,20 @@
               </div>
             </div>
           {{end}}
+
+          {{if eq (index .Params.categories 0) "Platforms"}}
+            <div id="versionSelector" class="menu__version-selector version-selector-control" onclick="_openVersionSelector()">
+              <button class="menu__version-selector-btn version-selector-control">
+                <span id="versionSelectorValue" class="version-selector-control"></span>
+                <span class="menu__version-selector__toggler opener version-selector-control">&#x25BC;</span>
+                <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
+              </button>
+              <div class="menu__version-selector__list version-selector-control">                
+                <a href="https://docs.redislabs.com/6.0/platforms" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.0 (latest)')">v6.0 (latest)</a>
+                <a href="https://docs.redislabs.com/5.6/platforms" id="version-select-5.6" onclick="_setSelectedVersion('5.6', 'v5.6')">v5.6</a>
+              </div>
+            </div>
+          {{end}}          
         {{end}}
 
         {{- if not .Site.Params.disableHomeIcon}}

--- a/layouts/partials/flex/scripts.html
+++ b/layouts/partials/flex/scripts.html
@@ -1,4 +1,4 @@
-<!-- Version selector -->
+<!-- RS version selector -->
 {{if .Params.categories}}
 {{if eq (index .Params.categories 0) "RS"}}
 <script>
@@ -54,7 +54,58 @@ window.onclick = function(e) {
 }</script>
 {{end}}
 {{end}}
-<!-- /Version selector -->
+<!-- /RS version selector -->
+
+<!-- Platforms version selector -->
+{{if .Params.categories}}
+{{if eq (index .Params.categories 0) "Platforms"}}
+<script>
+(function () {
+  var pa = window.location.pathname.split('/');
+  var pv = pa[1]; // 6.x, 5.x
+
+  if(pv == '6.0' || pv == 'latest') {
+    v = '6.x';
+    d = 'v6.x (latest)';
+  } else if (pv == '5.6') {
+    v = '5.x';
+    d = 'v5.x';
+  }
+  _setVersion(v, d);
+  _setSelectedVersion(v);
+})();
+
+function _setVersion(ver, displayName) {
+  document.getElementById('versionSelectorValue').innerText = displayName;
+}
+
+function _setSelectedVersion(ver) {
+  if(ver) {
+    var i = document.getElementById('version-select-' + ver);
+    if(i) {
+      i.classList.toggle('selected-version');
+    }
+  }
+}
+
+function _openVersionSelector() {
+    document.getElementById('versionSelector').classList.toggle('open');
+}
+
+window.onclick = function(e) {
+  if (!e.target.matches('.version-selector-control')) {
+    var d = document.getElementsByClassName('menu__version-selector');
+    var i;
+    for (i = 0; i < d.length; i++) {
+      if (d[i].classList.contains('open')) {
+        d[i].classList.remove('open');
+      }
+    }
+  }
+}</script>
+{{end}}
+{{end}}
+<!-- /Platforms version selector -->
 
 <script>
   // Set up GA Event tracking


### PR DESCRIPTION
This dropdown is so that customers can select between the 6.x version of the docs which is the latest and the 5.x version of the docs that is in /5.6.

I tried just re-using the RS dropdown but it didn't work for me.