### PR TITLE
Update rladmin.md

### DIFF
--- a/content/rs/references/rladmin.md
+++ b/content/rs/references/rladmin.md
@@ -45,7 +45,7 @@ rladmin bind
 | - | - |
 | all-master-shards | Multiple proxies, one on each master node (best for high traffic and multiple master shards)                     |
 | all-nodes | Multiple proxies, one on each node of the cluster (increases traffic in the cluster, only used in special cases) |
-| legacy | Copies existing binding configuration from earlier versions
+
 | single | All traffic flows through a single proxy bound to the database endpoint (preferable in most cases)               |
 
 ```text

--- a/content/rs/references/rladmin.md
+++ b/content/rs/references/rladmin.md
@@ -45,7 +45,6 @@ rladmin bind
 | - | - |
 | all-master-shards | Multiple proxies, one on each master node (best for high traffic and multiple master shards)                     |
 | all-nodes | Multiple proxies, one on each node of the cluster (increases traffic in the cluster, only used in special cases) |
-
 | single | All traffic flows through a single proxy bound to the database endpoint (preferable in most cases)               |
 
 ```text


### PR DESCRIPTION
legacy does not appear in rladmin bind endpoint anymore

rladmin> bind endpoint 6:1 policy
all-master-shards  all-nodes          single