### PR TITLE
add port 3343

### DIFF
--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -21,7 +21,7 @@ update your firewall with the port for that new database endpoint.
 |------------|-----------------|-----------------|-----------------|
 | ICMP | * | Internal | For connectivity checking between nodes |
 | TCP | 1968 | Internal | Proxy traffic |
-| TCP | 3333-3341, 3344, 36379, 36380 | Internal | Internode communication |
+| TCP | 3333-3341, 3343, 3344, 36379, 36380 | Internal | Internode communication |
 | TCP | 8001 | Internal, External | Traffic from application to RS [Discovery Service]({{< relref "/rs/concepts/data-access/discovery-service.md" >}}) |
 | TCP | 8002, 8004, 8006 | Internal | System health monitoring |
 | TCP | 8443 | Internal, External | Secure (HTTPS) access to the management web UI |


### PR DESCRIPTION
This port is used by envoy to push config changes and it is actively used but not mentioned. Thus this pull request

```
tcp        0      0 127.0.0.1:3343          0.0.0.0:*               LISTEN      112        27741      1707/envoy_control_ 
```