### PR TITLE
Updated the python package to redis

### DIFF
--- a/content/rc/rc-quickstart.md
+++ b/content/rc/rc-quickstart.md
@@ -144,13 +144,13 @@ Here's how to connect to your database using a client for Python.
 1.  If you don't already have the client installed:
 
     ```sh
-    sudo pip install redis-client
+    sudo pip install redis
     ```
 
 2.  The specific syntax vries according to the client:
 
     ```python
-    import redis-client
+    import redis
     r = redis.Redis(host='<endpoint>', port=<port>, password='<password>')
     r.set('hello', 'world')
     print(r.get('hello'))


### PR DESCRIPTION
Updated the python package to redis from redis-client as redis-client no longer works.

redis-client is no longer available on pypi.

```
sudo pip install redis-client
Password:
ERROR: Could not find a version that satisfies the requirement redis-client
ERROR: No matching distribution found for redis-client

```

Updated the sample python client code to include the redis pypi package instead.
