### PR TITLE
Jira DOC-937: Redirect obsolete URL

### DIFF
--- a/content/rc/api/examples/_index.md
+++ b/content/rc/api/examples/_index.md
@@ -13,5 +13,7 @@ aliases: /rv/api/how-to/
          /rv/api/concepts/
          /rc/api/concepts/
          /rc/api/concepts/_index.md
+         /rc/api/examples/metrics/
+         /rc/api/examples/metrics.md
 ---
 {{< allchildren style="h2" description="true" />}}


### PR DESCRIPTION
- Redirecting original URL, which now 404s.