### PR TITLE
Update password-rotation.md

### DIFF
--- a/content/rs/administering/access-control/password-rotation.md
+++ b/content/rs/administering/access-control/password-rotation.md
@@ -1,5 +1,5 @@
 ---
-Title: Database password rotation
+Title: User password rotation
 description:
 weight: $weight
 alwaysopen: false

--- a/content/rs/administering/access-control/password-rotation.md
+++ b/content/rs/administering/access-control/password-rotation.md
@@ -1,30 +1,35 @@
 ---
-Title: Database Password Rotation
+Title: Database password rotation
 description:
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
 ---
-Most organizational security policies require periodic password rotation.
-Redis Enterprise Software lets you implement these policies using its API.
-Specifically, you can add a new password for a database user without immediately invalidating the old one (which might cause authentication errors in production).
 
-For user access to the RS Admin Console,
-you can set a [password expiration policy]({{< relref "/rs/administering/access-control/_index.md#setting-local-user-password-expiration" >}}) that prompts the user to change their password.
+Redis Enterprise Software lets you implement password rotation policies using its API.
+
+You can add a new password for a database user without immediately invalidating the old one (which might cause authentication errors in production).
+
+{{note}}
+Password rotation does not work for the default user. [Add additional users]({{< relref "/rs/security/passwords-users-roles.md#adding-users" >}}) to enable password rotation.
+{{/note}}
+
+For user access to the Redis Enterprise Software admin console,
+you can set a [password expiration policy]({{< relref "/rs/security/admin-console-security/user-security.md#enabling-password-expiration" >}}) to prompt the user to change their password.
 However, for database connections that rely on password authentication,
 you need to allow for authentication with the existing password while you roll out the new password to your systems.
 
-With the RS REST API, you can add additional passwords to a user account for authentication to the database or the Admin Console and API.
+With the Redis Enterprise Software REST API, you can add additional passwords to a user account for authentication to the database or the admin console and API.
 After the old password is replaced in the database connections,
 just delete the old password to finish the password rotation process.
 
 {{< warning >}}
 Multiple passwords are only supported using the REST API.
-If you reset the password for a user in the RS Admin Console,
+If you reset the password for a user in the admin console,
 the new password replaces all other passwords for that user.
 {{< /warning >}}
 
-The new password cannot already exist as a password for the user and must meet the [password complexity]({{< relref "/rs/administering/access-control/_index.md#setting-up-local-password-complexity" >}}) requirements, if enabled.
+The new password cannot already exist as a password for the user and must meet the [password complexity]({{< relref "/rs/security/admin-console-security/user-security.md#enabling-the-password-complexity-profile" >}}) requirements, if enabled.
 
 ## Rotating the password of a user account
 

--- a/content/rs/administering/access-control/password-rotation.md
+++ b/content/rs/administering/access-control/password-rotation.md
@@ -14,7 +14,7 @@ you can set a [password expiration policy]({{< relref "/rs/administering/access-
 However, for database connections that rely on password authentication,
 you need to allow for authentication with the existing password while you roll out the new password to your systems.
 
-With the RS REST API, you can add additional passwords to an user account for authentication to the database or the Admin Console and API.
+With the RS REST API, you can add additional passwords to a user account for authentication to the database or the Admin Console and API.
 After the old password is replaced in the database connections,
 just delete the old password to finish the password rotation process.
 
@@ -30,16 +30,10 @@ The new password cannot already exist as a password for the user and must meet t
 
 To rotate the password of a user account:
 
-1. Add an additional password to an user account with this POST command:
+1. Add an additional password to a user account with this POST command:
 
     ```sh
-    curl -k -v -X POST -H "content-type: application/json" -u "<administrator_user>:<password>"
-        https://<RS_server_address>:9443/v1/users/password
-        -d '{
-        "username":"<username>",
-        "old_password":"<an_existing_password>",
-        "new_password":"<a_new_password>"
-        }'
+    curl -k -v -X POST -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}' https://<RS_server_address>:9443/v1/users/password
     ```
 
     After you run this command, you can authenticate with both the old and the new password.
@@ -48,12 +42,7 @@ To rotate the password of a user account:
 1. Delete the original password with this DELETE command:
 
 ```sh
-curl -k -v -X DELETE -H "content-type: application/json" -u "<administrator_user>:<password>"
-    https://<RS_server_address>:9443/v1/users/password
-    -d '{
-    "username":"<username>",
-    "old_password":"<an_existing_password>"
-    }'
+curl -k -v -X DELETE -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>"}' https://<RS_server_address>:9443/v1/users/password
 ```
 
 If there is only one valid password for a user account, you cannot delete that password.
@@ -66,13 +55,7 @@ This can be helpful if you suspect that your passwords are compromised and you w
 To replace all existing passwords for a user account with a single new password, use this PUT command:
 
 ```sh
-curl -k -v -X PUT -H "content-type: application/json" -u "<administrator_user>:<password>"
-    https://<RS_server_address>:9443/v1/users/password
-    -d '{
-    "username":"<username>",
-    "old_password":"<an_existing_password>",
-    "new_password":"<a_new_password>"
-    }'
+curl -k -v -X PUT -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}' https://<RS_server_address>:9443/v1/users/password
 ```
 
 All of the existing passwords are deleted and only the new password is valid.


### PR DESCRIPTION
Few issues on this page:
1. It doesn't seem like it will work on the database default access so there's a pre-requisite of adding custom users through ACLs to the database before you can add/rotate passwords. We should either mention that condition as a note/comment or include steps to a user/redirect to the ACLs page.
2. The API commands are broken to new lines and if a customer copies them as is, they won't work. It has to be a single line (I did the modification).
3. Fixed a minor typo ('an user' to 'a user' in two places).
4. Document title is 'Database Password Rotation' but it actually applies to all users, UI and Database and not only Database. We should consider renaming it but this is minor.