### PR TITLE
Update redisearch-2.0-release-notes.md

### DIFF
--- a/content/modules/redisearch/release-notes/redisearch-2.0-release-notes.md
+++ b/content/modules/redisearch/release-notes/redisearch-2.0-release-notes.md
@@ -5,11 +5,53 @@ weight: 95
 alwaysopen: false
 categories: ["Modules"]
 ---
-## RediSearch 2.0.6 (February, 2020)
+## RediSearch 2.0.9 (May, 2021)
 
 This is a maintenance release for version 2.0.
 
 Details:
+
+- Bug fix in RSCoordinator:
+    - #[259](https://github.com/RediSearch/RSCoordinator/pull/259): Fix deadlock on cursor read by performing cursor command on background thread
+
+## RediSearch 2.0.8 (May, 2021)
+
+This is a maintenance release for version 2.0.
+
+Details:
+
+- Bug fixes:
+    - #[1959](https://github.com/redisearch/redisearch/issues/1959) Renamed parse_time() to parsetime()
+    - #[1932](https://github.com/redisearch/redisearch/issues/1932) Fixed crash resulted from LIMIT arguments
+    - #[1919](https://github.com/redisearch/redisearch/issues/1919) Prevent GC fork from crashing
+- Minor enhancements:
+    - #[1880](https://github.com/redisearch/redisearch/issues/1880) Optimisation of intersect iterator
+    - #[1914](https://github.com/redisearch/redisearch/issues/1914) Do not return payload as a field
+
+## RediSearch 2.0.7 (May, 2021)
+
+This is a maintenance release for version 2.0.
+
+Details:
+
+- Major enhancements:
+    - #[1864](https://github.com/redisearch/redisearch/issues/1864) Improve query time by predetermining reply array length.
+    - #[1879](https://github.com/redisearch/redisearch/issues/1879) Improve loading time by calling RM_ScanKey instead of RM_Call
+- Major bug fix:
+    - #[1866](https://github.com/redisearch/redisearch/issues/1866) Fix a linking issue causing incompatibility with Redis 6.2.0.
+    - #[1842](https://github.com/redisearch/redisearch/issues/1842) #1852 Fix macOS build.
+- Minor bug fixes:
+    - #[1850](https://github.com/redisearch/redisearch/issues/1850) Fix a race condition on drop temporary index.
+    - #[1855](https://github.com/redisearch/redisearch/issues/1855) Fix a binary payload corruption.
+    - #[1876](https://github.com/redisearch/redisearch/issues/1876) Fix crash if the depth of the reply array is larger than 7.
+    - #[1843](https://github.com/redisearch/redisearch/issues/1843) #[1860](https://github.com/redisearch/redisearch/issues/1860) Fix low-level API issues.
+
+## RediSearch 2.0.6 (February, 2021)
+
+This is a maintenance release for version 2.0.
+
+Details:
+
 - Minor additions:
     - #[1696](https://github.com/redisearch/redisearch/issues/1696) The maximum number of results produced by `FT.AGGREGATE` is now configurable: [`MAXAGGREGATERESULTS`](https://oss.redislabs.com/redisearch/2.0/Configuring/#maxaggregateresults).
     - #[1708](https://github.com/redisearch/redisearch/issues/1708) [Stemming](https://oss.redislabs.com/redisearch/2.0/Stemming/#stemming_support) updated with support of new languages: Basque, Catalan, Greek, Indonesian, Irish, Lithuanian, Nepali.


### PR DESCRIPTION
Add missing release notes for v2.0.7, v2.0.8, v2.0.9