### PR TITLE
Jira DOC-677: RS replace hard-coded internal URLs in release notes

### DIFF
--- a/content/rs/release-notes/legacy-release-notes/rs-5-2-2-august-2018.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-2-2-august-2018.md
@@ -5,6 +5,8 @@ description:
 weight: 89
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-2-2-august-2018/
+         /rs/release-notes/rs-5-2-2-august-2018.md
 ---
 Redis Enterprise Software (RS) 5.2.2 is now available.
 

--- a/content/rs/release-notes/legacy-release-notes/rs-5-2-june-2018.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-2-june-2018.md
@@ -5,6 +5,8 @@ description:
 weight: 91
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-2-june-2018/
+         /rs/release-notes/rs-5-2-june-2018.md
 ---
 Redis Enterprise Software (RS) 5.2 is now available. Key features
 include new data types and Causal Consistency for active-active (also

--- a/content/rs/release-notes/legacy-release-notes/rs-5-3-beta-july-2018.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-3-beta-july-2018.md
@@ -5,6 +5,8 @@ description:
 weight: 90
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-3-beta-july-2018/
+         /rs/release-notes/rs-5-3-beta-july-2018.md
 ---
 Redis Enterprise Software (RS) 5.3 is now available.
 

--- a/content/rs/release-notes/legacy-release-notes/rs-5-4-10-december-2019.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-4-10-december-2019.md
@@ -5,6 +5,8 @@ description:
 weight: 83
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-4-10-december-2019/
+         /rs/release-notes/rs-5-4-10-december-2019.md
 ---
 
 [Redis Enterprise Software (RS) 5.4.10](https://redislabs.com/redis-enterprise/software/downloads/#downloads) is now available.
@@ -12,7 +14,7 @@ This release includes an improved synchronization mechanism for Active-Active Re
 
 ## Overview
 
-Follow these [instructions](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/) for upgrading to RS 5.4.10 from RS 5.0 and above.
+Follow these [instructions]({{<relref "/rs/installing-upgrading/upgrading.md">}}) for upgrading to RS 5.4.10 from RS 5.0 and above.
 
 ## New features
 
@@ -52,7 +54,7 @@ If you see this error, upgrade to OpenSSL 1.0.2 or higher before you install RS.
 
 ## Information
 
-- End of Life (EOL) for Redis Enterprise Software 5.4, as well as for Redis Modules and previous RS versions, can be found [here](https://docs.redislabs.com/latest/rs/administering/product-lifecycle/).
+- End of Life (EOL) for Redis Enterprise Software 5.4, as well as for Redis Modules and previous RS versions, can be found [here]({{<relref "/rs/administering/product-lifecycle.md">}}).
 - Google Chrome browser on macOS Catalina requires self-signed certificate generated after June 2019 to include the extendedKeyUsage field in order to connect to the RS admin console.
     If you use a self-signed certificate that does not include this field, [update the self-signed certificate]({{< relref "/rs/administering/cluster-operations/updating-certificates.md" >}}).
 - When you upgrade an Active-Active Redis with active AOF from version RS 5.4.2 or lower to version RS 5.4.4 or higher:

--- a/content/rs/release-notes/legacy-release-notes/rs-5-4-14-february-2020.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-4-14-february-2020.md
@@ -5,6 +5,8 @@ description:
 weight: 82
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-4-14-february-2020/
+         /rs/release-notes/rs-5-4-14-february-2020.md
 ---
 [Redis Enterprise Software (RS) 5.4.14](https://redislabs.com/redis-enterprise/software/downloads/#downloads) is now available.
 This release bundles OSS Redis 5.0.7 and includes new Redis Modules versions, several enhancements, and bug fixes.
@@ -61,7 +63,7 @@ Follow these [instructions]({{< relref "/rs/installing-upgrading/upgrading.md" >
 
 ## Information
 
-- End of Life (EOL) for Redis Enterprise Software 5.4, as well as for Redis Modules and previous RS versions, can be found [here](https://docs.redislabs.com/latest/rs/administering/product-lifecycle).
+- End of Life (EOL) for Redis Enterprise Software 5.4, as well as for Redis Modules and previous RS versions, can be found [here]({{<relref "/rs/administering/product-lifecycle.md">}}).
 - Google Chrome browser on macOS Catalina requires self-signed certificate generated after June 2019 to include the extendedKeyUsage field in order to connect to the RS admin console.
     If you use a self-signed certificate that does not include this field, [update the self-signed certificate]({{< relref "/rs/administering/cluster-operations/updating-certificates.md" >}}).
 - When you upgrade an Active-Active Redis with active AOF from version RS 5.4.2 or lower to version RS 5.4.4 or higher:

--- a/content/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md
@@ -5,6 +5,8 @@ description:
 weight: 86
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-4-2-april-2019/
+         /rs/release-notes/rs-5-4-2-april-2019.md
 ---
 [Redis Enterprise Software (RS) 5.4.2](https://redislabs.com/redis-enterprise/software/downloads/#downloads) is now available.
 This release improves the compatibility of Active-Active Redis (CRDB) with open source Redis, adds SFTP and Mount Points as backup destinations, email alerting and a number of other enhancements and bug fixes.

--- a/content/rs/release-notes/legacy-release-notes/rs-5-4-4-june-2019.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-4-4-june-2019.md
@@ -5,6 +5,8 @@ description:
 weight: 85
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-4-4-june-2019/
+         /rs/release-notes/rs-5-4-4-june-2019.md
 ---
 Redis Enterprise Software (RS) 5.4.4 is now available.
 This release enables the functionality of Active-Active Redis (CRDB) combined with RoF (Redis on Flash),
@@ -91,8 +93,8 @@ You can also upgrade the modules with the REST API.
 
 ### Upgrade
 
-- [RS 5.4.2](https://docs.redislabs.com/latestrs/release-notes/legacy-release-notes/rs-5-4-2-april-2019/) introduced new Active-Active Redis (CRDB) capabilities that improve its compatibility with open source Redis. Now the string data-type in CRDB is implicitly and dynamically typed, just like open source Redis. To use the new capabilities on nodes that are upgraded from version RS 5.4.2 or lower, you must [upgrade the CRDB protocol](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/#upgrading-crdbs).
-- Before you upgrade a database with RediSearch Module to Redis 5.0, you must [upgrade the RediSearch Module](https://docs.redislabs.com/latest/rs/developing/modules/upgrading/) to version 1.4.2 or above.
+- [RS 5.4.2]({{<relref "rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}}) introduced new Active-Active Redis (CRDB) capabilities that improve its compatibility with open source Redis. Now the string data-type in CRDB is implicitly and dynamically typed, just like open source Redis. To use the new capabilities on nodes that are upgraded from version RS 5.4.2 or lower, you must [upgrade the CRDB protocol]({{<relref "/rs/installing-upgrading/upgrading#upgrading-crdbs">}}).
+- Before you upgrade a database with RediSearch Module to Redis 5.0, you must [upgrade the RediSearch Module]({{<relref "/rs/developing/modules/upgrading/_index.md">}}) to version 1.4.2 or above.
 - Node upgrade fails if the SSL certificates were configured in version 5.0.2 or above by manually updating the certificates on the disk instead of [updating them through the API]({{< relref "/rs/administering/cluster-operations/updating-certificates.md" >}}). For assistance with this issue, [contact Redis Labs support](https://redislabs.com/company/support/).
 - We recommend that you test module upgrade commands in a test environment before you upgrade modules in a production environment. The module upgrade arguments are not validated during the upgrade process and incorrect arguments can cause unexpected downtime.
 - Starting from RS 5.4.2, to preserve the current Redis major.minor version during database upgrade you must use the `keep_redis_version` option instead of `keep_current_version`.

--- a/content/rs/release-notes/legacy-release-notes/rs-5-4-6-july-2019.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-4-6-july-2019.md
@@ -5,6 +5,8 @@ description:
 weight: 84
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-4-6-july-2019/
+         /rs/release-notes/rs-5-4-6-july-2019.md
 ---
 
 [Redis Enterprise Software (RS) 5.4.6](https://redislabs.com/redis-enterprise/software/downloads/#downloads) is now available.

--- a/content/rs/release-notes/legacy-release-notes/rs-5-4-december-2018.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-4-december-2018.md
@@ -5,6 +5,8 @@ description:
 weight: 88
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-4-december-2018/
+         /rs/release-notes/rs-5-4-december-2018.md
 ---
 Redis Enterprise Software (RS) 5.4 is now available. RS 5.4 adds support for Redis 5.0 (GA) with the new Redis Streams data type.
 

--- a/content/rs/release-notes/rs-6-0-12-january-2021.md
+++ b/content/rs/release-notes/rs-6-0-12-january-2021.md
@@ -9,12 +9,12 @@ categories: ["RS"]
 [Redis Enterprise Software (RS) 6.0.12](https://redislabs.com/download-center/#downloads) is now available!
 This version includes the following new features and improvements:
 
-- [Synchronization](https://docs.redislabs.com/latest/rs/administering/designing-production/active-active/#syncer-process) can now be [distributed across the nodes](https://docs.redislabs.com/latest/rs/administering/cluster-operations/synchronization-mode/) of Active-Active or Active-Passive databases
-- You can [disable several internal RS services](https://docs.redislabs.com/latest/rs/administering/troubleshooting/disabling-services/) to free up more memory
-- User accounts can have multiple passwords to allow for [password rotation](https://docs.redislabs.com/latest/rs/administering/access-control/password-rotation/)
-- [Dependencies are automatically installed](https://docs.redislabs.com/latest/modules/add-module-to-cluster/#adding-a-module-using-the-rest-api) when you add modules to a cluster
-- [Envoy replaces NGINX](https://docs.redislabs.com/latest/rs/administering/designing-production/networking/port-configurations/) for internal cluster administration
-- Automatic recovery of the [syncer process](https://docs.redislabs.com/latest/rs/administering/designing-production/active-active/#syncer-process) from out-of-memory (preview mode)
+- [Synchronization]({{<relref "/rs/administering/designing-production/active-active#syncer-process">}}) can now be [distributed across the nodes]({{<relref "/rs/administering/cluster-operations/synchronization-mode.md">}}) of Active-Active or Active-Passive databases
+- You can [disable several internal RS services]({{<relref "/rs/administering/troubleshooting/disabling-services.md">}}) to free up more memory
+- User accounts can have multiple passwords to allow for [password rotation]({{<relref "/rs/administering/access-control/password-rotation.md">}})
+- [Dependencies are automatically installed]({{<relref "/modules/add-module-to-cluster#adding-a-module-using-the-rest-api">}}) when you add modules to a cluster
+- [Envoy replaces NGINX]({{<relref "/rs/administering/designing-production/networking/port-configurations.md">}}) for internal cluster administration
+- Automatic recovery of the [syncer process]({{<relref "/rs/administering/designing-production/active-active#syncer-process">}}) from out-of-memory (preview mode)
 
 And other functional and stability improvements.
 
@@ -22,13 +22,13 @@ And other functional and stability improvements.
 
 #### Upgrade instructions
 
-- Follow [these instructions](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/) for upgrading to RS 6.0.12 from RS 5.4.0 and above.
-- For Active-Active deployments, this release requires that you [upgrade the CRDB featureset version](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/#upgrading-activeactive-databases).
+- Follow [these instructions]({{<relref "/rs/installing-upgrading/upgrading.md">}}) for upgrading to RS 6.0.12 from RS 5.4.0 and above.
+- For Active-Active deployments, this release requires that you [upgrade the CRDB featureset version]({{<relref "/rs/installing-upgrading/upgrading#upgrading-activeactive-databases">}}).
 
 #### Product lifecycle information
 
-- End of Life (EOL) for Redis Enterprise Software 6.0 and previous RS versions, can be found [here](https://docs.redislabs.com/latest/rs/administering/product-lifecycle/).
-- EOL for Redis modules can be found [here](https://docs.redislabs.com/latest/modules/modules-lifecycle/#modules-endoflife-schedule).
+- End of Life (EOL) for Redis Enterprise Software 6.0 and previous RS versions, can be found [here]({{<relref "/rs/administering/product-lifecycle.md">}}).
+- EOL for Redis modules can be found [here]({{<relref "/modules/modules-lifecycle#modules-endoflife-schedule">}}).
 
 #### Deprecation Notice
 
@@ -41,11 +41,11 @@ And other functional and stability improvements.
 
 #### Distributed Syncer
 
-The syncer process now supports running in a [distributed mode](https://docs.redislabs.com/latest/rs/administering/cluster-operations/synchronization-mode/). This option can improve the latency for Active-Active databases with a very high throughput profile. You can configure a replicated database to use distributed synchronization so that any available proxy endpoint can manage synchronization traffic.
+The syncer process now supports running in a [distributed mode]({{<relref "/rs/administering/cluster-operations/synchronization-mode.md">}}). This option can improve the latency for Active-Active databases with a very high throughput profile. You can configure a replicated database to use distributed synchronization so that any available proxy endpoint can manage synchronization traffic.
 
 #### Disabling RS services to free memory
 
-Redis Software users can now use the REST API to [disable the following services](https://docs.redislabs.com/latest/rs/administering/troubleshooting/disabling-services/):
+Redis Software users can now use the REST API to [disable the following services]({{<relref "/rs/administering/troubleshooting/disabling-services.md">}}):
 
 - cm_server
 - mdns_server
@@ -69,7 +69,7 @@ For users of Redis 6 and RS 6.0 and above, you can now add more security to your
 As of RS 6.0, you can assign specific data access permissions (Redis ACLs) and cluster administration permissions to users.
 Password rotation is especially helpful so that you can do a rolling update of the passwords in the application clients that connect to the Redis databases.
 
-In this version, you can only configure multiple passwords [using the REST API](https://docs.redislabs.com/latest/rs/administering/access-control/password-rotation/).
+In this version, you can only configure multiple passwords [using the REST API]({{<relref "/rs/administering/access-control/password-rotation.md">}}).
 
 #### Redis Modules dependencies management
 
@@ -105,13 +105,13 @@ The syncer process restarts to with automatic recovery on.
 
 The following GA releases of Redis modules are bundled with RS 6.0.12:
 
-- [RediSearch](https://redislabs.com/redis-enterprise/redis-search/), version [2.0.6](https://docs.redislabs.com/latest/modules/redisearch/release-notes/redisearch-2.0-release-notes/)
-- [RedisJSON](https://redislabs.com/redis-enterprise/redis-json/), version [1.0.4](https://docs.redislabs.com/latest/modules/redisjson/release-notes/redisjson-1.0-release-notes/)
-- [RedisGraph](https://redislabs.com/redis-enterprise/redis-graph/), version [2.2.11](https://docs.redislabs.com/latest/modules/redisgraph/release-notes/)
-- [RedisTimeSeries](https://redislabs.com/redis-enterprise/redis-time-series/), version [1.4.7](https://docs.redislabs.com/latest/modules/redistimeseries/release-notes/)
-- [RedisBloom](https://redislabs.com/redis-enterprise/redis-bloom/), version [2.2.4](https://docs.redislabs.com/latest/modules/redisbloom/release-notes/redisbloom-2.2-release-notes/)
+- [RediSearch](https://redislabs.com/redis-enterprise/redis-search/), version [2.0.6]({{<relref "/modules/redisearch/release-notes/redisearch-2.0-release-notes.md">}})
+- [RedisJSON](https://redislabs.com/redis-enterprise/redis-json/), version [1.0.4]({{<relref "/modules/redisjson/release-notes/redisjson-1.0-release-notes.md">}})
+- [RedisGraph](https://redislabs.com/redis-enterprise/redis-graph/), version [2.2.11]({{<relref "/modules/redisgraph/release-notes/_index.md">}})
+- [RedisTimeSeries](https://redislabs.com/redis-enterprise/redis-time-series/), version [1.4.7]({{<relref "/modules/redistimeseries/release-notes/_index.md">}})
+- [RedisBloom](https://redislabs.com/redis-enterprise/redis-bloom/), version [2.2.4]({{<relref "/modules/redisbloom/release-notes/redisbloom-2.2-release-notes.md">}})
 
-To use the updated modules with a database, you must [upgrade the module on the database](https://docs.redislabs.com/latest/modules/upgrading-rs/#upgrading-the-module-for-the-database).
+To use the updated modules with a database, you must [upgrade the module on the database]({{<relref "/modules/add-module-to-cluster#upgrading-the-module-for-the-database">}}).
 
 ### Additional capabilities
 
@@ -139,12 +139,12 @@ with 6.0.12-58:
 
 #### Upgrade
 
-- [RS 5.4.2](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-2-april-2019/) introduced new Active-Active Redis Database capabilities that improve its compatibility with open source Redis. Now the string data-type in Active-Active Redis Database is implicitly and dynamically typed, just like open source Redis. To use the new capabilities on nodes that are upgraded from version RS 5.4.2 or lower, you must [upgrade the Active-Active Redis Database protocol](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/#upgrading-crdbs).
-- When you upgrade an Active-Active Redis with active AOF from version [RS 5.4.2](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-2-april-2019/) or earlier to version [RS 5.4.4](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-4-june-2019/) or later:
+- [RS 5.4.2]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}}) introduced new Active-Active Redis Database capabilities that improve its compatibility with open source Redis. Now the string data-type in Active-Active Redis Database is implicitly and dynamically typed, just like open source Redis. To use the new capabilities on nodes that are upgraded from version RS 5.4.2 or lower, you must [upgrade the Active-Active Redis Database protocol]({{<relref "/rs/installing-upgrading/upgrading#upgrading-crdbs">}}).
+- When you upgrade an Active-Active Redis with active AOF from version [RS 5.4.2]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}}) or earlier to version [RS 5.4.4]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-4-june-2019.md">}}) or later:
     - If replication is enabled, you must run the BGREWRITEAOF command on all slave shards after the upgrade.
     - If replication is not enabled, you must run the BGREWRITEAOF command on all shards after the upgrade.
-- Node upgrade fails if the SSL certificates were configured in version 5.0.2 or above by manually updating the certificates on the disk instead of [updating them through the API](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/). For assistance with this issue, contact Support.
-- Starting from [RS 5.4.2](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-2-april-2019/), to preserve the current Redis major.minor version during database upgrade you must use the keep_redis_version option instead of keep_current_version.
+- Node upgrade fails if the SSL certificates were configured in version 5.0.2 or above by manually updating the certificates on the disk instead of [updating them through the API]({{<relref "/rs/administering/cluster-operations/updating-certificates.md">}}). For assistance with this issue, contact Support.
+- Starting from [RS 5.4.2]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}}), to preserve the current Redis major.minor version during database upgrade you must use the keep_redis_version option instead of keep_current_version.
 
 #### Redis commands
 

--- a/content/rs/release-notes/rs-6-0-20-april-2021.md
+++ b/content/rs/release-notes/rs-6-0-20-april-2021.md
@@ -10,25 +10,25 @@ categories: ["RS"]
 is now available! This version includes the following new features and
 improvements:
 
--   A [new integration for LDAP](https://docs.redislabs.com/latest/rs/security/ldap/) authentication and
+-   A [new integration for LDAP]({{<relref "/rs/security/ldap/_index.md">}}) authentication and
     authorization into RS role-based access controls (RBAC). You can now use
     LDAP to authorize access to the admin console and to authorize database
     access.
 
--   An enhanced [clients mutual authentication](https://docs.redislabs.com/latest/rs/security/tls-ssl/)
+-   An enhanced [clients mutual authentication]({{<relref "/rs/security/tls-ssl.md">}})
     mechanism, adding the ability to authenticate client connections using a
     Certificate Authority (CA).
 
 -   Support of [Redis eviction
-    policies](https://docs.redislabs.com/latest/rs/administering/database-operations/eviction-policy/)
+    policies]({{<relref "/rs/administering/database-operations/eviction-policy.md">}})
     on
-    [Active-Active](https://docs.redislabs.com/latest/rs/administering/creating-databases/create-active-active/)
+    [Active-Active]({{<relref "/rs/administering/creating-databases/create-active-active.md">}})
     Redis databases.
 
--   A new [migration process for Active-Active](https://docs.redislabs.com/latest/rs/administering/database-operations/migrate-to-active-active/)
+-   A new [migration process for Active-Active]({{<relref "/rs/administering/database-operations/migrate-to-active-active.md">}})
     Redis database using the Active-Passive (Replica Of) mechanism.
 
--   Support for the [BITFIELD data type on Active-Active](https://docs.redislabs.com/latest/rs/references/developing-for-active-active/developing-strings-active-active/)
+-   Support for the [BITFIELD data type on Active-Active]({{<relref "/rs/references/developing-for-active-active/developing-strings-active-active.md">}})
     Redis databases.
 
 And other functional and stability improvements.
@@ -37,12 +37,12 @@ And other functional and stability improvements.
 
 #### Upgrade instructions
 
--   Follow [these instructions](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/)
+-   Follow [these instructions]({{<relref "/rs/installing-upgrading/upgrading.md">}})
     for upgrading to Redis Software 6.0.20 from Redis Software 5.6.0 and above.
 
     -   Note that upgrades from earlier Redis Software versions are not supported.
 
--   For Active-Active deployments, this release requires that you [upgrade the CRDB featureset version](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/#upgrading-activeactive-databases).
+-   For Active-Active deployments, this release requires that you [upgrade the CRDB featureset version]({{<relref "/rs/installing-upgrading/upgrading#upgrading-activeactive-databases">}}).
 
 -   Upgrades of Active-Active databases to Redis Software 6.0.20, will require all their
     instances to run with protocol version 1 and featureset version 1 or above.
@@ -53,10 +53,10 @@ And other functional and stability improvements.
 
 -   End of Life (EOL) for Redis Enterprise Software 6.0 and earlier 
     versions, can be found
-    [here](https://docs.redislabs.com/latest/rs/administering/product-lifecycle/).
+    [here]({{<relref "/rs/administering/product-lifecycle.md">}}).
 
 -   EOL for Redis modules can be found
-    [here](https://docs.redislabs.com/latest/modules/modules-lifecycle/#modules-endoflife-schedule).
+    [here]({{<relref "/modules/modules-lifecycle#modules-endoflife-schedule">}}).
 
 #### Deprecation Notice
 
@@ -86,7 +86,7 @@ without the need to load new certificates to your database.
 
 #### Redis eviction policies on Active-Active Redis databases
 
-All [Redis eviction policies](https://docs.redislabs.com/latest/rs/administering/database-operations/eviction-policy/)
+All [Redis eviction policies]({{<relref "/rs/administering/database-operations/eviction-policy.md">}})
 are now supported on Active-Active Redis databases. You can create new
 Active-Active databases or edit existing ones using the UI console to enable it.
 
@@ -96,13 +96,13 @@ Active-Active databases or edit existing ones using the UI console to enable it.
 #### Migration to an Active-Active Redis database
 
 Redis Enterprise Software adds the ability to easily [migrate your Redis
-database to an Active-Active](https://docs.redislabs.com/latest/rs/administering/database-operations/migrate-to-active-active/)
+database to an Active-Active]({{<relref "/rs/administering/database-operations/migrate-to-active-active.md">}})
 Redis database using the Active-Passive (Replica Of) mechanism.
 
 #### BITFIELD on Active-Active Redis databases
 
 Redis Enterprise Software adds the ability to use the BITFIELD data type on
-Active-Active Redis databases. Please read more about [developing for Active-Active with BITFIELD](https://docs.redislabs.com/latest/rs/references/developing-for-active-active/developing-strings-active-active/)
+Active-Active Redis databases. Please read more about [developing for Active-Active with BITFIELD]({{<relref "/rs/references/developing-for-active-active/developing-strings-active-active.md">}})
 to understand the conflict resolution and limitations.
 
 ## Redis modules
@@ -111,23 +111,23 @@ The following GA releases of Redis modules are bundled with Redis Software 6.0.2
 (Please read the below updates for 6.0.20-97)
 
 -   [RediSearch](https://redislabs.com/redis-enterprise/redis-search/), version
-    [2.0.6](https://docs.redislabs.com/latest/modules/redisearch/release-notes/redisearch-2.0-release-notes/)
+    [2.0.6]({{<relref "/modules/redisearch/release-notes/redisearch-2.0-release-notes.md">}})
 
 -   [RedisJSON](https://redislabs.com/redis-enterprise/redis-json/), version
-    [1.0.7](https://docs.redislabs.com/latest/modules/redisjson/release-notes/redisjson-1.0-release-notes/)
+    [1.0.7]({{<relref "/modules/redisjson/release-notes/redisjson-1.0-release-notes.md">}})
 
 -   [RedisGraph](https://redislabs.com/redis-enterprise/redis-graph/), version
-    [2.2.14](https://docs.redislabs.com/latest/modules/redisgraph/release-notes/)
+    [2.2.14]({{<relref "/modules/redisgraph/release-notes/redisgraph-2.2-release-notes.md">}})
 
 -   [RedisTimeSeries](https://redislabs.com/redis-enterprise/redis-time-series/),
     version
-    [1.4.8](https://docs.redislabs.com/latest/modules/redistimeseries/release-notes/redistimeseries-1.4-release-notes/)
+    [1.4.8]({{<relref "/modules/redistimeseries/release-notes/redistimeseries-1.4-release-notes.md">}})
 
 -   [RedisBloom](https://redislabs.com/redis-enterprise/redis-bloom/), version
-    [2.2.4](https://docs.redislabs.com/latest/modules/redisbloom/release-notes/redisbloom-2.2-release-notes/)
+    [2.2.4]({{<relref "/modules/redisbloom/release-notes/redisbloom-2.2-release-notes.md">}})
 
 To use the updated modules with a database, you must [upgrade the module on the
-database](https://docs.redislabs.com/latest/modules/upgrading-rs/#upgrading-the-module-for-the-database).
+database]({{<relref "/modules/add-module-to-cluster#upgrading-the-module-for-the-database">}}).
 
 ## Additional capabilities
 
@@ -146,9 +146,9 @@ database](https://docs.redislabs.com/latest/modules/upgrading-rs/#upgrading-the-
 -   Starting with Redis Software 6.0.20, new clusters will be set with minimal TLS version v1.2
 
 
-All known bugs around setting ciphers were fixed.  To learn more, see [Updating certificates](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/#cipher-configuration).
+All known bugs around setting ciphers were fixed.  To learn more, see [Updating certificates]({{<relref "/rs/administering/cluster-operations/updating-certificates#cipher-configuration">}}).
 
--   Starting with Redis Software 6.0.20, the [syncer process](https://docs.redislabs.com/latest/rs/administering/designing-production/active-active/#syncer-process)
+-   Starting with Redis Software 6.0.20, the [syncer process]({{<relref "/rs/administering/designing-production/active-active#syncer-process">}})
     was improved to automatically recover and resume synchronisation after
     reaching out-of-memory.
 
@@ -199,16 +199,16 @@ All known bugs around setting ciphers were fixed.  To learn more, see [Updating 
 
 #### Upgrade
 
--   [Redis Software 5.4.2](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-2-april-2019/)
+-   [Redis Software 5.4.2]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}})
     introduced new Active-Active Redis Database capabilities that improve its
     compatibility with open source Redis. Now the string data-type in
     Active-Active Redis Database is implicitly and dynamically typed, just like
     open source Redis. To use the new capabilities on nodes that are upgraded
     from version RS 5.4.2 or lower, you must 
-    [upgrade the Active-Active Redis Database protocol](https://docs.redislabs.com/latest/rs/installing-upgrading/upgrading/#upgrading-crdbs).
+    [upgrade the Active-Active Redis Database protocol]({{<relref "/rs/installing-upgrading/upgrading#upgrading-crdbs">}}).
 
--   When you upgrade an Active-Active Redis with active AOF from [Redis Software 5.4.2](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-2-april-2019/)
-    or earlier to version [Redis Software 5.4.4](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-4-june-2019/)
+-   When you upgrade an Active-Active Redis with active AOF from [Redis Software 5.4.2]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}})
+    or earlier to version [Redis Software 5.4.4]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-4-june-2019.md">}})
     or later:
 
     -   If replication is enabled, you must run the BGREWRITEAOF command on all
@@ -219,10 +219,10 @@ All known bugs around setting ciphers were fixed.  To learn more, see [Updating 
 
 -   Node upgrade fails if the SSL certificates were configured in version 5.0.2
     or above by manually updating the certificates on the disk instead of
-    [updating them through the API](https://docs.redislabs.com/latest/rs/administering/cluster-operations/updating-certificates/).
+    [updating them through the API]({{<relref "/rs/administering/cluster-operations/updating-certificates.md">}}).
     For help with this issue, contact Support.
 
--   Starting from [Redis Software 5.4.2](https://docs.redislabs.com/latest/rs/release-notes/rs-5-4-2-april-2019/),
+-   Starting from [Redis Software 5.4.2]({{<relref "/rs/release-notes/legacy-release-notes/rs-5-4-2-april-2019.md">}}),
     to preserve the current Redis major.minor version during database upgrade
     you must use the keep_redis_version option instead of keep_current_version.
 

--- a/content/rs/release-notes/rs-6-0-8-september-2020.md
+++ b/content/rs/release-notes/rs-6-0-8-september-2020.md
@@ -33,9 +33,9 @@ For more information about Redis 6.0.5, check out the [release notes](https://ra
 
 ### Upgrading Redis modules via rladmin
 
-The [rladmin CLI](https://docs.redislabs.com/latest/rs/references/rladmin/) introduces several updates to the commands for upgrading modules.
+The [rladmin CLI]({{<relref "/rs/references/rladmin.md">}}) introduces several updates to the commands for upgrading modules.
 It is now easier to upgrade your modules to the latest module version.
-Find out more [here](https://docs.redislabs.com/latest/modules/add-module-to-cluster/#upgrading-the-module-for-the-database).
+Find out more [here]({{<relref "/modules/add-module-to-cluster#upgrading-the-module-for-the-database">}}).
 
 ## Redis modules
 
@@ -53,9 +53,9 @@ To use the updated modules with a database, you must [upgrade the module on the 
 
 - [Shard level metrics]({{< relref "/rs/administering/monitoring-metrics/prometheus-metrics-definitions#shard-metrics" >}}) have been added to the metrics_exporter and are now available from Prometheus. You can find all of the metrics [here]({{< relref "/rs/administering/monitoring-metrics/prometheus-metrics-definitions" >}}).
 
-- RS DEB packages (for Ubuntu) and RPM packages (for RHEL) are now signed with a GPG key so customers can verify that the package is authentic and has not been tampered with. You can access the GPG on the [installaion page](https://docs.redislabs.com/latest/rs/installing-upgrading/#installing-rs-on-linux).
+- RS DEB packages (for Ubuntu) and RPM packages (for RHEL) are now signed with a GPG key so customers can verify that the package is authentic and has not been tampered with. You can access the GPG on the [installaion page]({{<relref "/rs/installing-upgrading#installing-rs-on-linux">}}).
 
-- The [crdb-cli](https://docs.redislabs.com/latest/rs/references/crdb-cli-reference/) history log is now being added to support packages.
+- The [crdb-cli]({{<relref "/rs/references/crdb-cli-reference.md">}}) history log is now being added to support packages.
 
 ## Important fixes
 


### PR DESCRIPTION
1. Replaced hard-coded internal URLs in RS release notes with relref shortcodes.
2. Added some aliases for RS release notes that were moved from /release-notes to /release-notes/legacy-release-notes at some point.

[Staged version](https://docs.redislabs.com/staging/jira-doc-677/rs/release-notes/)