### PR TITLE
Use production search index

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,7 +1,7 @@
 (function() {
 
   const SEARCH_API_URL = "https://search-service.redislabs.com/search"
-  const SEARCH_SITE = "https://docs.redislabs.com/staging/boost-current-section"
+  const SEARCH_SITE = "https://docs.redislabs.com/latest"
   const THIRTY_SECONDS = 30000
   const SEARCH_LOGO = '<a class="powered-by-redisearch" href="https://oss.redislabs.com/redisearch/"></a>'
 


### PR DESCRIPTION
The search frontend should pass the production site URL to target the right index. 