### PR TITLE
RedisInsight: Added note about using RI with a reverse proxy.

### DIFF
--- a/content/ri/using-redisinsight/troubleshooting.md
+++ b/content/ri/using-redisinsight/troubleshooting.md
@@ -32,5 +32,5 @@ We are happy to receive your feedback at redisinsight@redislabs.com.
 
 RedisInsight should work fine behind a reverse proxy like Nginx for most use-cases.
 There are a couple of things to keep in mind:
-- Since some requests can be long-running, we recommend that the **request timeout is set to over 30 seconds**.
+- Since some requests can be long-running, we recommend that the **request timeout is set to over 30 seconds** on the reverse proxy.
 - Using path-rewriting, i.e, hosting RedisInsight behind a prefix path is not supported at this time.

--- a/content/ri/using-redisinsight/troubleshooting.md
+++ b/content/ri/using-redisinsight/troubleshooting.md
@@ -26,3 +26,11 @@ You can install RedisInsight on operating systems that are not officially suppor
 {{< /note >}}
 
 We are happy to receive your feedback at redisinsight@redislabs.com.
+
+
+## Using behind a reverse proxy
+
+RedisInsight should work fine behind a reverse proxy like Nginx for most use-cases.
+There are a couple of things to keep in mind:
+- Since some requests can be long-running, we recommend that the **request timeout is set to over 30 seconds**.
+- Using path-rewriting, i.e, hosting RedisInsight behind a prefix path is not supported at this time.


### PR DESCRIPTION

<img width="1440" alt="Screenshot 2020-09-21 at 4 48 46 PM" src="https://user-images.githubusercontent.com/25577002/93761200-04a5f600-fc2b-11ea-8b16-374fd3ce2fc5.png">


This note is relevant to all previous versions of RedisInsight as well. It can be merged after it is approved, no need to wait for the next release.