### PR TITLE
Update image shortcode to accept width parameter (and alt text).

### DIFF
--- a/content/rc/api/how-to/enable-your-account-to-use-api.md
+++ b/content/rc/api/how-to/enable-your-account-to-use-api.md
@@ -21,7 +21,7 @@ To enable the API:
 1. From the menu, choose **Settings**.
 1. In the **Account** tab, locate the **Cloud API Access Key** in the **Misc** section.
 
-    ![Cloud API Access Key setting in the Misc section of the Redis Cloud settings](/images/rc/settings-cloud-api-key.png)
+    {{<image filename="/images/rc/settings-cloud-api-key.png" width="75%" alt="Cloud API Access Key setting in the Misc section of the Redis Cloud settings" >}}{{< /image >}}
 
     If you do not see the **Cloud API Access Key** setting, verify that you're signed into a Flexible (or Annual) subscription and that you are an account owner.
 

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,5 +1,9 @@
+{{- $width :=  .Get "width" | default "75%" }}
 <a href="{{.Site.BaseURL}}{{.Page.Params.id}}/{{.Get "filename"}}" sdata-lightbox="{{.Get "filename"}}">
-	<img src="{{.Site.BaseURL}}{{.Page.Params.id}}/{{.Get "filename"}}" style="border:0px" {{ with .Get "width"}} width="{{.}}"{{ end }} {{ with .Get "align"}} align="{{.}}"{{ end }}/>
+	<img src="{{.Site.BaseURL}}{{.Page.Params.id}}/{{.Get "filename"}}" style="border:0px" 
+		 {{ with .Get "width" }} width="{{.}}"{{ end }} 
+		 {{ with .Get "align"}} align="{{.}}"{{ end }}
+		 {{ with .Get "alt"}} alt="{{.}}"{{ end }} />
 </a> 
 {{.Inner}}
 

--- a/static/tables/redisgraph-lifecycle.csv
+++ b/static/tables/redisgraph-lifecycle.csv
@@ -1,5 +1,5 @@
 Release Date,End of Life (EOL)
-2.2 – November 2020,-
-2.0 – January 2020, "November 30, 2021"
+2.2 – November 2020,"-"
+2.0 – January 2020,"November 30, 2021"
 1.2 – April 2019,"December 31, 2020"
 1.0 – November 2018,"May 31, 2020"


### PR DESCRIPTION
Extended the {{image}} shortcode to support a width parameter (and alt text).  This allows writers to control the size of the image displayed in content.

Here, the image is displayed at 75% original size.

(A future update will do this by default.)