### PR TITLE
Doc-804 K8s connect to the admin console

### DIFF
--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -6,7 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["Platforms"]
 aliases: /platforms/kubernetes/tasks/connect-to-admin-console.md
-/platforms/kubernetes/tasks/connect-to-admin-console/
+         /platforms/kubernetes/tasks/connect-to-admin-console/
 ---
 
 The username and password for the Redis Enterprise Software [admin console]({{<relref "/rs/administering/_index.md">}}) are stored in a Kubernetes [secret](https://kubernetes.io/docs/concepts/configuration/secret/). After retrieving your credentials, you can use port forwarding to connect to the admin console.

--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -1,0 +1,11 @@
+---
+Title: Connect to the admin console
+linkTitle: Admin console
+description: Connect to the Redis Enterprise admin console to manage your Redis Enterprise cluster.
+weight: 10
+alwaysopen: false
+categories: ["Platforms"]
+aliases: /platforms/kubernetes/tasks/connect-to-admin-console.md
+/platforms/kubernetes/tasks/connect-to-admin-console/
+---
+

--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -13,7 +13,7 @@ The username and password for the Redis Enterprise Software [admin console]({{<r
 
 {{<note>}}
 There are several methods for accessing the admin console. Port forwarding is the simplest, but not the most efficient method for long-term use. You could also use a load balancer service or ingress. 
-{{/note}}
+{{</note>}}
 
 1. Switch to the namespace with your Redis Enterprise cluster (REC).
 

--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -11,6 +11,10 @@ aliases: /platforms/kubernetes/tasks/connect-to-admin-console.md
 
 The username and password for the Redis Enterprise Software [admin console]({{<relref "/rs/administering/_index.md">}}) are stored in a Kubernetes [secret](https://kubernetes.io/docs/concepts/configuration/secret/). After retrieving your credentials, you can use port forwarding to connect to the admin console.
 
+{{<note>}}
+There are several methods for accessing the admin console. Port forwarding is the simplest, but not the most efficient method for long term use. You could also use a load balancer service or ingress. Configuring ingress is a good permanent solution for long term use.
+{{/note}}
+
 1. Switch to the namespace with your Redis Enterprise cluster (REC).
 
     ```sh

--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -9,3 +9,44 @@ aliases: /platforms/kubernetes/tasks/connect-to-admin-console.md
 /platforms/kubernetes/tasks/connect-to-admin-console/
 ---
 
+The username and password for the Redis Enterprise Software [admin console]({{<relref "/rs/administering/_index.md">}}) are stored in a Kubernetes [secret](https://kubernetes.io/docs/concepts/configuration/secret/). After retrieving your credentials, you can use port forwarding to connect to the admin console.
+
+1. Switch to the namespace with your Redis Enterprise cluster (REC).
+
+    ```sh
+    kubectl config set-context --current --namespace=<namespace-of-rec>
+    ```
+
+1. Find your cluster name from your list of secrets.
+
+    ```sh
+    kubectl get secret
+    ```
+
+    In this example, the cluster name is `rec`.
+
+1. Extract and decode your credentials from the secret.
+
+    ```sh
+    kubectl get secret <cluster-name> -o jsonpath='{.data.username}' | base64 --decode
+    kubectl get secret <cluster-name> -o jsonpath='{.data.password}' | base64 --decode
+    ```
+
+1. Find the port for the REC UI service in the `spec:ports` section of the service definition file.
+
+    ```sh
+    kubectl get service/<cluster-name>-ui -o yaml
+    ```
+
+    {{<note>}}
+    The default port is 8843.
+    {{</note>}}
+
+1. Use `kubectl port-forward` to forward your local port to the service port.
+
+    ```sh
+    kubectl port-forward service/<cluster-name>-ui <local-port>:<service-port>
+   ```
+
+1. View the admin console from a web browser on your local machine at `https://localhost:8443`.
+

--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -1,6 +1,6 @@
 ---
 Title: Connect to the admin console
-linkTitle: Admin console
+linkTitle: Connect to the admin console
 description: Connect to the Redis Enterprise admin console to manage your Redis Enterprise cluster.
 weight: 10
 alwaysopen: false

--- a/content/platforms/kubernetes/tasks/connect-to-admin-console.md
+++ b/content/platforms/kubernetes/tasks/connect-to-admin-console.md
@@ -12,7 +12,7 @@ aliases: /platforms/kubernetes/tasks/connect-to-admin-console.md
 The username and password for the Redis Enterprise Software [admin console]({{<relref "/rs/administering/_index.md">}}) are stored in a Kubernetes [secret](https://kubernetes.io/docs/concepts/configuration/secret/). After retrieving your credentials, you can use port forwarding to connect to the admin console.
 
 {{<note>}}
-There are several methods for accessing the admin console. Port forwarding is the simplest, but not the most efficient method for long term use. You could also use a load balancer service or ingress. Configuring ingress is a good permanent solution for long term use.
+There are several methods for accessing the admin console. Port forwarding is the simplest, but not the most efficient method for long-term use. You could also use a load balancer service or ingress. 
 {{/note}}
 
 1. Switch to the namespace with your Redis Enterprise cluster (REC).


### PR DESCRIPTION
DOC-804 How to connect the rec-ui service to the admin console using port forwarding. Source: https://github.com/RedisLabs/redis-enterprise-k8s-docs#Connect-to-Redis-Enterprise-Software-web-console