### PR TITLE
Update crdb-cli-reference.md

### DIFF
--- a/content/rs/references/crdb-cli-reference.md
+++ b/content/rs/references/crdb-cli-reference.md
@@ -251,6 +251,9 @@ When you add an instance to an Active-Active database, you must specify:
 |`crdb-guid <CRDB-GUID>`| string| The ID of the Active-Active database that you want to add the instance to|
 |`instance fqdn=<cluster_fqdn>,username=<username>,password=<password>`| strings| The connection information for the participating cluster that will host the new instance|
 
+The `crdb add-instance` command supports several additional options:
+<ADD OPTIONS>
+
 ### Removing an instance from an Active-Active database {#removing-an-instance-from-an-activeactive-database}
 
 The `remove-instance` command deletes all data from an Active-Active instance, deletes the instance from the participating cluster, and removes the instance from the list of instances for the Active-Active database.


### PR DESCRIPTION
The 'Adding an instance' section only includes a table of mandatory parameters but there are also optional parameters that can be added but are not mentioned.
For example: URL & replication_endpoint.

Here's a syntax example:
crdb-cli crdb add-instance --crdb-guid <GUID> --instance fqdn=<FQDN>,username=<USER>,password=<PASSWORD>,url=https://<FQDN>:9443,replication_endpoint=<FQDN>

Similar to the 'additional options' we provided in the 'crdb create' section, we should have something similar in the 'Adding an instance' section with an explanation of the optional parameters.

I only marked the place we should add the options in the page as I'm not aware of all the options.
Need R&D help here. Marked with:
============================================
The `crdb add-instance` command supports several additional options:
<ADD OPTIONS>
============================================