### PR TITLE
Add instructions to use Terraform to give Redis Labs access to setup RC in customer account

### DIFF
--- a/content/rc/how-to/view-edit-cloud-account.md
+++ b/content/rc/how-to/view-edit-cloud-account.md
@@ -13,6 +13,10 @@ so that we can take responsibility to make sure that the infrastructure is in op
 If you need to build your subscriptions in your own AWS accounts,
 we need to have access to your AWS account to help with monitoring, maintenance and technical support.
 
+Consider using the [terraform-aws-Redislabs-Cloud-Account-Resources](https://github.com/TobyHFerguson/terraform-aws-Redislabs-Cloud-Account-Resources) module to automate the entire multi-step process. 
+
+If you wish to do this manually, or to understand more deeply what the above module will accomplish, then read on:
+
 To provide us with secure authorization to access your AWS accounts, you need to:
 
 1. Create a programmatic user and provide us with the access key and secret access key for that user.


### PR DESCRIPTION
Added a terraform module which automates all of this work, leveraging the newly released RedisCloud Terraform provider.

This work is incomplete, in the sense that the module needs to be moved from my personal Github account to a RedisLabs account, but is otherwise functional and tested. Who needs to move this module across and exactly where they must move it to is something we need to figure out. 

Furthermore, the module includes the two policy files - it would be good to automate the updating of this module when those two files are themselves updated.