### PR TITLE
Cache the no results document for queries with 0 results

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -118,21 +118,21 @@
             resolve([])
           })
           .done(function(data) {
-            setWithExpiry(url, data.results, THIRTY_SECONDS)
-
+            // Push a fake 'no results' document if there were no results.
             if (!data.results.length) {
-              // Push a fake 'no results' document.
               results = [{
                 title: "",
                 section_title: `No results found for "${trimmedInput}"`,
                 body: "",
                 hierarchy: ['']
               }]
-              resolve(results)
             }
             else {
-              resolve(data.results)
+              results = data.results
             }
+
+            setWithExpiry(url, results, THIRTY_SECONDS)
+            resolve(results)
           })
       })
     },


### PR DESCRIPTION
Currently, an empty result set is cached for queries with zero results. That means you'll see the 'no results' message once, but if you type the query a second time, you won't see the 'no results' message.

This change caches the fake document that powers the 'no results' message, so that you see it again if you type the same query.