### PR TITLE
Recover configuration for databases

### DIFF
--- a/content/rs/administering/troubleshooting/database-recovery.md
+++ b/content/rs/administering/troubleshooting/database-recovery.md
@@ -69,6 +69,7 @@ of the configuration and persistence files on each of the nodes.
 
     - To recover all of the databases, run: `rladmin recover all`
     - To recover a single databases, run: `rladmin recover db <database_id|name>`
+    - To recover only the database configuration without the data (in case AOF or snapshot files aren't available), run: `recover db only_configuration <db_name>`
 
     All databases are recovered with the same data that they had in the old cluster.
     The data is recovered from the persistence files located in the persistent storage drives


### PR DESCRIPTION
The option for recovering configuration appears only in the A-A description and missing for the regular DB section.
In addition, I think need to mention for A-A restore, to use the data recovery only on the cluster that has the most updated data.
Other participating clusters should be created with configuration only and sync from the cluster on which the data restored.
But need to discuss it with R&D