### PR TITLE
Fix image paths for "Encryption at rest" page

### DIFF
--- a/content/rc/security/database-security/encryption-at-rest.md
+++ b/content/rc/security/database-security/encryption-at-rest.md
@@ -27,16 +27,16 @@ To enable encryption when creating a Flexible plan on AWS:
 
 1.  In the Flexible plan section, select the Create button.
 
-    {{<image filename="/images/rc/subscription-create-flexible.png" width="75%" alt="Create Flexible Plan" >}}{{< /image >}}
+    {{<image filename="images/rc/subscription-create-flexible.png" width="75%" alt="Create Flexible Plan" >}}{{< /image >}}
 
     This takes you to the **Create Custom Subscription** screen:
 
-    {{<image filename="/images/rc/create-custom-subscription.png" width="75%" 
+    {{<image filename="images/rc/create-custom-subscription.png" width="75%" 
     alt="Create Custom Subscription screen" >}}{{< /image >}}
 
 1.  Expand the **Advanced Options** and then verify that **Persistent Storage Encryption** is set to **Yes**.
 
-    {{<image filename="/images/rc/persistent-storage-encryption.png" width="75%" 
+    {{<image filename="images/rc/persistent-storage-encryption.png" width="75%" 
     alt="Persistent Storage Encryption setting" >}}{{< /image >}}
 
 When you create the subscription, all databases will be encrypted at rest.


### PR DESCRIPTION
Right now, the image paths on https://docs.redislabs.com/latest/rc/security/database-security/encryption-at-rest/ are broken:

![image](https://user-images.githubusercontent.com/1689183/125668637-4b7c6444-bb0f-437b-b4a9-26379b1ea0b7.png)


Because they point to https://docs.redislabs.com/latest//images/rc/persistent-storage-encryption.png instead of https://docs.redislabs.com/latest/images/rc/persistent-storage-encryption.png.