### PR TITLE
Update openshift-cli.md

### DIFF
--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -42,7 +42,7 @@ Prerequisites:
 1. Paste the `login` command into your shell, for example:
 
     ```sh
-    oc login https://your-cluster.acme.com –token=your$login$token
+    oc login --token=<yourToken> --server=https://<cluster FQDN:PORT>
     ```
 
 1. To verify that you are using the newly created project, run:


### PR DESCRIPTION
Not working

The original command 

```
oc login --server=https://api.cluster-a.cs.redislabs.com:6443 –-token=sha256~_b2662egvdIz5s6yK7xKLqxT-oslqb8Vc6F5TzvXpUg

error: --server and passing the server URL as an argument are mutually exclusive
```

The new command:

```
oc login --token=sha256~_b2662egvdIz5s6yK7xKLqxT-oslqb8Vc6F5TzvXpUg --server=https://api.cluster-a.cs.redislabs.com:6443
Logged into "https://api.cluster-a.cs.redislabs.com:6443" as "kube:admin" using the token provided.

You have access to 64 projects, the list has been suppressed. You can list all projects with 'oc projects'

```