### PR TITLE
Proper directory for uninstall script

### DIFF
--- a/content/rs/installing-upgrading/uninstalling.md
+++ b/content/rs/installing-upgrading/uninstalling.md
@@ -8,10 +8,10 @@ aliases: /rs/administering/installing-upgrading/uninstalling/
 ---
 You can uninstall Redis Enterprise Software (RS) from a node to uninstall RS
 and remove the RS files.
-By default, the files are in: `/opt/redislabs`, `/etc/opt/redislabs`, `/var/opt/redislabs`
+By default, the files are located here: `/opt/redislabs/bin`
 
 To uninstall RS from a node, run:
 
 ```sh
-rl_uninstall.sh
+sudo ./rl_uninstall.sh
 ```


### PR DESCRIPTION
On the current docs, we show 3 options to find the uninstall script. The script is located in /opt/redislabs/bin and we should only provide 1 option for users to find this script