### PR TITLE
Jira-DOC-700: RC: "Manage subscriptions" page: "Delete subscription" link doesn't work.

### DIFF
--- a/content/rc/subscriptions/_index.md
+++ b/content/rc/subscriptions/_index.md
@@ -62,6 +62,6 @@ View subscription details:
 
 - View [Flexible subscription]({{<relref "/rc/subscriptions/view-flexible-subscription.md">}})
 
-- [Delete a subscription](({{<relref "/rc/subscriptions/delete-subscription.md">}})
-)
+- [Delete a subscription]({{<relref "/rc/subscriptions/delete-subscription.md">}})
+
 


### PR DESCRIPTION
There was an extra set of parentheses in the source doc; these have been removed.