### PR TITLE
It is important to specify what is the image for the Bootstrapper

### DIFF
--- a/content/platforms/release-notes/k8s-6-0-8-20-2020-12.md
+++ b/content/platforms/release-notes/k8s-6-0-8-20-2020-12.md
@@ -22,7 +22,7 @@ To upgrade your deployment to this latest release, see ["Upgrading a Redis Enter
 ## Images
 This release includes the following container images:
  * **Redis Enterprise**: redislabs/redis:6.0.8-30 or redislabs/redis:6.0.8-30.rhel7-openshift
- * **Operator**: redislabs/operator:6.0.8-20
+ * **Operator (and Bootstrapper)**: redislabs/operator:6.0.8-20
  * **Services Rigger**: redislabs/k8s-controller:6.0.8-20 or redislabs/services-manager:6.0.8-20 (Red Hat registry)
 
 ## New features

--- a/content/platforms/release-notes/k8s-6-0-8-20-2020-12.md
+++ b/content/platforms/release-notes/k8s-6-0-8-20-2020-12.md
@@ -22,7 +22,7 @@ To upgrade your deployment to this latest release, see ["Upgrading a Redis Enter
 ## Images
 This release includes the following container images:
  * **Redis Enterprise**: redislabs/redis:6.0.8-30 or redislabs/redis:6.0.8-30.rhel7-openshift
- * **Operator (and Bootstrapper)**: redislabs/operator:6.0.8-20
+ * **Operator and Bootstrapper**: redislabs/operator:6.0.8-20
  * **Services Rigger**: redislabs/k8s-controller:6.0.8-20 or redislabs/services-manager:6.0.8-20 (Red Hat registry)
 
 ## New features


### PR DESCRIPTION
Customers who need to specify the Bootstrapper image in their YAML need to understand what that image is.