### PR TITLE
Refreshes the node_redis client page.

### DIFF
--- a/content/rs/references/client_references/client_nodejs.md
+++ b/content/rs/references/client_references/client_nodejs.md
@@ -1,74 +1,138 @@
 ---
-Title: Using Redis with Node.js
+Title: Using Redis with Node.js (node_redis)
 description:
 weight:
 alwaysopen: false
 categories: ["RS"]
 ---
-In order to use Redis with Node.js you need a Node.js Redis client. In following sections, we demonstrate the use of [node_redis](https://github.com/NodeRedis/node_redis), a complete Redis client for Node.js. Additional Node.js clients for Redis can be found under the [Node.js section](http://redis.io/clients#Node.js) of the Redis Clients page.
+In order to use Redis with Node.js you need to install a Node.js Redis client. In the following sections, we demonstrate the use of [node_redis](https://github.com/NodeRedis/node_redis), a complete Redis client for Node.js. Additional Node.js clients for Redis can be found under the [Node.js section](https://redis.io/clients#Node.js) of the [Redis Clients page](https://redis.io/clients).
 
 ## Installing node_redis
 
-node_redis installation instructions are given in the [README file](https://github.com/NodeRedis/node_redis/blob/master/README.md). To install using `npm` issue the following command:
+Complete instructions for installing node_redis can be found in the [README file](https://github.com/NodeRedis/node_redis/blob/master/README.md). To install node_redis, issue the following command:
 
     npm install redis 
 
-## Opening a connection to Redis using node_redis
+## Connecting to Redis
 
-The following code creates a connection to Redis using node_redis:
+The following code creates a connection to Redis:
 
-    var redis = require('redis');
-    var client = redis.createClient(port, 'hostname', {no_ready_check: true});
-    client.auth('password', function (err) {
-        if (err) then throw err;
+    const redis = require('redis');
+    const client = redis.createClient({
+        host: 'hostname',
+        port: 6379,
+        password: 'password'
     });
-    
-    client.on('error', function (err) {
+
+    client.on('error', err => {
         console.log('Error ' + err);
     }); 
+
+Make sure to replace the following values with those for your Redis instance:
+
+- `'hostname'` should be the name of the host your database runs on
+- `6379` is the default Redis port, change this if necessary
+- `'password'` should be the password you use to access Redis.  If a password is not required, remove this line.  Remember to always store passwords outside of your code, for example in environment variables
+
+## Connecting to Redis with TLS 
+
+The following example demonstrates how to make a connection to Redis using TLS:
+
+    const redis = require('redis');
+    const fs = require('fs');
+
+    const client = redis.createClient({
+        host: 'hostname',
+        port: 6379,
+        tls: {
+            key: fs.readFileSync('path_to_keyfile', encoding='ascii'),
+            cert: fs.readFileSync('path_to_certfile', encoding='ascii'),
+            ca: [ fs.readFileSync('path_to_ca_certfile', encoding='ascii') ]
+        }
+    });
     
-    client.on('connect', function() {
-        console.log('Connected to Redis');
+    ...
+
+## Connecting to Redis using an ACL user and password
+
+Redis 6 introduced [Access Control Lists](https://redis.io/topics/acl).  ACLs provide the capability to create named user accounts, each having its own password.
+
+node_redis doesn't currently support ACL commands, or the `AUTH` command with a username and password.  This means that you will need to disable the client's built in `auth` function and use the generic `send_command` function to authenticate.  `send_command` allows you to send any arbitrary command to Redis.
+
+Example:
+
+    const redis = require('redis');
+    const client = redis.createClient({
+        host: '127.0.0.1',
+        port: 6379
     });
 
-To adapt this example to your code, make sure that you replace the following values with those of your database:
+    // Disable client's AUTH command.
+    client['auth'] = null;
 
-- In line 2, the first argument to `createClient` should be your database's port
-- In line 2, the second argument to `createClient` should be your database's hostname or IP address
-- In line 3, the first argument to `auth` should be your database's password
+    // send_command expects a command name and array of parameters.
+    client.send_command('AUTH', ['username', 'password']);
 
-## Using SSL and node_redis
-
-TLS is supported by node_redis as of [version 2.4.0](https://github.com/NodeRedis/node_redis/releases/tag/v.2.4.0). The following example demonstrates how to use TLS:
-
-    var redis = require('redis');
-    var tls = require('tls');
-    var fs = require('fs');
-    
-    var ssl = {
-      key: fs.readFileSync('path_to_keyfile',encoding='ascii'),
-      cert: fs.readFileSync('path_to_certfile',encoding='ascii'),
-      ca: [ fs.readFileSync('path_to_ca_certfile',encoding='ascii') ]
-    };
-    
-    var client = redis.createClient(port, 'hostname', {tls: ssl});
-    ...
+You will need to replace `username` and `password` with the values for the ACL user that you are connecting as.
 
 ## Reading and writing data with node_redis
 
 Once connected to Redis, you can start reading and writing data. The following code snippet writes the value `bar` to the Redis key `foo`, reads it back, and prints it:
 
-    // open a connection to Redis
+    // Open a connection to Redis
     ...
  
-    client.set("foo", "bar", redis.print);
-    client.get("foo", function (err, reply) {
-        if (err) then throw err;
-        console.log(reply.toString());
+    client.set('foo', 'bar'); 
+    client.get('foo', (err, reply) => {
+        if (err) throw err;
+        console.log(reply);
     });
 
 The output of the above code should be:
 
     $ node example_node_redis.js
     Connected to Redis
-    bars
+    bar
+
+node_redis exposes a function named for each Redis command.  These functions take string arguments, the first of which is almost always the Redis key to run the command against. These arguments are followed by an optional error first callback function.
+
+## Promises and async / await
+
+To use promises and async / await with node_redis, wrap it using [Bluebird's](https://www.npmjs.com/package/bluebird) `promisifyAll` like so:
+
+    const redis = require('redis');
+    const { promisifyAll } = require('bluebird');
+
+    promisifyAll(redis);
+
+    const runApplication = async () => {
+        // Connect to redis at 127.0.0.1 port 6379 no password.
+        const client = redis.createClient();
+
+        await client.setAsync('foo', 'bar');
+        const fooValue = await client.getAsync('foo');
+        console.log(fooValue);
+    };
+
+    runApplication();
+
+This creates an async equivalent of each function, suffixing its name with `Async`.
+
+Alternatively, you can promisify a subset of node_redis functions one at a time using native Node.js promises and `util.promisify`:
+
+    const redis = require('redis');
+    const { promisify } = require('util');
+
+    const runApplication = async () => {
+        // Connect to redis at 127.0.0.1 port 6379 no password.
+        const client = redis.createClient();
+
+        const setAsync = promisify(client.set).bind(client);
+        const getAsync = promisify(client.get).bind(client);
+
+        await setAsync('foo', 'bar');
+        const fooValue = await getAsync('foo');
+        console.log(fooValue);
+    };
+
+    runApplication();

--- a/content/rs/references/client_references/client_nodejs.md
+++ b/content/rs/references/client_references/client_nodejs.md
@@ -5,85 +5,106 @@ weight:
 alwaysopen: false
 categories: ["RS"]
 ---
-In order to use Redis with Node.js you need to install a Node.js Redis client. In the following sections, we demonstrate the use of [node_redis](https://github.com/NodeRedis/node_redis), a community recommended Redis client for Node.js. The other community recommended client for Node.js developers is [ioredis]().
+To use Redis with Node.js you need to install a Node.js Redis client.
+In this article, you can learn how to use [node_redis](https://github.com/NodeRedis/node_redis), a community recommended Redis client for Node.js.
 
-Additional Node.js clients for Redis can be found under the [Node.js section](https://redis.io/clients#Node.js) of the [Redis Clients page](https://redis.io/clients).
+The other community recommended client for Node.js developers is [ioredis](https://github.com/luin/ioredis).
+You can find other node.js clients for Redis in the [Node.js section](https://redis.io/clients#Node.js) of the [Redis Clients page](https://redis.io/clients).
 
 ## Installing node_redis
 
-Complete instructions for installing node_redis can be found in the [README file](https://github.com/NodeRedis/node_redis/blob/master/README.md). To install node_redis, issue the following command:
+To install node_redis, run:
 
     npm install redis 
 
+For more information about installing node_redis, read the [node_redis README file](https://github.com/NodeRedis/node_redis/blob/master/README.md).
+
 ## Connecting to Redis
+
+Here we cover a few ways that you can connect to Redis with different security considerations.
+
+### Connecting to Redis with the default password
 
 The following code creates a connection to Redis:
 
+    ```js
     const redis = require('redis');
     const client = redis.createClient({
-        host: 'hostname',
-        port: 6379,
-        password: 'password'
+        host: '<hostname>',
+        port: <port>,
+        password: '<password>'
     });
 
     client.on('error', err => {
         console.log('Error ' + err);
-    }); 
+    });
+    ```
 
-Make sure to replace the following values with those for your Redis instance:
+    Where you must provide:
 
-- `'hostname'` should be the name of the host your database runs on
-- `6379` is the default Redis port, change this if necessary
-- `'password'` should be the password you use to access Redis.  If a password is not required, remove this line.  Remember to always store passwords outside of your code, for example in environment variables
+    - `<hostname>` - The name of the host your database runs on
+    - `<port>` - The port that the database is running on (default: 6379)
+    - `<password>` - The password you use to access Redis, if necessary.
 
-## Connecting to Redis with TLS 
+    Remember to always store passwords outside of your code, for example in environment variables.
+
+### Connecting to Redis with TLS
 
 The following example demonstrates how to make a connection to Redis using TLS:
 
+    ```js
     const redis = require('redis');
     const fs = require('fs');
 
     const client = redis.createClient({
-        host: 'hostname',
-        port: 6379,
+        host: '<hostname>',
+        port: <port>,
         tls: {
             key: fs.readFileSync('path_to_keyfile', encoding='ascii'),
             cert: fs.readFileSync('path_to_certfile', encoding='ascii'),
             ca: [ fs.readFileSync('path_to_ca_certfile', encoding='ascii') ]
         }
     });
-    
-    ...
+    ```
 
-## Connecting to Redis using an ACL user and password
+    Where you must provide:
 
-Redis 6 introduced [Access Control Lists](https://redis.io/topics/acl).  ACLs provide the capability to create named user accounts, each having its own password.
+    - `<hostname>` - The name of the host your database runs on
+    - `<port>` - The port that the database is running on (default: 6379)
 
-node_redis doesn't currently support ACL commands, or the `AUTH` command with a username and password.  This means that you will need to disable the client's built in `auth` function and use the generic `send_command` function to authenticate.  `send_command` allows you to send any arbitrary command to Redis.
+### Connecting to Redis using an ACL user and password
+
+Redis 6 introduced [Access Control Lists](https://redis.io/topics/acl).
+ACLs provide the capability to create named user accounts, each having its own password.
+
+node_redis doesn't currently support ACL commands or the `AUTH` command with a username and password.
+This means that you have to disable the client's built in `auth` function and use the generic `send_command` function to authenticate.
+`send_command` allows you to send any arbitrary command to Redis.
 
 Example:
 
+    ```js
     const redis = require('redis');
     const client = redis.createClient({
         host: '127.0.0.1',
-        port: 6379
+        port: <port>
     });
 
     // Disable client's AUTH command.
     client['auth'] = null;
 
     // send_command expects a command name and array of parameters.
-    client.send_command('AUTH', ['username', 'password']);
+    client.send_command('AUTH', ['<username>', '<password>']);
+    ```
 
-You will need to replace `username` and `password` with the values for the ACL user that you are connecting as.
+    Where you must provide `<username>` and `<password>` with the values for the ACL user that you are connecting as.
 
 ## Reading and writing data with node_redis
 
-Once connected to Redis, you can start reading and writing data. The following code snippet writes the value `bar` to the Redis key `foo`, reads it back, and prints it:
+After your application connects to Redis, you can start reading and writing data.
+The following code snippet writes the value `bar` to the Redis key `foo`, reads it back, and prints it:
 
-    // Open a connection to Redis
-    ...
- 
+    ```js 
     client.set('foo', 'bar', (err, reply) => {
         if (err) throw err;
         console.log(reply);
@@ -93,19 +114,25 @@ Once connected to Redis, you can start reading and writing data. The following c
             console.log(reply);
         });
     });
+    ```
 
 The output of the above code should be:
 
+    ```sh
     $ node example_node_redis.js
     OK
     bar
+    ```
 
-node_redis exposes a function named for each Redis command.  These functions take string arguments, the first of which is almost always the Redis key to run the command against. These arguments are followed by an optional error first callback function.
+node_redis exposes a function named for each Redis command.
+These functions take string arguments, the first of which is almost always the Redis key to run the command against.
+These arguments are followed by an optional error first callback function.
 
-## Promises and async / await
+## Promises and async/await
 
-To use promises and async / await with node_redis, wrap it using [Bluebird's](https://www.npmjs.com/package/bluebird) `promisifyAll` like so:
+To use promises and async/await with node_redis, wrap it using [Bluebird's](https://www.npmjs.com/package/bluebird) `promisifyAll` as shown here:
 
+    ```js
     const redis = require('redis');
     const { promisifyAll } = require('bluebird');
 
@@ -121,11 +148,13 @@ To use promises and async / await with node_redis, wrap it using [Bluebird's](ht
     };
 
     runApplication();
+    ```
 
-This creates an async equivalent of each function, suffixing its name with `Async`.
+This creates an async equivalent of each function, adding `Async` as a suffix.
 
 Alternatively, you can promisify a subset of node_redis functions one at a time using native Node.js promises and `util.promisify`:
 
+    ```js
     const redis = require('redis');
     const { promisify } = require('util');
 
@@ -142,3 +171,4 @@ Alternatively, you can promisify a subset of node_redis functions one at a time 
     };
 
     runApplication();
+    ```

--- a/content/rs/references/client_references/client_nodejs.md
+++ b/content/rs/references/client_references/client_nodejs.md
@@ -5,7 +5,9 @@ weight:
 alwaysopen: false
 categories: ["RS"]
 ---
-In order to use Redis with Node.js you need to install a Node.js Redis client. In the following sections, we demonstrate the use of [node_redis](https://github.com/NodeRedis/node_redis), a complete Redis client for Node.js. Additional Node.js clients for Redis can be found under the [Node.js section](https://redis.io/clients#Node.js) of the [Redis Clients page](https://redis.io/clients).
+In order to use Redis with Node.js you need to install a Node.js Redis client. In the following sections, we demonstrate the use of [node_redis](https://github.com/NodeRedis/node_redis), a community recommended Redis client for Node.js. The other community recommended client for Node.js developers is [ioredis]().
+
+Additional Node.js clients for Redis can be found under the [Node.js section](https://redis.io/clients#Node.js) of the [Redis Clients page](https://redis.io/clients).
 
 ## Installing node_redis
 
@@ -82,16 +84,20 @@ Once connected to Redis, you can start reading and writing data. The following c
     // Open a connection to Redis
     ...
  
-    client.set('foo', 'bar'); 
-    client.get('foo', (err, reply) => {
+    client.set('foo', 'bar', (err, reply) => {
         if (err) throw err;
         console.log(reply);
+        
+        client.get('foo', (err, reply) => {
+            if (err) throw err;
+            console.log(reply);
+        });
     });
 
 The output of the above code should be:
 
     $ node example_node_redis.js
-    Connected to Redis
+    OK
     bar
 
 node_redis exposes a function named for each Redis command.  These functions take string arguments, the first of which is almost always the Redis key to run the command against. These arguments are followed by an optional error first callback function.


### PR DESCRIPTION
This pull request updates the `node_redis` client page for Node.js with the following additions and improvements:

* Generally overhauls the code to modern JavaScript, fixes previous syntax errors
* Adds section for using promises and async/await
* Adds section for connecting to Redis with an ACL user
* General tidy up of the prose

I propose to keep this page as is and open another pull request to add a second page as a sibling for it to cover the `ioredis` client... then have the first paragraph of this page reference `ioredis` as an alternative and the `ioredis` page reference this one as an alternative too... saves having a generic Node.js landing page I think?