### PR TITLE
Updated the annotations as the prefix in the case of HAProxy Ingress …

### DIFF
--- a/content/kubernetes/re-clusters/create-aa-database.md
+++ b/content/kubernetes/re-clusters/create-aa-database.md
@@ -104,8 +104,8 @@ From inside your K8s cluster, edit your Redis Enterprise cluster (REC) resource 
       dbIngressSuffix: <ingress-suffix>
       ingressAnnotations:
         kubernetes.io/ingress.class: <nginx | haproxy>
-        <nginx | haproxy>.ingress.kubernetes.io/backend-protocol: HTTPS
-        <nginx | haproxy>.ingress.kubernetes.io/ssl-passthrough: "true"  
+        <nginx.ingress.kubernetes.io | haproxy-ingress.github.io>/backend-protocol: HTTPS
+        <nginx.ingress.kubernetes.io | haproxy-ingress.github.io>/ssl-passthrough: "true"  
       method: ingress
     ```
 


### PR DESCRIPTION
…were not correct.

According to the HAProxy Ingress documentation: "The default prefix is haproxy-ingress.github.io"