### PR TITLE
Cipher configuration

### DIFF
--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -164,7 +164,6 @@ After you set the minimum TLS version, RS does not accept communications with
 TLS versions older than the specified version.
 
 ### Cipher configuration
-need to fix below
 
 {{<note>}}
 Redis Enterprise Software doesn't support Diffie–Hellman key exchange (`DHE-`) ciphers.

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -166,7 +166,7 @@ TLS versions older than the specified version.
 ### Cipher configuration
 need to fix below
 
-{note}
+{{<note>}}
 Redis Enterprise Software doesn't support Diffie–Hellman key exchange (`DHE-`) ciphers.
 {/note}
 

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -167,6 +167,7 @@ TLS versions older than the specified version.
 
 {{<note>}}
 Redis Enterprise Software doesn't support Diffie–Hellman key exchange (`DHE-`) ciphers.
+{{</note>}}
 {/note}
 
 #### Control plane cipher suite configuration (for 6.0.8 or earlier)

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -168,7 +168,6 @@ TLS versions older than the specified version.
 {{<note>}}
 Redis Enterprise Software doesn't support Diffie–Hellman key exchange (`DHE-`) ciphers.
 {{</note>}}
-{/note}
 
 #### Control plane cipher suite configuration (for 6.0.8 or earlier)
 

--- a/content/rs/administering/cluster-operations/updating-certificates.md
+++ b/content/rs/administering/cluster-operations/updating-certificates.md
@@ -164,6 +164,7 @@ After you set the minimum TLS version, RS does not accept communications with
 TLS versions older than the specified version.
 
 ### Cipher configuration
+need to fix below
 
 {note}
 Redis Enterprise Software doesn't support Diffie–Hellman key exchange (`DHE-`) ciphers.


### PR DESCRIPTION
It's not showing as a note

{note}
Redis Enterprise Software doesn't support Diffie–Hellman key exchange (`DHE-`) ciphers.
{/note}