### PR TITLE
Fixed an error in EKS supported version

### DIFF
--- a/content/platforms/release-notes/k8s-6-0-20-12-2021-07.md
+++ b/content/platforms/release-notes/k8s-6-0-20-12-2021-07.md
@@ -120,7 +120,7 @@ is required, the only fix is to upgrade the K8s cluster to a newer version.
 
 ## Compatibility Notes
 
-* EKS is now supported (K8s 1.19)
+* EKS is now supported (K8s 1.18)
 * OpenShift 4.4 (previously deprecated) is no longer supported
 * GKE K8s versions 1.15, 1.16 (previously deprecated) is no longer supported
 * VMWare TKGIE 1.10 (K8s 1.19) is now supported


### PR DESCRIPTION
We've certified on 1.18; 1.19 was written in error (my bad)