### PR TITLE
Update to upgrade procedure

### DIFF
--- a/content/platforms/kubernetes/tasks/upgrading-with-operator.md
+++ b/content/platforms/kubernetes/tasks/upgrading-with-operator.md
@@ -22,6 +22,11 @@ You can download the bundle for the latest release by issuing the following `cur
 VERSION=`curl --silent https://api.github.com/repos/RedisLabs/redis-enterprise-k8s-docs/releases/latest | grep tag_name | awk -F'"' '{print $4}'`
 curl --silent -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/$VERSION/bundle.yaml
 ```
+For openshift environments, the name of the bundle is openshift.bundle.yaml, and so the curl command to run is:
+
+```
+curl --silent -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/$VERSION/openshift.bundle.yaml
+```
 
 If you need a different release, replace `VERSION` in the above with a specific release tag.
 
@@ -38,6 +43,12 @@ You can upgrade the bundle and operator with a single apply command, passing in 
 
 ```
 kubectl apply -f bundle.yaml
+```
+
+If you are using openshift, run this instead:
+
+```
+kubectl apply -f openshift.bundle.yaml
 ```
 
 After running this command, you should see a result similar to this:

--- a/content/platforms/kubernetes/tasks/upgrading-with-operator.md
+++ b/content/platforms/kubernetes/tasks/upgrading-with-operator.md
@@ -29,10 +29,10 @@ If you need a different release, replace `VERSION` in the above with a specific 
 
 Applying the bundle applies the changes made in the new release to custom resource definitions, roles, role binding, operator service account and deploys a new operator binary.
 
-    {{< note >}}
+{{< note >}}
 If you are not pulling images from Docker Hub, update the operator image spec to point to your private repository.
 If you have made changes to the role, role binding, rbac or crd in the previous version you must merge them with the updated declarations in the new version files.
-    {{< /note >}}
+{{< /note >}}
     
 You can upgrade the bundle and operator with a single apply command, passing in the bundle YAML file:
 


### PR DESCRIPTION
Introduced pulling a version tag rather than cloning the repo.
TODO: add a user check for valid upgrade paths