### PR TITLE
Add dynatrace issue RED-54704 to upgrade notes

### DIFF
--- a/content/rs/release-notes/rs-6-0-may-2020.md
+++ b/content/rs/release-notes/rs-6-0-may-2020.md
@@ -115,6 +115,7 @@ To use the updated modules with a database, you must [upgrade the module on the 
     - If replication is enabled, you must run the BGREWRITEAOF command on all slave shards after the upgrade.
     - If replication is not enabled, you must run the BGREWRITEAOF command on all shards after the upgrade.
 - Starting from RS 5.4.2, to preserve the current Redis major.minor version during database upgrade you must use the keep_redis_version option instead of keep_current_version.
+- Dynatrace agent installed on the cluster nodes can hamper the working on Envoy process leading to failure of UI and REST API. Prior upgrading we recommed removing Dynatrace completely or try upgrading to newer versions. 
 
 ### Redis commands
 


### PR DESCRIPTION
Dynatrace agent installed on the cluster nodes can hamper the working on Envoy process leading to failure of UI and REST API. Prior upgrading we recommed removing Dynatrace completely or try upgrading to newer versions.