### PR TITLE
Disabled outdated doc on CRDB/Active-Active for K8s

### DIFF
--- a/content/platforms/openshift/getting-started-openshift-crdb.md
+++ b/content/platforms/openshift/getting-started-openshift-crdb.md
@@ -4,6 +4,7 @@ description:
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
+hidden: true
 ---
 In this guide, we'll set up an [Active-Active database]({{< relref "/rs/administering/designing-production/active-active.md" >}})
 (formerly known as CRDB) deployment with Active-Active replication


### PR DESCRIPTION
Removed outdated crdb/active-active document using the unsupported service broker