### PR TITLE
Fixed mini-TOC encoding bug

### DIFF
--- a/layouts/partials/mini-toc.html
+++ b/layouts/partials/mini-toc.html
@@ -39,7 +39,7 @@
           {{end}}
 
           <li>
-            <a href="#{{ $anchorID }}">{{ $header | plainify | htmlEscape }}</a>
+            <a href="#{{ $anchorID }}">{{ $header | plainify | safeHTML }}</a>
 
           {{ if eq $i (sub (len $headers) 1) }}
             {{ range seq (sub $prevHeaderLevel $headerLevel) }}
@@ -48,7 +48,7 @@
           {{end}}
       {{else}}
       <li>
-        <a href="#{{ $anchorID }}">{{ $header | plainify | htmlEscape }}</a>
+        <a href="#{{ $anchorID }}">{{ $header | plainify | safeHTML }}</a>
       {{end}}
     {{end}}
 


### PR DESCRIPTION
This change fixes an encoding bug in the mini-TOC where double quotes displayed incorrectly as "\&amp;ldquo;"

[Staged preview](https://docs.redis.com/staging/jira-doc-1041/rs/references/developing-for-active-active/developing-strings-active-active/)