### PR TITLE
Tweak platforms version selector

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -54,8 +54,8 @@
                 <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
               </button>
               <div class="menu__version-selector__list version-selector-control">                
-                <a href="https://docs.redislabs.com/6.0/platforms" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.x (latest)')">v6.x (latest)</a>
-                <a href="https://docs.redislabs.com/5.6/platforms" id="version-select-5.6" onclick="_setSelectedVersion('5.6', 'v5.x')">v5.x</a>
+                <a href="https://docs.redislabs.com/6.0/platforms" id="version-select-6.x" onclick="_setSelectedVersion('6.0', 'v6.x (latest)')">v6.x (latest)</a>
+                <a href="https://docs.redislabs.com/5.6/platforms" id="version-select-5.x" onclick="_setSelectedVersion('5.6', 'v5.x')">v5.x</a>
               </div>
             </div>
           {{end}}          

--- a/layouts/partials/flex/scripts.html
+++ b/layouts/partials/flex/scripts.html
@@ -1,3 +1,39 @@
+<!-- Common code for version selectors -->
+{{if .Params.categories}}
+{{if or (eq (index .Params.categories 0) "RS") (eq (index .Params.categories 0) "Platforms")}}
+<script>
+  function _setVersion(ver, displayName) {
+  document.getElementById('versionSelectorValue').innerText = displayName;
+}
+
+function _setSelectedVersion(ver) {
+  if(ver) {
+    var i = document.getElementById('version-select-' + ver);
+    if(i) {
+      i.classList.toggle('selected-version');
+    }
+  }
+}
+
+function _openVersionSelector() {
+    document.getElementById('versionSelector').classList.toggle('open');
+}
+
+window.onclick = function(e) {
+  if (!e.target.matches('.version-selector-control')) {
+    var d = document.getElementsByClassName('menu__version-selector');
+    var i;
+    for (i = 0; i < d.length; i++) {
+      if (d[i].classList.contains('open')) {
+        d[i].classList.remove('open');
+      }
+    }
+  }
+}
+</script>
+{{end}}
+{{end}}
+
 <!-- RS version selector -->
 {{if .Params.categories}}
 {{if eq (index .Params.categories 0) "RS"}}
@@ -23,35 +59,7 @@
   _setVersion(v, d);
   _setSelectedVersion(v);
 })();
-
-function _setVersion(ver, displayName) {
-  document.getElementById('versionSelectorValue').innerText = displayName;
-}
-
-function _setSelectedVersion(ver) {
-  if(ver) {
-    var i = document.getElementById('version-select-' + ver);
-    if(i) {
-      i.classList.toggle('selected-version');
-    }
-  }
-}
-
-function _openVersionSelector() {
-    document.getElementById('versionSelector').classList.toggle('open');
-}
-
-window.onclick = function(e) {
-  if (!e.target.matches('.version-selector-control')) {
-    var d = document.getElementsByClassName('menu__version-selector');
-    var i;
-    for (i = 0; i < d.length; i++) {
-      if (d[i].classList.contains('open')) {
-        d[i].classList.remove('open');
-      }
-    }
-  }
-}</script>
+</script>
 {{end}}
 {{end}}
 <!-- /RS version selector -->
@@ -74,35 +82,7 @@ window.onclick = function(e) {
   _setVersion(v, d);
   _setSelectedVersion(v);
 })();
-
-function _setVersion(ver, displayName) {
-  document.getElementById('versionSelectorValue').innerText = displayName;
-}
-
-function _setSelectedVersion(ver) {
-  if(ver) {
-    var i = document.getElementById('version-select-' + ver);
-    if(i) {
-      i.classList.toggle('selected-version');
-    }
-  }
-}
-
-function _openVersionSelector() {
-    document.getElementById('versionSelector').classList.toggle('open');
-}
-
-window.onclick = function(e) {
-  if (!e.target.matches('.version-selector-control')) {
-    var d = document.getElementsByClassName('menu__version-selector');
-    var i;
-    for (i = 0; i < d.length; i++) {
-      if (d[i].classList.contains('open')) {
-        d[i].classList.remove('open');
-      }
-    }
-  }
-}</script>
+</script>
 {{end}}
 {{end}}
 <!-- /Platforms version selector -->


### PR DESCRIPTION
This change hides the current version as an option in Platforms version dropdown and simplifies the version dropdown code a bit.