### PR TITLE
The prefix for the ssl-passthrough annotation in the case of HAProxy …

### DIFF
--- a/content/kubernetes/re-databases/set-up-ingress-controller.md
+++ b/content/kubernetes/re-databases/set-up-ingress-controller.md
@@ -88,7 +88,7 @@ Install one of the supported ingress controllers:
     For HAProxy, insert the following into the `annotations` section:  
 
         kubernetes.io/ingress.class: haproxy
-        haproxy.ingress.kubernetes.io/ssl-passthrough: "true"
+        haproxy-ingress.github.io/ssl-passthrough: "true"
 
     For NGINX, insert the following into the `annotations` section:  
 


### PR DESCRIPTION
…Ingress was incorrect

According to the HAProxy Ingress documentation: "The default prefix is haproxy-ingress.github.io"