### PR TITLE
Update add-module-to-cluster.md

### DIFF
--- a/content/modules/add-module-to-cluster.md
+++ b/content/modules/add-module-to-cluster.md
@@ -40,7 +40,7 @@ Example: [Installing RedisGears](https://docs.redislabs.com/latest/modules/redis
 
 - The admin console - For modules without dependencies, such as RedisGraph.
 
-### Adding a module using the REST API
+### Adding a module using the REST API (Not working)
 
 Modules that have dependencies can only be added from the REST API.
 The `module.json` file in the module package lists the dependencies for the module and the URL to download each dependency.


### PR DESCRIPTION
https://docs.redis.com/latest/modules/add-module-to-cluster/#adding-a-module-using-the-rest-api
The instructions are not correct at least for redis gears:

https://redislabs.atlassian.net/browse/MOD-1388

The correct steps that I successfully executed with the customer TIAA in ticket #74273 are:

Copied the redisgears dependencies tar file to /var/opt/redislabls/modules/rg/<rg version>/deps/.

Modified the permission to 775 and ownership to redislabs.

Downloaded the redisgears installation zip file to the /tmp directory.

Modified the permission to 775 and ownership to redislabs.

Run the following API call to install the dependencies and module

curl -k -u "admin@poc.com:****" -F "module=@/tmp/<redisgears>.zip" https://localhost:9443/v2/modules
Verified from the UI and status of action Id we completed the installation successfully.