### PR TITLE
replication backlogs update

### DIFF
--- a/content/rs/administering/database-operations/updating-configurations.md
+++ b/content/rs/administering/database-operations/updating-configurations.md
@@ -60,26 +60,51 @@ If a participating cluster that was removed forcefully returns attempts to re-jo
 it will have an out of date on Active-Active database membership.
 The joined participating clusters reject updates sent from the removed participating cluster.
 
-## Replication backlog
+## Database replication backlog
 
-Active-Active and Active-Passive databases maintain a replication backlog to synchronize the database instances between clusters.
-By default, the replication backlog is set to one percent (1%) of the database size and ranges between 1MB to 250MB per shard.
-Use the [crdb-cli]({{< relref "rs/references/crdb-cli-reference.md" >}}) and the [rladmin]({{< relref "rs/references/rladmin.md" >}}) utilities to control the size of the replication backlog. You can set it to `auto` or set a specific size.  
+Redis databases that use [replication for high availability]({{< relref "rs/concepts/high-availability/replication.md" >}}) maintain a replication backlog (per shard) to synchronize the primary and replica shards of a database.
+By default, the replication backlog is set to one percent (1%) of the database size divided by the database number of shards and ranges between 1MB to 250MB per shard.
+Use the [rladmin]({{< relref "rs/references/rladmin.md" >}}) and the [crdb-cli]({{< relref "rs/references/crdb-cli-reference.md" >}}) utilities to control the size of the replication backlog. You can set it to `auto` or set a specific size.  
 
-The syntax varies between Active-Active and Active-Passive databases. 
+The syntax varies between regular and Active-Active databases. 
+
+For a regular Redis database:
+```text
+rladmin tune db <db:id | name> repl_backlog <Backlog size in MB or 'auto'>
+```
 
 For an Active-Active database:
 ```text
-crdb-cli crdb update --crdb-guid <crdb_guid> --default-db-config "{\"crdt_repl_backlog_size\": <SIZE_IN_BYTES | 'auto'>}"
+crdb-cli crdb update --crdb-guid <crdb_guid> --default-db-config "{\"repl_backlog_size\": <size in MB | 'auto'>}"
 ```
+
+## Active-Active CRDT replication backlog
+
+In addition to the database replication backlog, Active-Active databases maintain a CRDT replication backlog (per shard) to synchronize the database instances between clusters.
+By default, the CRDT replication backlog is set to one percent (1%) of the Active-Active database size divided by the database number of shards and ranges between 1MB to 250MB per shard.
+Use the [crdb-cli]({{< relref "rs/references/crdb-cli-reference.md" >}}) utility to control the size of the CRDT replication backlog. You can set it to `auto` or set a specific size:  
+
+```text
+crdb-cli crdb update --crdb-guid <crdb_guid> --default-db-config "{\"crdt_repl_backlog_size\": <size in MB | 'auto'>}"
+```
+
+## Active-Passive replication backlog
+
+In addition to the database replication backlog, Active-Passive databases maintain a replication backlog (per shard) to synchronize the database instances between clusters.
+By default, the replication backlog is set to one percent (1%) of the database size divided by the database number of shards and ranges between 1MB to 250MB per shard.
+Use the [rladmin]({{< relref "rs/references/rladmin.md" >}}) utility to control the size of the replication backlog. You can set it to `auto` or set a specific size.  
 
 For an Active-Passive database:
 ```text
 rladmin tune db <db:id | name> repl_backlog <Backlog size in MB or 'auto'>
 ```
 
+    {{< note >}}
+On an Active-Passive database, the replication backlog configuration applies to both the replication backlog for shards synchronization and for synchronization of database instances between clusters.
+    {{< /note >}}
+
 **For Redis Software versions earlier than 6.0.20:**
-The replication backlog defaults to 1MB and cannot be set dynamically with 'auto' mode.
+The replication backlog and the CRDT replication backlog defaults are set to 1MB and cannot be set dynamically with 'auto' mode.
 To control the size of the replication log, use [rladmin]({{< relref "rs/references/rladmin.md" >}}) to tune the local database instance in each cluster.
 ```text
 rladmin tune db <db:id | name> repl_backlog <Backlog size in MB (or if ending with bytes, KB or GB, in the respective unit)>


### PR DESCRIPTION
@kaitlynmichael @lanceleonard
1. Happy to get another review now :) Thanks
2. What do you think about moving all these "replication backlogs" to be under [concepts / high availability] instead of here? and maybe reference from here to there? my "cons" for this move is that this is "DB configuration" section which makes more sense.