### PR TITLE
fixed formatting and clarify image tag for upgrade

### DIFF
--- a/content/platforms/kubernetes/tasks/upgrading-with-operator.md
+++ b/content/platforms/kubernetes/tasks/upgrading-with-operator.md
@@ -79,7 +79,7 @@ redis-enterprise-operator   1/1     1            1           0m36s
 
 ### Upgrade the Redis Enterprise cluster version
 
-Before beginning the upgrade of the Redis Enterprise cluster version, check the Operator release notes to find the Redis Enterprise image tag. For example, in Operator release [6.0.12-5](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases/tag/v6.0.12-5), the Images section shows the Redis Enterprise tag is `6.0.12-57`.
+Before beginning the upgrade of the Redis Enterprise cluster version, check the K8s operator release notes to find the Redis Enterprise image tag. For example, in Redis Enterprise K8s operator release [6.0.12-5](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases/tag/v6.0.12-5), the `Images` section shows the Redis Enterprise tag is `6.0.12-57`.
 
 After the Operator upgrade is complete, you can upgrade Redis Enterprise cluster version using the following steps.
 

--- a/content/platforms/kubernetes/tasks/upgrading-with-operator.md
+++ b/content/platforms/kubernetes/tasks/upgrading-with-operator.md
@@ -79,14 +79,13 @@ redis-enterprise-operator   1/1     1            1           0m36s
 
 ### Upgrade the Redis Enterprise cluster version
 
-After the Operator upgrade is complete:
-    1. Run `kubectl edit rec` in the namespace your Redis Enterprise Cluster is deployed in.
-    1. Replace the `image:` declaration under `redisEnterpriseImageSpec` with the new version tag provided in the release documentation.
+Before beginning the upgrade of the Redis Enterprise cluster version, check the Operator release notes to find the Redis Enterprise image tag. For example, in Operator release [6.0.12-5](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases/tag/v6.0.12-5), the Images section shows the Redis Enterprise tag is `6.0.12-57`.
 
-    For example, in Operator release [5.4.10-8](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases/tag/5.4.10-8) the tag is `5.4.10-22` for the Ubuntu-based Redis Enterprise image.
+After the Operator upgrade is complete, you can upgrade Redis Enterprise cluster version using the following steps.
 
-    1. Save the changes.
-        If your default text editor is vim then enter `<ESC>:wq` to save the file.
+1. Run `kubectl edit rec` in the namespace your Redis Enterprise Cluster is deployed in.
+2. Replace the `image:` declaration under `redisEnterpriseImageSpec` with the new version tag you found in the Operator release notes.
+3. Save the changes to apply
 
 The rolling upgrade of the cluster nodes' statefulSet starts.
 

--- a/content/platforms/kubernetes/tasks/upgrading-with-operator.md
+++ b/content/platforms/kubernetes/tasks/upgrading-with-operator.md
@@ -83,7 +83,7 @@ Before beginning the upgrade of the Redis Enterprise cluster version, check the 
 
 After the Operator upgrade is complete, you can upgrade Redis Enterprise cluster version using the following steps.
 
-1. Run `kubectl edit rec` in the namespace your Redis Enterprise Cluster is deployed in.
+1. Run `kubectl edit rec` in the namespace your Redis Enterprise cluster is deployed in.
 2. Replace the `image:` declaration under `redisEnterpriseImageSpec` with the new version tag you found in the Operator release notes.
 3. Save the changes to apply
 

--- a/content/platforms/kubernetes/tasks/upgrading-with-operator.md
+++ b/content/platforms/kubernetes/tasks/upgrading-with-operator.md
@@ -84,7 +84,7 @@ Before beginning the upgrade of the Redis Enterprise cluster version, check the 
 After the Operator upgrade is complete, you can upgrade Redis Enterprise cluster version using the following steps.
 
 1. Run `kubectl edit rec` in the namespace your Redis Enterprise cluster is deployed in.
-2. Replace the `image:` declaration under `redisEnterpriseImageSpec` with the new version tag you found in the Operator release notes.
+2. Replace the `image:` declaration under `redisEnterpriseImageSpec` with the new version tag you found in the operator release notes.
 3. Save the changes to apply
 
 The rolling upgrade of the cluster nodes' statefulSet starts.


### PR DESCRIPTION
Formatting of list of steps for upgrade was broken, fixed that.
Clarified how to get the Redis Enterprise image tag using a newer version of Operator release notes. In addition, the old version linked to Redis Enterprise release notes which no longer exist, resulting in 404.