### PR TITLE
DOC-426 Fix cloud account creation script for Could API

### DIFF
--- a/static/code/rv/api/10-create-subscription.sh
+++ b/static/code/rv/api/10-create-subscription.sh
@@ -14,7 +14,7 @@ echo "TASK_ID=$TASK_ID"
 echo "Step 2: wait for processing completion"
 
 STATUS=received
-while [ "$STATUS" == "processing-in-progress" ] || [ "$STATUS" == "received" ]
+while [ "$STATUS" == "processing-in-progress" -o "$STATUS" == "received" ]
 do
     sleep 3 # seconds   
     STATUS=$(curl -s -X GET "https://$HOST/tasks/$TASK_ID" \

--- a/static/code/rv/api/50-create-cloud-account.sh
+++ b/static/code/rv/api/50-create-cloud-account.sh
@@ -15,7 +15,7 @@ echo "TASK_ID=$TASK_ID"
 echo "Step 2: wait for processing completion"
 
 STATUS=
-while [ "$STATUS" != 'processing-completed' ] || [ "$STATUS" != 'processing-error' ]
+while [ "$STATUS" != 'processing-completed' -a "$STATUS" != 'processing-error' ]
 do
     sleep 3 # seconds   
     STATUS=$(curl -s -X GET "https://$HOST/tasks/$TASK_ID" \


### PR DESCRIPTION
Corrected invalid scripting that used `||` as an 'or', which doesn't work for bash!