### PR TITLE
Update rs-6-0-20-april-2021.md

### DIFF
--- a/content/rs/release-notes/rs-6-0-20-april-2021.md
+++ b/content/rs/release-notes/rs-6-0-20-april-2021.md
@@ -241,14 +241,24 @@ All known bugs around setting ciphers were fixed.  To learn more, see [Updating 
     
 #### Security
 
--   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement `LCS`. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.4, Redis 6.0.14)
- 
 -   As part of Redis commitment to security, the following [Open Source Redis](https://github.com/redis/redis) [CVE's](https://github.com/redis/redis/security/advisories) have been addressed in Redis Enterprise 6.0.20: 
  
--   [CVE-2021-32626](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32626) - Lua scripts can overflow the heap-based Lua stack. This has been addressed in Redis Enterprise 6.0.20-62
+    -   [CVE-2021-32626](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32626) - Lua scripts can overflow the heap-based Lua stack. This has been                 addressed in Redis Enterprise 6.0.20-62
 
--   [CVE-2021-32627](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32627) - Integer overflow issue with Streams. This has been addressed in Redis Enterprise 6.0.20-1
+    -   [CVE-2021-32627](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32627) - Integer overflow issue with Streams. This has been addressed in Redis            Enterprise 6.0.20-1
 
--   [CVE-2021-32628](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32628) - Vulnerability in handling large ziplists. This has been addressed in Redis Enterprise 6.0.20-1
+    -   [CVE-2021-32628](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32628) - Vulnerability in handling large ziplists. This has been addressed in             Redis Enterprise 6.0.20-1
 
--   [CVE-2021-32687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32687) - Integer overflow issue with intsets. This has been addressed in Redis Enterprise 6.0.20-89
+    -   [CVE-2021-32687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32687) - Integer overflow issue with intsets. This has been addressed in Redis             Enterprise 6.0.20-89
+
+-   The following [Open Source Redis](https://github.com/redis/redis) [CVE's](https://github.com/redis/redis/security/advisories) do not affect Redis Enterprise:
+
+    -   [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in           open source Redis since Redis Enterprise does not implement `LCS`. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.4, Redis 6.0.14)
+
+    -   [CVE-2021-32672](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32672) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the LUA debugger is unsupported in Redis Enterprise. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)
+
+    -   [CVE-2021-32675](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32675) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the proxy in Redis Enterprise does not forward unauthenticated requests. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)
+
+    -   [CVE-2021-32762](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32762) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the memory allocator used in Redis Enterprise is not vulnerable. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)
+
+    -   [CVE-2021-41099](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41099) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the proto-max-bulk-len CONFIG is blocked in Redis Enterprise. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)


### PR DESCRIPTION
Updating 6.0.20 release notes with information regarding open source Redis CVE's that do not affect Redis Enterprise.