### PR TITLE
Fixed card icon and title links

### DIFF
--- a/content/embeds/modules.html
+++ b/content/embeds/modules.html
@@ -1,137 +1,158 @@
 <section class="home-options" style="width:100%">
     <div class="home-options__option" style="transform: translateY(0px);">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redisearch.svg" alt="RediSearch Icon" style="border:0px;width:80px;padding-top:8px">
-            <a href="/modules/redisearch/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redisearch/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redisearch.svg" alt="RediSearch Icon" style="border:0px;width:80px;padding-top:8px">
+            </div>
+            <h5>RediSearch</h5>
+            <p>RediSearch is a source-available full-text and secondary index engine for Redis.</p>
+        </a>
         </div>
-        <h5><a href="/modules/redisearch/">RediSearch</a></h5>
-        <p>RediSearch is a source available Full-Text and Secondary Index engine over Redis.</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisearch/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisearch/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisearch/release-notes/">Release notes</a></li>
             </section>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
-                        href="https://redislabs.com/redis-enterprise/redis-search/redisearch-sizing-calculator/">Sizing Calculator</a></li>
+                        href="https://redislabs.com/redis-enterprise/redis-search/redisearch-sizing-calculator/">Sizing calculator</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisearch.io">Documentation</a></li>
             </section>
         </ul>
     </div>
     <div class="home-options__option">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redis-bloom.svg" alt="RedisBloom Icon" style="border:0px;width:88px">
-            <a href="/modules/redisbloom/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redisbloom/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-bloom.svg" alt="RedisBloom Icon" style="border:0px;width:88px">
+            </div>
+            <h5>RedisBloom</h5>
+            <p>RedisBloom provides four data types: a scalable Bloom filter, a cuckoo filter,
+            a count-min-sketch, and a top-k.</p>
+        </a>
         </div>
-        <h5><a href="/modules/redisbloom/">RedisBloom</a></h5>
-        <p>RedisBloom module provides four data types, a Scalable Bloom Filter, a Cuckoo Filter,
-        a Count-Mins-Sketch, and a Top-K.</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/release-notes/">Release notes</a></li>
             </section>
             <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/redisbloom-quickstart">Quick Start</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/redisbloom-quickstart">Quick start</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisbloom.io">Documentation</a></li>
             </section>
         </ul>
     </div>
     <div class="home-options__option" style="transform: translateY(6px);">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redis-timeseries.svg" alt="RedisTimeSeries Icon" style="border:0px;width:80px;padding-top:2px">
-            <a href="/modules/redistimeseries/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redistimeseries/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-timeseries.svg" alt="RedisTimeSeries Icon" style="border:0px;width:80px;padding-top:2px">
+            </div>
+            <h5>RedisTimeSeries</h5>
+            <p>RedisTimeSeries adds a time series data structure to Redis.</p>
+        </a>
         </div>
-        <h5><a href="/modules/redistimeseries/">RedisTimeSeries</a></h5>
-        <p>RedisTimeSeries is a Redis Module adding a Time Series data structure to Redis.</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/release-notes/">Release notes</a></li>
             </section>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
-                        href="https://redislabs.com/redis-enterprise/redis-time-series/time-series-calculator/">Sizing Calculator</a></li>
+                        href="https://redislabs.com/redis-enterprise/redis-time-series/time-series-calculator/">Sizing calculator</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redistimeseries.io">Documentation</a></li>
             </section>
         </ul>
     </div>
     <div class="home-options__option">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redis-graph.svg" alt="RedisGraph Icon" style="border:0px;width:80px">
-            <a href="/modules/redisgraph/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redisgraph/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-graph.svg" alt="RedisGraph Icon" style="border:0px;width:80px">
+            </div>
+            <h5>RedisGraph</h5>
+            <p>RedisGraph is the first queryable property graph database to use sparse matrices to represent the adjacency matrix in graphs and linear algebra to query the graph.</p>
+        </a>
         </div>
-        <h5><a href="/modules/redisgraph/">RedisGraph</a></h5>
-        <p>RedisGraph is the first queryable Property Graph database to use sparse matrices to represent the adjacency matrix in graphs and linear algebra to query the graph.</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/release-notes/">Release notes</a></li>
             </section>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
-                        href="https://redislabs.com/redis-enterprise/redis-graph/redisgraph-calculator/">Sizing Calculator</a></li>
+                        href="https://redislabs.com/redis-enterprise/redis-graph/redisgraph-calculator/">Sizing calculator</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisgraph.io">Documentation</a></li>
             </section>
         </ul>
     </div>
     <div class="home-options__option">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redis-json.svg" alt="RedisJSON Icon" style="border:0px;width:88px">
-            <a href="/modules/redisjson/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redisjson/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-json.svg" alt="RedisJSON Icon" style="border:0px;width:88px">
+            </div>
+            <h5>RedisJSON</h5>
+            <p>RedisJSON implements ECMA-404 The JSON Data Interchange Standard as a native data type. It allows storing, updating, and fetching JSON values from Redis keys (documents).</p>
+        </a>
         </div>
-        <h5><a href="/modules/redisjson/">RedisJSON</a></h5>
-        <p>RedisJSON is a Redis module that implements ECMA-404 The JSON Data Interchange Standard as a native data type. It allows storing, updating and fetching JSON values from Redis keys (documents).</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisjson/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisjson/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisjson/release-notes/">Release notes</a></li>
             </section>
             <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisjson/redisjson-quickstart">Quick Start</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisjson/redisjson-quickstart">Quick start</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisjson.io">Documentation</a></li>
             </section>
         </ul>
     </div>
     <div class="home-options__option">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redis-ai.svg" alt="RedisAI Icon" style="border:0px;width:80px">
-            <a href="/modules/redisai/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redisai/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-ai.svg" alt="RedisAI Icon" style="border:0px;width:80px">
+            </div>
+            <h5>RedisAI</h5>
+            <p>RedisAI is a Redis module for executing deep learning/machine learning models and managing their data. (Redis Enterprise Software only)</p>
+        </a>
         </div>
-        <h5><a href="/modules/redisai/">RedisAI</a></h5>
-        <p>RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data. (Redis Enterprise Software only)</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/release-notes/">Release notes</a></li>
             </section>
             <section>
-                    <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/redisai-quickstart">Quick Start</a></li>
+                    <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/redisai-quickstart">Quick start</a></li>
                     <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisai.io">Documentation</a></li>
             </section>
         </ul>
     </div>
     <div class="home-options__option">
-        <div class="home-options__option__icon">
-            <img src="../theme-flex/img/icon-redis-gears.svg" alt="RedisGears Icon" style="border:0px;width:80px">
-            <a href="/modules/redisgears/" class="opener"></a>
+        <div class="tile-opener">
+        <a href="/modules/redisgears/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-gears.svg" alt="RedisGears Icon" style="border:0px;width:80px">
+            </div>
+            <h5>RedisGears</h5>
+            <p>RedisGears is a serverless engine for transaction, batch, and event-driven data processing in Redis. (Redis Enterprise Software only)</p>
+        </a>
         </div>
-        <h5><a href="/modules/redisgears/">RedisGears</a></h5>
-        <p>RedisGears is a serverless engine for transaction, batch and event-driven data processing in Redis. (Redis Enterprise Software only)</p>
         <hr>
         <ul>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgears/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgears/release-notes/">Release Notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgears/release-notes/">Release notes</a></li>
             </section>
             <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/redisgears-quickstart">Quick Start</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgears/redisgears-quickstart">Quick start</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisgears.io">Documentation</a></li>
             </section>
         </ul>

--- a/content/embeds/modules.html
+++ b/content/embeds/modules.html
@@ -4,7 +4,7 @@
             <img src="../theme-flex/img/icon-redisearch.svg" alt="RediSearch Icon" style="border:0px;width:80px;padding-top:8px">
             <a href="/modules/redisearch/" class="opener"></a>
         </div>
-        <h5>RediSearch</h5>
+        <h5><a href="/modules/redisearch/">RediSearch</a></h5>
         <p>RediSearch is a source available Full-Text and Secondary Index engine over Redis.</p>
         <hr>
         <ul>
@@ -24,7 +24,7 @@
             <img src="../theme-flex/img/icon-redis-bloom.svg" alt="RedisBloom Icon" style="border:0px;width:88px">
             <a href="/modules/redisbloom/" class="opener"></a>
         </div>
-        <h5>RedisBloom</h5>
+        <h5><a href="/modules/redisbloom/">RedisBloom</a></h5>
         <p>RedisBloom module provides four data types, a Scalable Bloom Filter, a Cuckoo Filter,
         a Count-Mins-Sketch, and a Top-K.</p>
         <hr>
@@ -44,7 +44,7 @@
             <img src="../theme-flex/img/icon-redis-timeseries.svg" alt="RedisTimeSeries Icon" style="border:0px;width:80px;padding-top:2px">
             <a href="/modules/redistimeseries/" class="opener"></a>
         </div>
-        <h5>RedisTimeSeries</h5>
+        <h5><a href="/modules/redistimeseries/">RedisTimeSeries</a></h5>
         <p>RedisTimeSeries is a Redis Module adding a Time Series data structure to Redis.</p>
         <hr>
         <ul>
@@ -64,7 +64,7 @@
             <img src="../theme-flex/img/icon-redis-graph.svg" alt="RedisGraph Icon" style="border:0px;width:80px">
             <a href="/modules/redisgraph/" class="opener"></a>
         </div>
-        <h5>RedisGraph</h5>
+        <h5><a href="/modules/redisgraph/">RedisGraph</a></h5>
         <p>RedisGraph is the first queryable Property Graph database to use sparse matrices to represent the adjacency matrix in graphs and linear algebra to query the graph.</p>
         <hr>
         <ul>
@@ -84,7 +84,7 @@
             <img src="../theme-flex/img/icon-redis-json.svg" alt="RedisJSON Icon" style="border:0px;width:88px">
             <a href="/modules/redisjson/" class="opener"></a>
         </div>
-        <h5>RedisJSON</h5>
+        <h5><a href="/modules/redisjson/">RedisJSON</a></h5>
         <p>RedisJSON is a Redis module that implements ECMA-404 The JSON Data Interchange Standard as a native data type. It allows storing, updating and fetching JSON values from Redis keys (documents).</p>
         <hr>
         <ul>
@@ -103,7 +103,7 @@
             <img src="../theme-flex/img/icon-redis-ai.svg" alt="RedisAI Icon" style="border:0px;width:80px">
             <a href="/modules/redisai/" class="opener"></a>
         </div>
-        <h5>RedisAI</h5>
+        <h5><a href="/modules/redisai/">RedisAI</a></h5>
         <p>RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data. (Redis Enterprise Software only)</p>
         <hr>
         <ul>
@@ -122,7 +122,7 @@
             <img src="../theme-flex/img/icon-redis-gears.svg" alt="RedisGears Icon" style="border:0px;width:80px">
             <a href="/modules/redisgears/" class="opener"></a>
         </div>
-        <h5>RedisGears</h5>
+        <h5><a href="/modules/redisgears/">RedisGears</a></h5>
         <p>RedisGears is a serverless engine for transaction, batch and event-driven data processing in Redis. (Redis Enterprise Software only)</p>
         <hr>
         <ul>

--- a/layouts/partials/home/options.html
+++ b/layouts/partials/home/options.html
@@ -1,11 +1,14 @@
 <section class="home-options">
         <div class="home-options__option" style="transform: translateY(10px);">
-            <div class="home-options__option__icon">
-                <img src="./theme-flex/img/RedisLabs_Homepage_Getstarted_Cloud.svg" alt="Cloud Icon" style="width:70px;transform: translateY(-2px); margin-top:13px; margin-bottom:24px;">
-                <a href="/rc" class="opener"></a>
+            <div class="tile-opener">
+            <a href="/rc">
+                <div class="home-options__option__icon">
+                    <img src="./theme-flex/img/RedisLabs_Homepage_Getstarted_Cloud.svg" alt="Cloud Icon" style="width:70px;transform: translateY(-2px); margin-top:13px; margin-bottom:24px;">
+                </div>
+                <h5>Cloud</h5>
+                <p>Hosted and serverless DBaaS. The fastest way to deploy Redis Enterprise.</p>
+            </a>
             </div>
-            <h5><a href="/rc">Cloud</a></h5>
-            <p>Hosted and serverless DBaaS. The fastest way to deploy Redis Enterprise.</p>
             <hr>
             <ul>
                 <section>
@@ -21,12 +24,15 @@
         </div>
 
         <div class="home-options__option" style="transform: translateY(-1px);">
-            <div class="home-options__option__icon">
-                <img src="./theme-flex/img/RedisLabs_Homepage_Getstarted_Software.svg" alt="Software Icon" style="width: 70px; margin-top:13px; margin-bottom:14px;">
-                <a href="/rs" class="opener"></a>
+            <div class="tile-opener">
+            <a href="/rs">
+                <div class="home-options__option__icon">
+                    <img src="./theme-flex/img/RedisLabs_Homepage_Getstarted_Software.svg" alt="Software Icon" style="width: 70px; margin-top:13px; margin-bottom:14px;">
+                </div>
+                <h5>Software</h5>
+                <p>Software you can install on any cloud or private data center as software, containers, Pivotal CF, OpenShift, or AWS AMI.</p>
+            </a>
             </div>
-            <h5><a href="/rs">Software</a></h5>
-            <p>Software you can install on any cloud or private data center as software, containers, Pivotal CF, OpenShift or AWS AMI.</p>
             <hr>
             <ul>
                 <section>
@@ -42,13 +48,16 @@
         </div>
 
         <div class="home-options__option" style="transform: translateY(-5px);">
-            <div class="home-options__option__icon">
-                <img src="./theme-flex/img/ico-redisinsight.svg" alt="RedisInsight Icon" style="height: 70%; margin-top:20px;">
-                <a href="/ri" class="opener"></a>
+            <div class="tile-opener">
+            <a href="/ri">
+                <div class="home-options__option__icon">
+                    <img src="./theme-flex/img/ico-redisinsight.svg" alt="RedisInsight Icon" style="height: 70%; margin-top:20px;">
+                </div>
+                <h5>RedisInsight</h5>
+                <p>RedisInsight is a cross-platform GUI for Redis, with a focus on reducing memory usage and improving application performance.
+                </p>
+            </a>
             </div>
-            <h5><a href="/ri">RedisInsight</a></h5>
-            <p>RedisInsight is a cross-platform GUI for redis, with a focus on reducing memory usage and improving application performance.
-            </p>
             <hr>
             <ul>
                 <section>
@@ -65,14 +74,17 @@
         </div>
 
         <div class="home-options__option">
-            <div class="home-options__option__icon">
-                <img src="./theme-flex/img/ico-modules.svg" alt="Modules Icon" class="modules-icon">
-                <a href="/modules" class="opener"></a>
-            </div>
-            <h5><a href="/modules">Modules</a></h5>
-            <p>Redis Modules are add-ons that extend Redis to cover most of the popular use cases in many
+            <div class="tile-opener">
+            <a href="/modules">
+                <div class="home-options__option__icon">
+                    <img src="./theme-flex/img/ico-modules.svg" alt="Modules Icon" class="modules-icon">
+                </div>
+                <h5>Modules</h5>
+                <p>Redis Modules are add-ons that extend Redis to cover most of the popular use cases in many
                 industries.
-            </p>
+                </p>
+            </a>
+            </div>
             <hr>
             <ul>
                 <section>
@@ -92,12 +104,15 @@
         </div>
 
         <div class="home-options__option" style="transform: translateY(-4.5px);">
-            <div class="home-options__option__icon">
-                <img src="./theme-flex/img/ico-platforms.svg" alt="Platforms Icon" class="platforms-icon">
-                <a href="/platforms" class="opener"></a>
+            <div class="tile-opener">
+            <a href="/platforms">
+                <div class="home-options__option__icon">
+                    <img src="./theme-flex/img/ico-platforms.svg" alt="Platforms Icon" class="platforms-icon">
+                </div>
+                <h5>Kubernetes</h5>
+                <p>Redis Enterprise deployed on containerized software platforms and integrated with our partners.</p>
+            </a>
             </div>
-            <h5><a href="/platforms">Kubernetes</a></h5>
-            <p>Redis Enterprise deployed on containerized software platforms and integrated with our partners.</p>
             <hr>
             <ul>
                 <section>

--- a/layouts/partials/home/options.html
+++ b/layouts/partials/home/options.html
@@ -4,7 +4,7 @@
                 <img src="./theme-flex/img/RedisLabs_Homepage_Getstarted_Cloud.svg" alt="Cloud Icon" style="width:70px;transform: translateY(-2px); margin-top:13px; margin-bottom:24px;">
                 <a href="/rc" class="opener"></a>
             </div>
-            <h5>Cloud</h5>
+            <h5><a href="/rc">Cloud</a></h5>
             <p>Hosted and serverless DBaaS. The fastest way to deploy Redis Enterprise.</p>
             <hr>
             <ul>
@@ -25,7 +25,7 @@
                 <img src="./theme-flex/img/RedisLabs_Homepage_Getstarted_Software.svg" alt="Software Icon" style="width: 70px; margin-top:13px; margin-bottom:14px;">
                 <a href="/rs" class="opener"></a>
             </div>
-            <h5>Software</h5>
+            <h5><a href="/rs">Software</a></h5>
             <p>Software you can install on any cloud or private data center as software, containers, Pivotal CF, OpenShift or AWS AMI.</p>
             <hr>
             <ul>
@@ -46,7 +46,7 @@
                 <img src="./theme-flex/img/ico-redisinsight.svg" alt="RedisInsight Icon" style="height: 70%; margin-top:20px;">
                 <a href="/ri" class="opener"></a>
             </div>
-            <h5>RedisInsight</h5>
+            <h5><a href="/ri">RedisInsight</a></h5>
             <p>RedisInsight is a cross-platform GUI for redis, with a focus on reducing memory usage and improving application performance.
             </p>
             <hr>
@@ -69,7 +69,7 @@
                 <img src="./theme-flex/img/ico-modules.svg" alt="Modules Icon" class="modules-icon">
                 <a href="/modules" class="opener"></a>
             </div>
-            <h5>Modules</h5>
+            <h5><a href="/modules">Modules</a></h5>
             <p>Redis Modules are add-ons that extend Redis to cover most of the popular use cases in many
                 industries.
             </p>
@@ -96,7 +96,7 @@
                 <img src="./theme-flex/img/ico-platforms.svg" alt="Platforms Icon" class="platforms-icon">
                 <a href="/platforms" class="opener"></a>
             </div>
-            <h5>Kubernetes</h5>
+            <h5><a href="/platforms">Kubernetes</a></h5>
             <p>Redis Enterprise deployed on containerized software platforms and integrated with our partners.</p>
             <hr>
             <ul>

--- a/static/theme-flex/script.js
+++ b/static/theme-flex/script.js
@@ -68,7 +68,7 @@ jQuery(document).ready(function() {
     // Wrap image inside a featherlight (to get a full size view in a popup)
     images.wrap(function () {
         var image = $(this);
-        if (!image.parent("a").length) {
+        if ((!image.parent("a").length) && (this.parentElement.className != "home-options__option__icon")) {
             return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
         }
     });

--- a/static/theme-flex/script.js
+++ b/static/theme-flex/script.js
@@ -68,7 +68,7 @@ jQuery(document).ready(function() {
     // Wrap image inside a featherlight (to get a full size view in a popup)
     images.wrap(function () {
         var image = $(this);
-        if ((!image.parent("a").length) && (this.parentElement.className != "home-options__option__icon")) {
+        if (!image.parent("a").length) {
             return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
         }
     });

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -642,22 +642,28 @@ section a {
 
 .home-options__option__icon img {
   width: 100px;
+  pointer-events: none;
+  cursor: default;
 }
 
 .home-options__option__icon img.modules-icon {
   width: 80px;
   margin-top: 8px;
+  pointer-events: none;
+  cursor: default;
 }
 
 .home-options__option__icon img.platforms-icon {
   width: 88px;
   margin-top: 8px;
   transform: translateY(1px);
+  pointer-events: none;
+  cursor: default;
 }
 
 .home-options__option__icon a {
-  pointer-events: none;
-  cursor: default;
+  pointer-events: none !important;
+  cursor: default !important;
 }
 
 .home-options__option__icon a.opener {
@@ -668,6 +674,26 @@ section a {
   width: 140px;
   pointer-events: auto;
   cursor: pointer;
+}
+
+.home-options__option .tile-opener {
+  display: block !important;
+}
+
+.home-options__option .tile-opener a, .tile-opener a:visited, .tile-opener a:hover, .tile-opener a:active {
+  color: #3d5051 !important;
+  text-decoration: none !important;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.home-options__option .tile-opener a:hover h5 {
+  color: #3d5051;
+  font-size: 1.75rem;
+  font-style: normal;
+  font-weight: 400;
+  margin: 8px 0 12px 0;
+  text-decoration: underline !important;
 }
 
 .home-options__option h5 {
@@ -1165,6 +1191,12 @@ article section.page h2::before, article section.page h3::before {
   height: 60px; /* header height*/
   margin: -60px 0 0;
 }
+
+article section.page .tile-opener a:hover h5 {
+  font-size: 1.2rem;
+  margin: 1.6 0rem 0.6 0rem;
+}
+
 article section.page table {
   width: 100%;
   margin-bottom: 2em;

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -655,12 +655,19 @@ section a {
   transform: translateY(1px);
 }
 
+.home-options__option__icon a {
+  pointer-events: none;
+  cursor: default;
+}
+
 .home-options__option__icon a.opener {
   height: 100%;
   left: 28%;
   position: absolute;
   top: 0;
   width: 140px;
+  pointer-events: auto;
+  cursor: pointer;
 }
 
 .home-options__option h5 {

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -671,6 +671,10 @@ section a {
   margin: 8px 0 12px 0;
 }
 
+.home-options__option h5 a {
+  color: #3d5051;
+}
+
 .home-options__option p {
   color: #5f5f5f;
   font-size: 1.05rem;


### PR DESCRIPTION
This change should prevent users from accidentally expanding the card icon images when they try to navigate via the cards on the home page.

[Home page preview](https://docs.redis.com/staging/jira-doc-991/)
[Modules preview](https://docs.redis.com/staging/jira-doc-991/modules/)