### PR TITLE
Bugfix for RS v5.2 redirecting to latest

### DIFF
--- a/website.json
+++ b/website.json
@@ -48,12 +48,12 @@
         },
         {
             "Condition": {
-                "KeyPrefixEquals": "5.2/"
+                "KeyPrefixEquals": "5.2/rc/"
             },
             "Redirect": {
                 "HostName": "docs.redislabs.com",
                 "Protocol": "https",
-                "ReplaceKeyPrefixWith": "latest/"
+                "ReplaceKeyPrefixWith": "latest/rc/"
             }
         },
         {


### PR DESCRIPTION
This is a potential fix for the bug where RS v5.2 incorrectly redirects to latest. This should make RS v5.2 accessible and only redirect RC to latest.