### PR TITLE
Fix FT.CREATE example and add example for document scoring

### DIFF
--- a/content/embeds/tryout-redisearch-2.md
+++ b/content/embeds/tryout-redisearch-2.md
@@ -19,7 +19,8 @@ In this example, we have four fields: `title` (`TEXT`), `body` (`TEXT`), `url` 
 
     This command indexes all of the hashes with the prefix "`doc:`" as well as all the future ones that will be created with that prefix.
 
-    By default, all hashes get a score of 1.0, but we can configure that value through the `SCORE` directive. If we need to be able to assign document-specific score to documents, we can do that too. We only need to specify the name of the document element in which we will define the document score which will override the default. This is done by using the `SCORE_FIELD` directive.
+    By default, all hashes get a score of 1.0, but we can configure that value through the `SCORE` directive. If we need to assign a document-specific score to documents, we can do that too. 
+    We only need to specify the name of the document element in which we will define the document score which will override the default. This is done by using the `SCORE_FIELD` directive.
     
     In our example the default document score is `0.5` and we can have a document-specific score by setting a value between 0 and 1 in the  "`doc_score`" field of the hash.
 
@@ -47,7 +48,9 @@ Now add some data to this index. Here we add a hash with the key "`doc:1`" and t
 OK
 ```
 
-To add a document specific score, causing the document to appear higher or lower in results, set a value for the `doc_score` field, which we specified as the `SCORE_FIELD` in the schema definition:
+To add a document specific score, that causes the document to appear higher or lower in results, set a value for the `doc_score` field.
+We specified the `SCORE_FIELD` in the schema definition to hold the document weight value.
+
 ```sh
 127.0.0.1:12543> HSET doc:2 title "Redis Labs" body "Modules" url "<https://redislabs.com/modules>" visits 102 doc_score 0.8
 OK

--- a/content/embeds/tryout-redisearch-2.md
+++ b/content/embeds/tryout-redisearch-2.md
@@ -14,7 +14,7 @@ In this example, we have four fields: title (TEXT), body (TEXT), url (TEXT), an
 1. Create the schema:
 
     ```sh
-    127.0.0.1:12543> FT.CREATE database_idx PREFIX 1 "doc:" SCORE_FIELD "weight" SCHEMA title TEXT body TEXT url TEXT weight NUMERIC
+    127.0.0.1:12543> FT.CREATE database_idx PREFIX 1 "doc:" SCORE_FIELD "doc_weight" SCHEMA title TEXT body TEXT url TEXT doc_weight NUMERIC
     ```
 
     This command indexes all of the hashes with the prefix "doc:".
@@ -45,6 +45,13 @@ Now add some data to this index. Here we add a hash with the key
 127.0.0.1:12543> HSET doc:1 title "Redis Labs" body "primary and caching" url "<https://redislabs.com>" value 10
 OK
 ```
+
+To add a document specific score, set a value for the `doc_weight` field, which we specified as the `SCORE_FIELD` in the schema definition:
+```sh
+127.0.0.1:12543> HSET doc:2 title "Redis Labs" body "primary and caching" url "<https://redislabs.com>" value 10 doc_weight 2
+OK
+```
+
 
 ### Search the index
 

--- a/content/embeds/tryout-redisearch-2.md
+++ b/content/embeds/tryout-redisearch-2.md
@@ -17,7 +17,7 @@ In this example, we have four fields: `title` (`TEXT`), `body` (`TEXT`), `url` 
     127.0.0.1:12543> FT.CREATE database_idx PREFIX 1 "doc:" SCORE_FIELD "doc_weight" SCHEMA title TEXT body TEXT url TEXT visits NUMERIC
     ```
 
-    This command indexes all of the hashes with the prefix "`doc:`" as well as all the future ones that will be created.
+    This command indexes all of the hashes with the prefix "`doc:`" as well as all the future ones that will be created with that prefix.
 
     By default, all hashes get a score of 1.0, but if we need to be able to assign document-specific score to documents, we can do that too. We only need to specify in the schema the name of the hash element in which we will define the document score which will override the default of 1.0. This is done by using the `SCORE_FIELD` directive.
     In our example, `SCORE_FIELD` specifies a "`doc_weight`" field.
@@ -48,7 +48,7 @@ OK
 
 To add a document specific score, causing the document to appear higher or lower in results, set a value for the `doc_weight` field, which we specified as the `SCORE_FIELD` in the schema definition:
 ```sh
-127.0.0.1:12543> HSET doc:2 title "Redis Labs" body "Modules" url "<https://redislabs.com/modules>" visits 102 doc_weight 2
+127.0.0.1:12543> HSET doc:2 title "Redis Labs" body "Modules" url "<https://redislabs.com/modules>" visits 102 doc_weight 0.8
 OK
 ```
 

--- a/content/embeds/tryout-redisearch-2.md
+++ b/content/embeds/tryout-redisearch-2.md
@@ -14,13 +14,14 @@ In this example, we have four fields: `title` (`TEXT`), `body` (`TEXT`), `url` 
 2. Create the schema:
 
     ```sh
-    127.0.0.1:12543> FT.CREATE database_idx PREFIX 1 "doc:" SCORE_FIELD "doc_weight" SCHEMA title TEXT body TEXT url TEXT visits NUMERIC
+    127.0.0.1:12543> FT.CREATE database_idx PREFIX 1 "doc:" SCORE 0.5 SCORE_FIELD "doc_score" SCHEMA title TEXT body TEXT url TEXT visits NUMERIC
     ```
 
     This command indexes all of the hashes with the prefix "`doc:`" as well as all the future ones that will be created with that prefix.
 
-    By default, all hashes get a score of 1.0, but if we need to be able to assign document-specific score to documents, we can do that too. We only need to specify in the schema the name of the hash element in which we will define the document score which will override the default of 1.0. This is done by using the `SCORE_FIELD` directive.
-    In our example, `SCORE_FIELD` specifies a "`doc_weight`" field.
+    By default, all hashes get a score of 1.0, but we can configure that value through the `SCORE` directive. If we need to be able to assign document-specific score to documents, we can do that too. We only need to specify the name of the document element in which we will define the document score which will override the default. This is done by using the `SCORE_FIELD` directive.
+    
+    In our example the default document score is `0.5` and we can have a document-specific score by setting a value between 0 and 1 in the  "`doc_score`" field of the hash.
 
 {{< note >}}
 For databases in a Redis Cloud Essentials subscription, you need to add the index name to the document key as a tag to make sure that the index and the documents are located on the same shard:
@@ -46,9 +47,9 @@ Now add some data to this index. Here we add a hash with the key "`doc:1`" and t
 OK
 ```
 
-To add a document specific score, causing the document to appear higher or lower in results, set a value for the `doc_weight` field, which we specified as the `SCORE_FIELD` in the schema definition:
+To add a document specific score, causing the document to appear higher or lower in results, set a value for the `doc_score` field, which we specified as the `SCORE_FIELD` in the schema definition:
 ```sh
-127.0.0.1:12543> HSET doc:2 title "Redis Labs" body "Modules" url "<https://redislabs.com/modules>" visits 102 doc_weight 0.8
+127.0.0.1:12543> HSET doc:2 title "Redis Labs" body "Modules" url "<https://redislabs.com/modules>" visits 102 doc_score 0.8
 OK
 ```
 


### PR DESCRIPTION
Changing the score field name in the FT.CREATE example to something else than the reserved `WEIGHT`.
Currently, the following error is returned:

```
(error) Bad arguments for weight: Could not convert argument to expected type
```

Added an example for document scoring.