### PR TITLE
Updated release notes around CVE-2021-32625

### DIFF
--- a/content/rs/release-notes/rs-6-0-20-april-2021.md
+++ b/content/rs/release-notes/rs-6-0-20-april-2021.md
@@ -224,7 +224,6 @@ with 6.0.20-69
     
 #### Security
 
--   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement `LCS`. Additional information about opensource Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases/tag/6.2.4)
+-   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement `LCS`. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases/tag/6.2.4)
  
-
 

--- a/content/rs/release-notes/rs-6-0-20-april-2021.md
+++ b/content/rs/release-notes/rs-6-0-20-april-2021.md
@@ -224,6 +224,6 @@ with 6.0.20-69
     
 #### Security
 
--   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement `LCS`. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases/tag/6.2.4)
+-   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement `LCS`. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.4, Redis 6.0.14)
  
 

--- a/content/rs/release-notes/rs-6-0-20-april-2021.md
+++ b/content/rs/release-notes/rs-6-0-20-april-2021.md
@@ -221,3 +221,10 @@ with 6.0.20-69
 
 -   Starting from RS 5.4.2 and after upgrading the CRDB, TYPE commands for
     string data-type in CRDBs return "string" (OSS Redis standard).
+    
+#### Security
+
+-   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement `LCS`. Additional information about opensource Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases/tag/6.2.4)
+ 
+
+


### PR DESCRIPTION
Added note to reflect that Redis Enterprise isn't impacted by the found and fixed CVE on Redis opensource.
@K-Jo @AlonMagrafta FYI.