### PR TITLE
Jira DOC-683: Openshift link on main site generates a 404

### DIFF
--- a/content/platforms/kubernetes/getting-started/openshift/_index.md
+++ b/content/platforms/kubernetes/getting-started/openshift/_index.md
@@ -7,6 +7,10 @@ alwaysopen: false
 categories: ["Platforms"]
 aliases: /rs/getting-started/getting-started-kubernetes/k8s-openshift/
          /platforms/openshift/
+         /platforms/kubernetes/getting-started/openshift/getting-started-openshift-crdb/
+         /platforms/kubernetes/getting-started/openshift/getting-started-openshift-crdb.md
+         /platforms/openshift/getting-started-openshift-crdb/
+         /platforms/openshift/getting-started-openshift-crdb.md
 ---
 
 Redis Enterprise is supported on OpenShift Kubernetes cluster deployments via

--- a/content/platforms/kubernetes/getting-started/openshift/getting-started-openshift-crdb.md
+++ b/content/platforms/kubernetes/getting-started/openshift/getting-started-openshift-crdb.md
@@ -5,6 +5,7 @@ weight: $weight
 alwaysopen: false
 categories: ["RS"]
 hidden: true
+draft: true
 ---
 In this guide, we'll set up an [Active-Active database]({{< relref "/rs/administering/designing-production/active-active.md" >}})
 (formerly known as CRDB) deployment with Active-Active replication


### PR DESCRIPTION
Adding redirects to manage the 404 error, which was caused when the previous content was hidden, rather than being updated.