### PR TITLE
Active Active expiration values

### DIFF
--- a/content/rs/references/developing-for-active-active/_index.md
+++ b/content/rs/references/developing-for-active-active/_index.md
@@ -188,7 +188,7 @@ Furthermore, a replica that is NOT the "owner" of the expired value:
     attempts to access it in WRITE mode.
     
     {{< note >}}
-Expiration values are in the range of [0, 2^49] for Active-Active databases and [0, 2^64] for non Active-Active databases.
+Expiration values are in the range of [0,&nbsp;2^49] for Active-Active databases and [0,&nbsp;2^64] for non Active-Active databases.
     {{< /note >}}
 
 ## Out-of-Memory (OOM) {#outofmemory-oom}

--- a/content/rs/references/developing-for-active-active/_index.md
+++ b/content/rs/references/developing-for-active-active/_index.md
@@ -188,8 +188,7 @@ Furthermore, a replica that is NOT the "owner" of the expired value:
     attempts to access it in WRITE mode.
     
     {{< note >}}
-Active-Active databases expiration values are in range of [0, 2^49].
-While non Active-Active Redis expiration values are in range of [0, 2^64], 
+Expiration values are in the range of [0, 2^49] for Active-Active databases and [0, 2^64] for non Active-Active databases.
     {{< /note >}}
 
 ## Out-of-Memory (OOM) {#outofmemory-oom}

--- a/content/rs/references/developing-for-active-active/_index.md
+++ b/content/rs/references/developing-for-active-active/_index.md
@@ -186,6 +186,11 @@ Furthermore, a replica that is NOT the "owner" of the expired value:
     DEL.
 - Expires it (sending a DEL) before making any modifications if a user
     attempts to access it in WRITE mode.
+    
+    {{< note >}}
+Active-Active databases expiration values are in range of [0, 2^49].
+While non Active-Active Redis expiration values are in range of [0, 2^64], 
+    {{< /note >}}
 
 ## Out-of-Memory (OOM) {#outofmemory-oom}
 


### PR DESCRIPTION
@lanceleonard @kaitlynmichael I probably need rewording here.
The underlying issue is the number of bit allocated for expiration in A/A vs regular Redis DB (49 in A/A , 64 in Redis).
Once ready - can be merged to latest