### PR TITLE
Updated table-children shortcode to handle page description

### DIFF
--- a/layouts/shortcodes/table-children.html
+++ b/layouts/shortcodes/table-children.html
@@ -33,6 +33,13 @@
                         <td style="text-align:left">{{ $child.Title }}</td>
                     {{ end }}
                 {{ end }}
+                {{ if eq $cSource "Description" }}
+                    {{ if in $enableLinks $cSource }}
+                        <td style="text-align:left"><a href="{{$child.RelPermalink}}" >{{ $child.Description }}</a></td>
+                    {{ else }}
+                        <td style="text-align:left">{{ $child.Description }}</td>
+                    {{ end }}
+                {{ end }}
             {{ end }}
         </tr>
         {{ end }}


### PR DESCRIPTION
Example of shortcode with page description field:

{{< table-children columnNames="Name,Description" columnSources="LinkTitle,Description" enableLinks="LinkTitle" >}}