### PR TITLE
Fix list CSS by scoping padding correctly

### DIFF
--- a/static/css/search.css
+++ b/static/css/search.css
@@ -37,7 +37,7 @@
   justify-content: space-between;
 }
 
-li:last-child {
+.autocomplete-result-list li:last-child {
   padding-bottom: 80px !important; /* height of powered-by-redisearch section */
 }
 


### PR DESCRIPTION
My last PR applied a `li:last-child` style without scoping it to a specific class, causing many list items to get extra padding. 😅 