### PR TITLE
Update openshift-cli.md

### DIFF
--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -126,7 +126,7 @@ Changes to this file can cause unexpected results.
     1. To verify that your redis-enterprise-operator deployment is running, run:
 
         ```sh
-        kubectl get deployment -l name=redis-enterprise-operator
+        oc get deployment
         ```
 
         A typical response will look like this:


### PR DESCRIPTION
wrong command and output

With the original command:

```
kubectl get deployment -l name=redis-enterprise-operator
No resources found in cluster1 namespace.
```

With suggested command 

```
oc get deployment
NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
redis-enterprise-operator   1/1     1            1           5m21s 

```
Or with capital L, works as well

`oc get deployment -L Name=redis-enterprise-operator
`