### PR TITLE
Update openshift-cli.md

### DIFF
--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -110,7 +110,7 @@ Changes to this file can cause unexpected results.
     1. Apply the yaml file with:
 
         ```sh
-        oc apply -f redis-enterprise-k8s-docs/openshift.bundle.yaml
+        oc apply -f openshift.bundle.yaml
         ```
 
         The command returns a confirmation response such as:


### PR DESCRIPTION
Wrong command and path

**With kubectl :**
```
kubectl apply -f redis-enterprise-k8s-docs/openshift.bundle.yaml
error: error validating "redis-enterprise-k8s-docs/openshift.bundle.yaml": error validating data: [ValidationError(SecurityContextConstraints): unknown field "FSGroup" in io.openshift.security.v1.SecurityContextConstraints, ValidationError(SecurityContextConstraints): missing required field "allowHostDirVolumePlugin" in io.openshift.security.v1.SecurityContextConstraints, ValidationError(SecurityContextConstraints): missing required field "allowHostIPC" in io.openshift.security.v1.SecurityContextConstraints, ValidationError(SecurityContextConstraints): missing required field "allowHostNetwork" in io.openshift.security.v1.SecurityContextConstraints, ValidationError(SecurityContextConstraints): missing required field "allowHostPID" in io.openshift.security.v1.SecurityContextConstraints, ValidationError(SecurityContextConstraints): missing required field "allowHostPorts" in io.openshift.security.v1.SecurityContextConstraints, ValidationError(SecurityContextConstraints): missing required field "readOnlyRootFilesystem" in io.openshift.security.v1.SecurityContextConstraints]; if you choose to ignore these errors, turn validation off with --validate=false
```

**With oc:**

```
oc apply -f redis-enterprise-k8s-docs/openshift.bundle.yaml
securitycontextconstraints.security.openshift.io/redis-enterprise-scc configured
role.rbac.authorization.k8s.io/redis-enterprise-operator created
serviceaccount/redis-enterprise-operator created
rolebinding.rbac.authorization.k8s.io/redis-enterprise-operator created
W1011 12:45:06.156006    1057 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W1011 12:45:06.917534    1057 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/redisenterpriseclusters.app.redislabs.com created
service/admission created
deployment.apps/redis-enterprise-operator created
W1011 12:45:08.337400    1057 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W1011 12:45:08.530264    1057 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/redisenterprisedatabases.app.redislabs.com created
```