### PR TITLE
OS ports restriction recommendation

### DIFF
--- a/content/rs/installing-upgrading/_index.md
+++ b/content/rs/installing-upgrading/_index.md
@@ -63,7 +63,7 @@ sudo lsblk
     {{% /expand %}}
 
 - Make sure that the OS is not using ports in the [range that Redis assigns to databases]({{< relref "/rs/administering/designing-production/networking/port-configurations.md" >}}).
-    We recommend that you restrict the OS from using Redis ports range in `/etc/sysctl.conf` with `net.ipv4.ip_local_port_range = 30000 65535'.
+    We recommend that you restrict the OS from using Redis ports range in `/etc/sysctl.conf` with `net.ipv4.ip_local_port_range = 40000 65535'.
 
 ## Installing RS on Linux
 


### PR DESCRIPTION
Update recommended restriction for the ports used by the OS.
Due to RED-49152.
To start from 40k instead of 30k