### PR TITLE
Added embed-replace shortcode

### DIFF
--- a/layouts/shortcodes/embed-replace.html
+++ b/layouts/shortcodes/embed-replace.html
@@ -1,0 +1,6 @@
+{{$oldString := .Get "oldString"}}
+{{$newString := .Get "newString"}}
+
+{{ $oldEmbed := .Inner}}
+{{ $newEmbed := replace $oldEmbed $oldString $newString }}
+{{ $newEmbed | safeHTML }}


### PR DESCRIPTION
The embed-replace shortcode allows you to replace all instances of a string that occurs within an embedded document.

**embed-md example:**

{{\<embed-replace oldString="redis" newString="Redis">}}
{{<embed-md "discovery-clients.md">}}
{{\</embed-replace>}}

This example replaces all occurrences of lowercase "redis" with the properly capitalized "Redis".

**embed-html example:**

{{\<embed-replace oldString="embed" newString="embed replacement">}}
{{<embed-html "sample.html">}}
{{\</embed-replace>}}

In this example, the original text "this is a sample embed test" becomes "this is a sample embed replacement test".