### PR TITLE
Need to add a very important note about images version tag

### DIFF
--- a/content/platforms/kubernetes/concepts/managing-images.md
+++ b/content/platforms/kubernetes/concepts/managing-images.md
@@ -24,7 +24,7 @@ For security reasons (e.g., in air-gapped environments), you may want to pull th
 from a public registry once and then push them to a private registry under
 your control.
 
-{{ % warning %}}It is very important that the images you are pushing to the private registry have the same exact version tag as the original images. {{% /warning %}}
+{{ < warning >}}It is very important that the images you are pushing to the private registry have the same exact version tag as the original images. {{< /warning >}}
 
 Furthermore, because [Docker now rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
 you may want to consider pulling images from a

--- a/content/platforms/kubernetes/concepts/managing-images.md
+++ b/content/platforms/kubernetes/concepts/managing-images.md
@@ -24,7 +24,7 @@ For security reasons (e.g., in air-gapped environments), you may want to pull th
 from a public registry once and then push them to a private registry under
 your control.
 
-{{ < warning >}}It is very important that the images you are pushing to the private registry have the same exact version tag as the original images. {{< /warning >}}
+{{<warning>}}It is very important that the images you are pushing to the private registry have the same exact version tag as the original images. {{</warning>}}
 
 Furthermore, because [Docker now rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
 you may want to consider pulling images from a

--- a/content/platforms/kubernetes/concepts/managing-images.md
+++ b/content/platforms/kubernetes/concepts/managing-images.md
@@ -24,7 +24,7 @@ For security reasons (e.g., in air-gapped environments), you may want to pull th
 from a public registry once and then push them to a private registry under
 your control.
 
-**Note:** It is very important that the images you are pushing to the private registry have the same exact version tag than the original images.
+{{ % warning %}}It is very important that the images you are pushing to the private registry have the same exact version tag as the original images. {{% /warning %}}
 
 Furthermore, because [Docker now rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
 you may want to consider pulling images from a

--- a/content/platforms/kubernetes/concepts/managing-images.md
+++ b/content/platforms/kubernetes/concepts/managing-images.md
@@ -22,7 +22,11 @@ undecorated reference to `redislabs/redis` will likely pull from DockerHub
 
 For security reasons (e.g., in air-gapped environments), you may want to pull the images
 from a public registry once and then push them to a private registry under
-your control.  Furthermore, because [Docker now rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
+your control.
+
+**Note:** It is very important that the images you are pushing to the private registry have the same exact version tag than the original images.
+
+Furthermore, because [Docker now rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
 you may want to consider pulling images from a
 private registry to avoid deployment failures when you hit your DockerHub rate limit.
 


### PR DESCRIPTION
I am not sure where to add this or how to make it as a "warning note", but it is very important that customers will use the exact same version tags as the ones we have on dockerhub. This might apply only to the main RS image, and not the others, but better make this a good practice.
We have has multiple customer issues because they used version tags that were custom and that the operator could not parse.