### PR TITLE
Allow toc parameter to force page TOC to appear

### DIFF
--- a/layouts/partials/mini-toc.html
+++ b/layouts/partials/mini-toc.html
@@ -6,7 +6,7 @@
 {{ $min_word_count := 250 }}
 <!-- a post can explicitly disable Table of Contents with toc: false
 {{ $show_toc := (eq $.Params.toc true) }} -->
-{{ if and (gt .WordCount $min_word_count ) (ne .Params.toc "false") $has_headers }}
+{{ if and (or (and (gt .WordCount $min_word_count ) (ne .Params.toc "false")) (eq .Params.toc "true")) $has_headers }}
 <nav id="toc" data-toggle="toc">
   <!-- TOC header -->
   <h4 class="text-muted">Contents</h4>


### PR DESCRIPTION
You can now add `toc: "true"` to a page's front matter to force its TOC to appear.