### PR TITLE
Verify bdb_egress description

### DIFF
--- a/content/rs/administering/monitoring-metrics/prometheus-metrics-definitions.md
+++ b/content/rs/administering/monitoring-metrics/prometheus-metrics-definitions.md
@@ -21,8 +21,8 @@ Here are the metrics available to Prometheus:
 | bdb_avg_write_latency | Average latency of write operations (seconds); returned only when there is traffic |
 | bdb_avg_write_latency_max | Highest value of average latency of write operations (seconds); returned only when there is traffic |
 | bdb_conns | Number of client connections to DB |
-| bdb_egress_bytes | Rate of outgoing network traffic to DB (bytes/sec) |
-| bdb_egress_bytes_max | Highest value of rate of outgoing network traffic to DB (bytes/sec) |
+| bdb_egress_bytes | Rate of outgoing network traffic from the DB (bytes/sec) |
+| bdb_egress_bytes_max | Highest value of rate of outgoing network traffic from the DB (bytes/sec) |
 | bdb_evicted_objects | Rate of key evictions from DB (evictions/sec) |
 | bdb_evicted_objects_max | Highest value of rate of key evictions from DB (evictions/sec) |
 | bdb_expired_objects | Rate keys expired in DB (expirations/sec) |


### PR DESCRIPTION
I think there's a typo in the description of 'bdb_egress_bytes' and 'bdb_egress_bytes_max'.
Since it's outgoing traffic, it would make sense that it's traffic from the DB and not to the DB.
Please verify first that my understanding is correct.