### PR TITLE
Add remark for envoy replacement

### DIFF
--- a/content/rs/installing-upgrading/upgrading.md
+++ b/content/rs/installing-upgrading/upgrading.md
@@ -33,6 +33,8 @@ Using features from the newer version before all nodes are upgraded can produce 
 
 {{< /warning >}}
 
+NOTE to be added
+
 ## Upgrading a node
 
 Upgrading the software on a node requires installing the [RS installation


### PR DESCRIPTION
We Need to add a note or remark. On upgrade from version 5.X to 6.X, the default web server application was changed from nginx to envoy.
If any software is monitoring or allowing nginx, it should be updated to allow envoy.
We detected sp,e  software that was blocking envoy to listen to the required ports, such as TrendMicro Deep security,  dynatrace, and more.