### PR TITLE
Updates to latest 6.0.6-23 release notes

### DIFF
--- a/content/platforms/release-notes/k8s-6-0-6-23-2020-08.md
+++ b/content/platforms/release-notes/k8s-6-0-6-23-2020-08.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.6-23 (August 2020)
 description: Release notes for version 6.0.6-23 (latest)
-weight: 78
+weight: 76
 alwaysopen: false
 categories: ["Platforms"]
 ---
@@ -38,11 +38,11 @@ The services rigger and operator images are now based on Red Hat UBI base images
 
 ### Rancher support (RED37918)
 
-The operator is now supported on [Rancher](https://rancher.com/) version ([v2.4.5](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.4.5/)).
+The operator is now supported on [Rancher](https://rancher.com/) version ([v2.4.5](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.4.5/)). Please note that since this release of the operator doesn't support K8s 1.18, it requires one of the other supported upstread version in this Rancher release, i.e. 1.15.12, 1.16.13 or 1.17.9. 
 
 ### Database Replica Of support (RED40160)
 
-Support for Replica Of was added to the [DB controller](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_database_api.md#replicasource).
+Support for [Replica Of](https://docs.redislabs.com/latest/rs/administering/active-passive/) was added to the [DB controller](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_database_api.md#replicasource).
 
 ### Database backup configuration (RED40165)
 
@@ -54,7 +54,7 @@ Support for alert configuration was added to the [DB controller spec](https://gi
 
 ### Database TLS configuration (RED41758)
 
-Support for TLS authentication configuration was added to the DB controller.
+Support for TLS authentication configuration was added to the [DB controller spec](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/0ec741ffb3d621d371b5eec5b0a045ee7364e50e/redis_enterprise_database_api.md#redisenterprisedatabasespec).
 
 ### OpenShift 4.4 support (RED41352)
 


### PR DESCRIPTION
Changed weight so it will appear at the top, being the latest.
Added Rancher upstream K8s note around 1.18 limitations
Added link to generic Replica Of description
Added link to TLS spec docs