### PR TITLE
Update metrics.md

### DIFF
--- a/content/rc/api/examples/metrics.md
+++ b/content/rc/api/examples/metrics.md
@@ -112,3 +112,6 @@ Data points are shown divided into these categories:
 ```shell
 {{% embed-code "rv/api/70-query-metrics.sh" %}}
 ```
+
+
+<<<<PAGE NEEDS TO BE REMOVED-SEE COMMENT>>>>


### PR DESCRIPTION
Per a slack discussion, metrics via cloud API are not supported.
As such, we should remove this page since customers are using it to get metrics via API.

Slack discussion - https://redislabs.slack.com/archives/CE98Y318Q/p1633593680062700