### PR TITLE
Use a friendly HTML escaping function

### DIFF
--- a/static/css/search.css
+++ b/static/css/search.css
@@ -37,8 +37,8 @@
   justify-content: space-between;
 }
 
-.autocomplete-result::last {
-  padding-bottom: 60px; /* height of powered-by-redisearch section */
+li:last-child {
+  padding-bottom: 80px !important; /* height of powered-by-redisearch section */
 }
 
 .search-root {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,6 +1,7 @@
 (function() {
 
   const SEARCH_API_URL = "https://search-service.redislabs.com/search"
+  const SEARCH_SITE = "https://docs.redislabs.com"
   const THIRTY_SECONDS = 30000
   const SEARCH_LOGO = '<a class="powered-by-redisearch" href="https://oss.redislabs.com/redisearch/"></a>'
 
@@ -58,7 +59,7 @@
 
     search: input => {
       const trimmedInput = input.trim()
-      const url = `${SEARCH_API_URL}?q=${trimmedInput}*`
+      const url = `${SEARCH_API_URL}?q=${trimmedInput}*&site=${SEARCH_SITE}`
 
       if (input.length === 0) {
         return []

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -10,6 +10,20 @@
     e.preventDefault()
   })
 
+  function escapeHtml(str) {
+    return str.replace(/[&<>"'\/]/g, function (s) {
+      var entityMap = {
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': '&quot;',
+          "'": '&#39;',
+          "/": '&#x2F;'
+        };
+
+      return entityMap[s];
+    });
+  }
 
   function setWithExpiry(key, value, ttl) {
     const now = new Date()
@@ -72,7 +86,7 @@
           .done(function(data) {
             // Push a fake 'no results' document if there were no results.
             if (!data.results.length) {
-              const safeInput = encodeURIComponent(trimmedInput).replaceAll("%22", '"').replaceAll("%20", " ")
+              const safeInput = escapeHtml(trimmedInput)
               results = [{
                 title: "",
                 section_title: `No results found for '${safeInput}'`,


### PR DESCRIPTION
Use a less aggressive mechanism for escaping unsafe HTML, so that we don't show users percent signs for new query syntax like `@`.

![image](https://user-images.githubusercontent.com/97182/106821446-06001a00-6632-11eb-947a-6fccbcd1f319.png)

After:

![image](https://user-images.githubusercontent.com/97182/106821496-1dd79e00-6632-11eb-9ab7-d5d19a51971d.png)
