### PR TITLE
Clarify need for default password

### DIFF
--- a/content/rs/administering/creating-databases/_index.md
+++ b/content/rs/administering/creating-databases/_index.md
@@ -96,7 +96,10 @@ for this database. Minimum RAM portion is 10%, and maximum RAM portion is 50%.
     - **Default database access** - When you configure a password for your database,
         all connections to the database must authenticate with the [AUTH command](https://redis.io/commands/auth).
         If you also configure an access control list, connections can specify other users for authentication,
-        and requests are allowed according to the Redis ACLs specified for that user.
+        and requests are allowed according to the Redis ACLs specified for that user. 
+        
+        Please note that creating a database without further ACLs (see below) contains a *default* user with full access to the database which
+        in turn requires the definition a password for security reasons. 
 
         {{< note >}}
 If you are creating a Memcached database, enter a username and password for SASL Authentication.


### PR DESCRIPTION
Added clarification about password definition when using a default user.