### PR TITLE
[RedisInsight] [Next Version] Document new environment variable to configure log level.

### DIFF
--- a/content/ri/installing/configurations.md
+++ b/content/ri/installing/configurations.md
@@ -31,3 +31,5 @@ The following environment variables can be set to configure RedisInsight:
 - `REDISINSIGHT_HOME_DIR` - By default, RedisInsight stores application data (such as local database, log files and snapshot files) in  `~/.redisinsight` in your home directory on desktop and in the `/db` directory in the Docker container. To change this directory, set the `REDISINSIGHT_HOME_DIR` environment variable.
 
 - `LOG_DIR` - By default, RedisInsight stores log files in your home directory (`REDISINSIGHT_HOME_DIR`). To have RedisInsight store the log files in a different directory, set the `LOG_DIR` environment variable.
+
+- `REDISINSIGHT_LOG_LEVEL` - By default, RedisInsight logs all warnings produced by it. To configure log level of RedisInsight, set the `REDISINSIGHT_LOG_LEVEL` environment variable. Possible values of this variable are - DEBUG, INFO, WARNING, ERROR and CRITICAL.


### PR DESCRIPTION
This PR updates `configuration.md` to include information about the environment variable that can be used to configure the log level of the application.

**NOTE** : This functionality will be available from RedisInsight version > 1.7.0. The latest release is 1.7.0.
Thus, **this PR can be merged after a new release of RedisInsight is made**.

Attaching the JIRA issue link for convenience: [https://redislabs.atlassian.net/browse/RI-456](https://redislabs.atlassian.net/browse/RI-456)