### PR TITLE
Added a note about the /v2/module endpoint for RS

### DIFF
--- a/content/modules/add-module-to-cluster.md
+++ b/content/modules/add-module-to-cluster.md
@@ -34,7 +34,7 @@ You can add a module to your cluster using:
 - The REST API - For all modules, but modules with dependencies must use the `/v2/modules` endpoint.
 
 ```sh
-**Note:** The /v2/modules endpoint only exists for RS v6.0.12 and above. If you are on an older RS version, you must perform a manual installation of the module and it's dependencies 
+**Note:** The /v2/modules endpoint only exists for Redis Enterprise Software v6.0.12 and above. If you are on an older version, you must perform a manual installation of the module and its dependencies 
 Example: [Installing RedisGears](https://docs.redislabs.com/latest/modules/redisgears/installing-redisgears/)
 ```
 

--- a/content/modules/add-module-to-cluster.md
+++ b/content/modules/add-module-to-cluster.md
@@ -32,6 +32,12 @@ To get the latest features and fixes for a module, you must upgrade the module i
 You can add a module to your cluster using:
 
 - The REST API - For all modules, but modules with dependencies must use the `/v2/modules` endpoint.
+
+```sh
+**Note:** The /v2/modules endpoint only exists for RS v6.0.12 and above. If you are on an older RS version, you must perform a manual installation of the module and it's dependencies 
+Example: [Installing RedisGears](https://docs.redislabs.com/latest/modules/redisgears/installing-redisgears/)
+```
+
 - The admin console - For modules without dependencies, such as RedisGraph.
 
 ### Adding a module using the REST API


### PR DESCRIPTION
There is no explanation that the v2/module endpoint only exists for RS v6.0.12 and above. I added clarification to this when adding a module via the REST API