### PR TITLE
Removed xkusage option RED-69013

### DIFF
--- a/content/rs/references/rladmin.md
+++ b/content/rs/references/rladmin.md
@@ -590,7 +590,6 @@ rladmin tune db <db:id | name>
         [ syncer_monitoring <enabled | disabled> ]
         [ mtls_allow_weak_hashing <enabled | disabled> ]
         [ mtls_allow_outdated_cert <enabled | disabled> ]
-        [ mtls_allow_no_xkusage <enabled | disabled> ]
         [ data_internode_encryption <enable | disable> ]
 ```
 


### PR DESCRIPTION
tune db mtls_allow_no_xkusage option is not available in the product; removed reference.