### PR TITLE
Clarification of version_integer format

### DIFF
--- a/content/modules/redisgears/installing-redisgears.md
+++ b/content/modules/redisgears/installing-redisgears.md
@@ -31,7 +31,7 @@ On each node in the Redis Enterprise cluster:
 
 {{< note >}}
 - `<version>` - The version number in the format `x.y.z`.
-- `<version_integer>` - The version number in integer format `xxyyzz` or you can calculate it as `10000*x + 100*y + z`.
+- `<version_integer>` - The version number in integer format `xxyyzz` (`xyyzz` if `x` < 10) or you can calculate it as `10000*x + 100*y + z`.
 - You must also run these commands on new nodes before you join them to an existing cluster.
 {{< /note >}}
 

--- a/content/modules/redisgears/installing-redisgears.md
+++ b/content/modules/redisgears/installing-redisgears.md
@@ -31,7 +31,7 @@ On each node in the Redis Enterprise cluster:
 
 {{< note >}}
 - `<version>` - The version number in the format `x.y.z`.
-- `<version_integer>` - The version number in integer format `xxyyzz` (`xyyzz` if `x` < 10) or you can calculate it as `10000*x + 100*y + z`.
+- `<version_integer>` - The version number in integer format `xxyyzz` (`xyyzz` if `x` < 10). You can calculate this number using the formula `10000*x + 100*y + z`.
 - You must also run these commands on new nodes before you join them to an existing cluster.
 {{< /note >}}
 


### PR DESCRIPTION
The version integer format for modules is listed as "xxyyzz", but for major versions < 10, the format is actually "xyyzz".