### PR TITLE
Jira DOC-1039: Clarify RC support for modules

### DIFF
--- a/content/modules/_index.md
+++ b/content/modules/_index.md
@@ -1,5 +1,6 @@
 ---
-Title: Redis Modules
+Title: Redis modules
+linkTitle: Redis modules
 description:
 weight: 70
 alwaysopen: false
@@ -9,9 +10,10 @@ aliases: /modules/
 ---
 Redis develops several modules that extend the core Redis feature set. Some of the features these modules provide include [querying, indexing and full-text search]({{< relref "/modules/redisearch" >}}), [JSON support]({{< relref "/modules/redisjson" >}}), and [probabalistic data structures]({{< relref "/modules/redisbloom" >}}).
 
-You can use these modules with [Redis Enterprise Software]({{< relref "/rs" >}}).  
+You can use these modules with [Redis Enterprise Software]({{< relref "/rs" >}}).
 
-You can use many, but not all, of them with [Redis Enterprise Cloud]({{< relref "/rc" >}}).  For details, see [Supported modules]({{< relref "/rc/databases/create-database#supported-modules" >}}).
+You can use many, but not all, modules with [Redis Enterprise Cloud]({{< relref "/rc" >}}).  For details, see [Redis Enterprise module support]({{<relref "modules/enterprise-capabilities#redis-enterprise-module-support">}}).
+
 
 Each module includes a quick start guide.
 

--- a/content/modules/enterprise-capabilities.md
+++ b/content/modules/enterprise-capabilities.md
@@ -5,7 +5,8 @@ description: Describes the Redis Enterprise features supported by each Redis mod
 weight: 8
 alwaysopen: false
 categories: ["Modules"]
-aliases: /modules/packaging
+aliases: /modules/enterprise-capabilities/
+         /modules/enterprise-capabilities.md
 ---
 
 This article describes Redis Enterprise feature compatibility for Redis modules.  Version numbers indicate the minimum module version required for feature support.  Footnotes provide additional information as needed.

--- a/content/rc/databases/create-database.md
+++ b/content/rc/databases/create-database.md
@@ -41,7 +41,7 @@ The available settings vary according to your subscription plan:
 | **Redis on Flash** | Checked when the subscription supports Redis on Flash (_Flexible or Annual subscriptions only_) |
 | **Database Name** | A name for your database (_required_) |
 | **Protocol**  | Set to _Redis_ unless you need to support legacy memcached databases |
-| **Modules** | Extend core Redis functionality using [modules]({{< relref "modules/" >}}) |
+| **Modules** | Extend core Redis functionality using [modules]({{<relref "modules/">}}).  Redis Enterprise Cloud supports selected modules; for details, see [Redis Enterprise module support]({{<relref "modules/enterprise-capabilities#redis-enterprise-module-support">}}) |
 
 ## Scalability section
 


### PR DESCRIPTION
This PR:
- Updates several links to point to matrix showing RC support for Redis modules.
- Other minor edits.

Staged preview of the affected files are available:
- [Redis modules home page](https://docs.redis.com/staging/jira-doc-1039/modules/)
- RC:Create database, [General section](https://docs.redis.com/staging/jira-doc-1039/rc/databases/create-database/#general-section)