### PR TITLE
JIRA DOC-613: RS Getting Started doesn't show setting the DB port number

### DIFF
--- a/content/rs/getting-started/_index.md
+++ b/content/rs/getting-started/_index.md
@@ -74,11 +74,11 @@ To set up your machine as an RS cluster:
 
     ![Redis Enterprise Software create database](/images/rs/getstarted-newdatabase.png)
 
-1. Enter a database name such as `database1` and select **Show Advanced Options**.
+1. Enter a database name such as `database1` and then select **Show Advanced Options**.
 
     ![Redis Enterprise Software configure new database screen](/images/rs/getstarted-createdatabase.png)
 
-1. Select **Endpoint port number** and then enter `12000`.
+1. In **Endpoint port number**, enter `12000`.
 
 1. Select the **Activate** button to create your database.
 

--- a/content/rs/getting-started/_index.md
+++ b/content/rs/getting-started/_index.md
@@ -74,9 +74,13 @@ To set up your machine as an RS cluster:
 
     ![Redis Enterprise Software create database](/images/rs/getstarted-newdatabase.png)
 
-1. Enter a database name such as `database1` and click **Activate** to create your database.
+1. Enter a database name such as `database1` and select **Show Advanced Options**.
 
     ![Redis Enterprise Software configure new database screen](/images/rs/getstarted-createdatabase.png)
+
+1. Select **Endpoint port number** and then enter `12000`.
+
+1. Select the **Activate** button to create your database.
 
 You now have a Redis database!
 


### PR DESCRIPTION
Updating 'Creating a database' instructions to include setting the port number used in the next section.