### PR TITLE
Fix reference to DB in rladmin command line

### DIFF
--- a/content/rs/concepts/data-access/persistence.md
+++ b/content/rs/concepts/data-access/persistence.md
@@ -104,5 +104,5 @@ case, you can disable data-persistence on the master shards using the
 following *rladmin* command:
 
 ```sh
-rladmin tune db <db_id_or_name> master_persistence disabled
+rladmin tune db <database_ID_or_name> master_persistence disabled
 ```

--- a/content/rs/concepts/data-access/persistence.md
+++ b/content/rs/concepts/data-access/persistence.md
@@ -104,5 +104,5 @@ case, you can disable data-persistence on the master shards using the
 following *rladmin* command:
 
 ```sh
-rladmin tune db db: master_persistence disabled
+rladmin tune db <db_id_or_name> master_persistence disabled
 ```


### PR DESCRIPTION
remove misleading reference to "db:" where DB name or ID is needed