### PR TITLE
DOC-343 Specify on landing page that AI and Gears are RS only

### DIFF
--- a/content/embeds/modules.html
+++ b/content/embeds/modules.html
@@ -104,7 +104,7 @@
             <a href="/modules/redisai/" class="opener"></a>
         </div>
         <h5>RedisAI</h5>
-        <p>RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data.</p>
+        <p>RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data. (RS only)</p>
         <hr>
         <ul>
             <section>
@@ -123,7 +123,7 @@
             <a href="/modules/redisgears/" class="opener"></a>
         </div>
         <h5>RedisGears</h5>
-        <p>RedisGears is a serverless engine for transaction, batch and event-driven data processing in Redis.</p>
+        <p>RedisGears is a serverless engine for transaction, batch and event-driven data processing in Redis. (RS only)</p>
         <hr>
         <ul>
             <section>

--- a/content/embeds/modules.html
+++ b/content/embeds/modules.html
@@ -104,7 +104,7 @@
             <a href="/modules/redisai/" class="opener"></a>
         </div>
         <h5>RedisAI</h5>
-        <p>RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data. (RS only)</p>
+        <p>RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data. (Redis Enterprise Software only)</p>
         <hr>
         <ul>
             <section>
@@ -123,7 +123,7 @@
             <a href="/modules/redisgears/" class="opener"></a>
         </div>
         <h5>RedisGears</h5>
-        <p>RedisGears is a serverless engine for transaction, batch and event-driven data processing in Redis. (RS only)</p>
+        <p>RedisGears is a serverless engine for transaction, batch and event-driven data processing in Redis. (Redis Enterprise Software only)</p>
         <hr>
         <ul>
             <section>


### PR DESCRIPTION
https://docs.redislabs.com/staging/DOC-343-specify-RC-support/modules/

The quick start pages state that you need RS to run AI and Gears so I think we just need to specify on the landing page that they are RS only.