### PR TITLE
 HTTP to HTTPS redirection

### DIFF
--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -79,4 +79,4 @@ After you disable HTTP support, traffic sent to the unencrypted API endpoint is 
 
 ## HTTP to HTTPS redirection
 Starting with version 6.0.12, the automatic HTTP to HTTPS redirection is disabled.
-To poll metrics from the metrics_exporter, or to access the web UI (the CM), use HTTPS in your request, as HTTP requests won't be automatically redirected to HTTPS for those services. 
+To poll metrics from the `metrics_exporter` or to access the admin console, use HTTPS in your request. HTTP requests won't be automatically redirected to HTTPS for those services. 

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -78,5 +78,5 @@ After you disable HTTP support, traffic sent to the unencrypted API endpoint is 
 
 
 ## HTTP to HTTPS redirection
-Starting version 6.0.12, the automatic HTTP to HTTPS redirection is disabled.
+Starting with version 6.0.12, the automatic HTTP to HTTPS redirection is disabled.
 To poll metrics from the metrics_exporter, or to access the web UI (the CM), use HTTPS in your request, as HTTP requests won't be automatically redirected to HTTPS for those services. 

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -79,4 +79,4 @@ After you disable HTTP support, traffic sent to the unencrypted API endpoint is 
 
 ## HTTP to HTTPS redirection
 Starting version 6.0.12, the automatic HTTP to HTTPS redirection is disabled.
-To pull metrics from the metrics_exporter, or to access the web UI (the CM), use HTTPS in your request, as HTTP requests won't be automatically redirected to HTTPS for those services. 
+To poll metrics from the metrics_exporter, or to access the web UI (the CM), use HTTPS in your request, as HTTP requests won't be automatically redirected to HTTPS for those services. 

--- a/content/rs/administering/designing-production/networking/port-configurations.md
+++ b/content/rs/administering/designing-production/networking/port-configurations.md
@@ -76,3 +76,7 @@ rladmin cluster config http_support disabled
 
 After you disable HTTP support, traffic sent to the unencrypted API endpoint is blocked.
 
+
+## HTTP to HTTPS redirection
+Starting version 6.0.12, the automatic HTTP to HTTPS redirection is disabled.
+To pull metrics from the metrics_exporter, or to access the web UI (the CM), use HTTPS in your request, as HTTP requests won't be automatically redirected to HTTPS for those services. 


### PR DESCRIPTION
@lanceleonard @kaitlynmichael if I can kindly ask you to review me.
@guyco-redis FYI and thanks!
This is how Guy described it: (for more context)

> Starting version 6.0.12, automatic HTTP to HTTPS redirection is disabled.
> This means that if you want to poll metrics from metrics exporter, or access the CM, you’ll need to explicitly use https in your request, instead of relying on the RS old mechanism that automatically redirected all http requests to https for these services.