### PR TITLE
Removed platforms no longer supported

### DIFF
--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -12,15 +12,13 @@ Make sure your system meets these requirements:
 
 | **Platform** | **Versions/Information** |
 |------------|-----------------|
-| Ubuntu | 14.04 (Support ends on November 30, 2020)<br>16.04, 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
-| RHEL/CentOS 6 | 6.7, 6.8, 6.9 (Support ends on November 30, 2020) |
+| Ubuntu | 16.04, 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
 | RHEL/CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}}) |
 | RHEL/CentOS 8 | 8.0, 8.1, 8.2, 8.3, 8.4 |
-| Oracle Linux 6 | Based on the corresponding RHEL version |
 | Oracle Linux 7 | Based on the corresponding RHEL version |
 | Amazon Linux | Version 1 |
 | Docker | [Docker images]({{< relref "/rs/getting-started/getting-started-docker.md" >}}) of Redis Enterprise Software are certified for Development and Testing only. |
-| Kubernetes | See the [Platform documentation]({{< relref "/kubernetes/_index.md" >}}) |
+| Kubernetes | See the [Redis Enterprise Software on Kubernetes documentation]({{< relref "/kubernetes/_index.md" >}}) |
 
 Be aware that Redis Enterprise Software relies on certain components that require support from the operating system.  You cannot enable support for components, services, protocols, or versions that aren't supported by the operating system running Redis Enterprise Software.  In addition, updates to the operating system or to Redis Enterprise Software can impact component support.
 


### PR DESCRIPTION
Removed references to the platforms we stopped supporting in 2020.
Updated the naming of "Platforms" to "Redis Enterprise Software on Kubernetes" to reflect the change in documentation structure.