### PR TITLE
RS: Removed v5.2 from version dropdown

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -81,7 +81,6 @@
                 <a href="https://docs.redislabs.com/6.0/rs" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.0 (latest)')">v6.0 (latest)</a>
                 <a href="https://docs.redislabs.com/5.6/rs" id="version-select-5.6" onclick="_setSelectedVersion('5.6', 'v5.6')">v5.6</a>
                 <a href="https://docs.redislabs.com/5.4/rs" id="version-select-5.4" onclick="_setSelectedVersion('5.4', 'v5.4')">v5.4</a>
-                <a href="https://docs.redislabs.com/5.2/rs" id="version-select-5.2" onclick="_setSelectedVersion('5.2', 'v5.2 (and below)')">v5.2 (and below)</a>
               </div>
             </div>
           {{end}}

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -45,7 +45,6 @@
                 <a href="https://docs.redislabs.com/6.0/rs" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.0 (latest)')">v6.0 (latest)</a>
                 <a href="https://docs.redislabs.com/5.6/rs" id="version-select-5.6" onclick="_setSelectedVersion('5.6', 'v5.6')">v5.6</a>
                 <a href="https://docs.redislabs.com/5.4/rs" id="version-select-5.4" onclick="_setSelectedVersion('5.4', 'v5.4')">v5.4</a>
-                <a href="https://docs.redislabs.com/5.2/rs" id="version-select-5.2" onclick="_setSelectedVersion('5.2', 'v5.2 (and below)')">v5.2 (and below)</a>
               </div>
             </div>
           {{end}}


### PR DESCRIPTION
Removed the v5.2 option from the version dropdown list since that version reached end-of-life in December 2019.

[Staged version](https://docs.redislabs.com/staging/jira-doc-819/rs/)