### PR TITLE
K8s Intrepid release

### DIFF
--- a/content/kubernetes/deployment/openshift/_index.md
+++ b/content/kubernetes/deployment/openshift/_index.md
@@ -47,7 +47,7 @@ To [create a database on an OpenShift 4.x cluster via the OperatorHub]({{< relre
 
 ## For OpenShift via the CLI
 
-To [create a database on an OpenShift cluster via the CLI]({{< relref "openshift-cli.md" >}}) you need:
+To [create a database on an OpenShift cluster via the CLI]({{< relref "openshift-cli.md" >}}), you need:
 
 1. An [OpenShift cluster installed](https://docs.openshift.com/container-platform/4.3/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}).
 1. The [kubectl package installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/) at version 1.9 or higher

--- a/content/kubernetes/deployment/openshift/_index.md
+++ b/content/kubernetes/deployment/openshift/_index.md
@@ -47,8 +47,8 @@ To [create a database on an OpenShift 4.x cluster via the OperatorHub]({{< relre
 
 ## For OpenShift via the CLI
 
-To [create a database on an OpenShift 4.x cluster via the CLI]({{< relref "openshift-cli.md" >}}) you need:
+To [create a database on an OpenShift cluster via the CLI]({{< relref "openshift-cli.md" >}}) you need:
 
-1. An [OpenShift 4.x cluster installed](https://docs.openshift.com/container-platform/4.3/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}).
+1. An [OpenShift cluster installed](https://docs.openshift.com/container-platform/4.3/welcome/index.html) with at least three nodes that each meet the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}).
 1. The [kubectl package installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/) at version 1.9 or higher
 1. The [OpenShift cli installed](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html)

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -24,7 +24,10 @@ cluster with OpenShift.
 
 ## Prerequisites
 
-- [OpenShift cluster](https://docs.openshift.com/container-platform/4.8/installing/index.html) installed at version 4.6 or higher, with at least three nodes (each meeting the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}))
+- [OpenShift cluster](https://docs.openshift.com/container-platform/4.8/installing/index.html) installed, with at least three nodes (each meeting the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}))
+  {{<note>}}
+If you are running an OpenShift 3 version, use the `bundle.yaml` file located in teh `openshift_3_x` folder in the `redis-enterprise-k8s-docs` repo. This folder also contains the custom resource definitions (CRDs) compatible with OpenShift 3.x.  
+  {{</note>}}
 - [kubectl tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/)  installed at version 1.9 or higher
 - [OpenShift CLI](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html) installed
 
@@ -69,15 +72,21 @@ cluster with OpenShift.
     oc adm policy add-scc-to-user redis-enterprise-scc system:serviceaccount:<my-project>:rec
     ```
 
-    You can see the name of your project with the `oc project` command to replace `<my-project>` in the command above. Replace `rec` with the name of your Redis Enterprise cluster, if different. 
+    You can see the name of your project with the `oc project` command to replace `<my-project>` in the command above. Replace `rec` with the name of your Redis Enterprise cluster, if different.
 
 1. Deploy the OpenShift operator bundle.
 
-    {{< warning >}}Changes to the `openshift.bundle.yaml` file can cause unexpected results.{{< /warning >}}
+  {{<note>}}
+If you are running on OpenShift 3.x, use the `openshift.bundle.yaml` file in the `openshift_3_x` folder.
+  {{</note>}}
 
-    ```sh
-    oc apply -f openshift.bundle.yaml
-    ```
+  ```sh
+  oc apply -f openshift.bundle.yaml
+   ```
+
+{{< warning >}}
+Changes to the `openshift.bundle.yaml` file can cause unexpected results.
+{{< /warning >}}
 
 1. Verify that your redis-enterprise-operator deployment is running, run:
 

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -26,7 +26,7 @@ cluster with OpenShift.
 
 - [OpenShift cluster](https://docs.openshift.com/container-platform/4.8/installing/index.html) installed, with at least three nodes (each meeting the [minimum requirements for a development installation]({{< relref "/rs/administering/designing-production/hardware-requirements.md" >}}))
   {{<note>}}
-If you are running an OpenShift 3 version, use the `bundle.yaml` file located in teh `openshift_3_x` folder in the `redis-enterprise-k8s-docs` repo. This folder also contains the custom resource definitions (CRDs) compatible with OpenShift 3.x.  
+If you are running an OpenShift 3 version, use the `bundle.yaml` file located in the `openshift_3_x` folder in the `redis-enterprise-k8s-docs` repo. This folder also contains the custom resource definitions (CRDs) compatible with OpenShift 3.x.  
   {{</note>}}
 - [kubectl tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/)  installed at version 1.9 or higher
 - [OpenShift CLI](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html) installed

--- a/content/kubernetes/re-clusters/create-aa-database.md
+++ b/content/kubernetes/re-clusters/create-aa-database.md
@@ -127,6 +127,16 @@ From inside your K8s cluster, edit your Redis Enterprise cluster (REC) resource 
 
 1. Make sure you have DNS aliases for each database that resolve your API hostname `<api-hostname>`,`<ingress-suffix>`, `<replication-hostname>` to the IP address of the ingress controller’s LoadBalancer. To avoid entering multiple DNS records, you can use a wildcard in your alias (such as `*.ijk.redisdemo.com`).
 
+#### If using Istio Gateway and VirtualService
+
+No changes are required to the REC spec if you are using [Istio]({{<relref "/kubernetes/re-databases/ingress_routing_with_istio.md">}}) in place of an ingress controller. The `activeActive` section added above creates ingress resources. The two custom resources used to configure Istio (Gateway and VirtualService) replace the need for ingress resources.
+
+{{<warning>}}
+These custom resources are not controlled by the operator and will need to be configured and maintained manually.
+{{</warning>}}
+
+For each cluster, verify the VirtualService resource has two `- match:` blocks in the `tls` section. The hostname under `sniHosts:` should match your `<replication-hostname>`.
+
 ### Using OpenShift routes
 
 1. Make sure your Redis Enterprise cluster (REC) has a different name (`<rec-name.namespace>`) than any other participating clusters. If not, you'll need to manually rename the REC or move it to a different namespace.
@@ -161,7 +171,6 @@ From inside your K8s cluster, edit your Redis Enterprise cluster (REC) resource 
     NAME    HOST/PORT                       PATH    SERVICES  PORT  TERMINATION   WILDCARD
     rec01   api-openshift.apps.abc.redisdemo.com rec01   api             passthrough   None
     ```
-
 
 ## Create an Active-Active database with `crdb-cli`
 

--- a/content/kubernetes/re-databases/ingress_routing_with_istio.md
+++ b/content/kubernetes/re-databases/ingress_routing_with_istio.md
@@ -113,7 +113,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
           - api.istio.k8s.my.redisdemo.com
         route:
         - destination:
-            host: rec
+            host: rec1
             port:
               number: 9443
       - match:
@@ -125,10 +125,11 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
             host: db1
     ```
 
-    This creates both a route to contact the API server and a route to contact one of the databases (`db1` in this example).
+    This creates both a route to contact the API server on the REC (`rec1`) and a route to contact one of the databases (`db1`).
 
     - Replace `.istio.k8s.my.redisdemo.com` with the domain that matches your DNS record.
     - The gateway's metadata name must be similar to the gateway's spec name (`redis-gateway` in this example).
+    - When creating an Active-Active database with the `crdb-cli` command,  
 
 1. Apply `redis-vs.yaml` to create the virtual service.
 

--- a/content/kubernetes/re-databases/ingress_routing_with_istio.md
+++ b/content/kubernetes/re-databases/ingress_routing_with_istio.md
@@ -34,7 +34,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
 
 1. Create a DNS entry that resolves your chosen database hostname (or a wildcard `*` followed by your domain) to the Istio `EXTERNAL-IP`. Use this hostname to access your database from outside the cluster.
 
-    In this example, any hostname that ends with `.istio.k8s.my.redisdemo.com` will resolve to the Istio LoadBalancer's external IP of `12.345.678.910`. Substitute your own values accordingly.
+    In this example, any hostname that ends with `.istio.k8s.my.redisdemo.com` will resolve to the Istio LoadBalancer's external IP of `10.145.78.91`. Substitute your own values accordingly.
 
 1. Verify the record was created successfully.
 
@@ -46,7 +46,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
 
     ```sh
     ;; ANSWER SECTION:
-    api.istio.k8s.my.redisdemo.com. 0 IN    A       12.345.678.910
+    api.istio.k8s.my.redisdemo.com. 0 IN    A       10.145.78.91
     ```
 
 ## Create custom resources

--- a/content/kubernetes/re-databases/ingress_routing_with_istio.md
+++ b/content/kubernetes/re-databases/ingress_routing_with_istio.md
@@ -1,0 +1,155 @@
+---
+Title: Configure Istio for external routing
+linkTitle: Istio ingress routing
+description: Configure Istio as an ingress controller for access to your Redis Enterprise databases from outside the Kubernetes cluster. 
+weight: 25
+alwaysOpen: false
+categories: ["Platforms"]
+aliases: [
+    /kubernetes/re-databases/ingress_routing_with_istio.md,
+    /kubernetes/re-databases/ingress_routing_with_istio/,
+]
+---
+
+Redis Enterprise for Kubernetes version `6.2.8-tbd` introduces the ability to use an Istio ingress gateway as an alternative to NGINX or HaProxy ingress controllers.
+
+Istio can also understand ingress resources, but using that mechanism takes away the advantages and options that the native Istio resources provide. Istio offers its own configuration methods using custom resources.
+
+To configure Istio to work with the Redis Kubernetes operator, we will use two custom resources: a `Gateway` and a `VirtualService`. Then you'll be able to establish external access to your database.
+
+## Install and configure Istio for Redis Enterprise
+
+1. [Download](https://istio.io/latest/docs/setup/getting-started/) and [install](https://istio.io/latest/docs/setup/getting-started/) Istio (see instructions from Istio's [Getting Started](https://istio.io/latest/docs/setup/getting-started/) guide).
+
+    Once the installation is complete, all the deployments, pods, and services will be deployed in a namespace called `istio-system`. This namespace contains a `LoadBalancer` type service called `service/istio-ingressgateway` that exposes the external IP address.
+
+1. Find the `EXTERNAL-IP` for the `istio-ingressgateway` service.
+
+    ```sh
+    kubectl get svc istio-ingressgateway -n istio-system
+
+    NAME                   TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                                                      AGE
+    istio-ingressgateway   LoadBalancer   10.34.67.89   10.145.78.91   15021:12345/TCP,80:67891/TCP,443:23456/TCP,31400:78901/TCP,15443:10112/TCP   3h8m
+    ```
+
+1. Create a DNS entry that resolves your chosen database hostname (or a wildcard `*` followed by your domain) to the Istio `EXTERNAL-IP`. Use this hostname to access your database from outside the cluster.
+
+    In this example, any hostname that ends with `.istio.k8s.my.redisdemo.com` will resolve to the Istio LoadBalancer's external IP of `12.345.678.910`. Substitute your own values accordingly.
+
+1. Verify the record was created successfully.
+
+    ```sh
+    dig api.istio.k8s.my.redisdemo.com
+    ```
+
+    Look in the `ANSWER SECTION` for the record you just created.
+
+    ```sh
+    ;; ANSWER SECTION:
+    api.istio.k8s.my.redisdemo.com. 0 IN    A       12.345.678.910
+    ```
+
+## Create custom resources
+
+### `Gateway` custom resource
+
+1. On a different namespace from `istio-system`, create a `Gateway` custom resource file (`redis-gateway.yaml`).
+
+    ```yaml
+    apiVersion: networking.istio.io/v1beta1
+    kind: Gateway
+    metadata:
+      name: redis-gateway
+    spec:
+      selector:
+        istio: ingressgateway 
+      servers:
+      - hosts:
+        - '*.istio.k8s.my.redisdemo.com'
+        port:
+          name: https
+          number: 443
+          protocol: HTTPS
+        tls:
+          mode: PASSTHROUGH
+    ```
+
+    - Replace `.istio.k8s.my.redisdemo.com` with the domain that matches your DNS record.
+    - TLS passthrough mode is required to allow secure access to the database.
+
+1. Apply `gateway.yaml` to create the ingress gateway.
+
+    ```sh
+    kubectl apply -f gateway.yaml
+    ```
+
+1. Verify the gateway was created successfully.
+
+      ```sh
+      kubectl get gateway
+
+      NAME            AGE
+      redis-gateway   3h33m
+      ```
+
+### `VirtualService` custom resource
+
+1. On a different namespace than `istio-system`, create the `VirtualService` custom resource file (`redis-vs.yaml`).
+
+    ```yaml
+    apiVersion: networking.istio.io/v1beta1
+    kind: VirtualService
+    metadata:
+      name: redis-vs
+    spec:
+      gateways:
+      - redis-gateway
+      hosts:
+      - "*.istio.k8s.my.redisdemo.com"
+      tls:
+      - match:
+        - port: 443
+          sniHosts:
+          - api.istio.k8s.my.redisdemo.com
+        route:
+        - destination:
+            host: rec
+            port:
+              number: 9443
+      - match:
+        - port: 443
+          sniHosts:
+          - db1.istio.k8s..my.redisdemo.com
+        route:
+        - destination:
+            host: db1
+    ```
+
+    This creates both a route to contact the API server and a route to contact one of the databases (`db1` in this example).
+
+    - Replace `.istio.k8s.my.redisdemo.com` with the domain that matches your DNS record.
+    - The gateway's metadata name must be similar to the gateway's spec name (`redis-gateway` in this example).
+
+1. Apply `redis-vs.yaml` to create the virtual service.
+
+    ```sh
+    kubectl apply -f redis-vs.yaml
+    ```
+
+1. Verify the virtual service was created successfully.
+
+    ```sh
+    kubectl get vs
+
+    NAME       GATEWAYS            HOSTS                              AGE
+    redis-vs   ["redis-gateway"]   ["*.istio.k8s.my.redisdemo.com"]   3h33m
+    ```
+
+1. [Deploy the operator]({{<relref "/kubernetes/deployment/quick-start.md">}}), Redis Enterprise Cluster (REC), and Redis Enterprise Database (REDB) on the same namespace as the gateway and virtual service.
+
+## Test your external access to the database
+
+To [test your external access]({{<relref "/kubernetes/re-databases/set-up-ingress-controller.md">}}) to the database, you need a client that supports [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) and [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication).
+
+See [Test your access with Openssl]({{<relref "/kubernetes/re-databases/set-up-ingress-controller#test-your-access-with-openssl">}}) or [Test your access with Python]({{<relref "/kubernetes/re-databases/set-up-ingress-controller#test-your-access-with-python">}}) for more info.
+

--- a/content/kubernetes/re-databases/ingress_routing_with_istio.md
+++ b/content/kubernetes/re-databases/ingress_routing_with_istio.md
@@ -11,7 +11,7 @@ aliases: [
 ]
 ---
 
-Redis Enterprise for Kubernetes version `6.2.8-tbd` introduces the ability to use an Istio ingress gateway as an alternative to NGINX or HaProxy ingress controllers.
+Redis Enterprise for Kubernetes version `6.2.8-11` introduces the ability to use an Istio ingress gateway as an alternative to NGINX or HaProxy ingress controllers.
 
 Istio can also understand ingress resources, but using that mechanism takes away the advantages and options that the native Istio resources provide. Istio offers its own configuration methods using custom resources.
 

--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -26,23 +26,28 @@ Each release of the Redis Enterprise operator is thoroughly tested against a set
 | OpenShift 4.6  (K8s 1.19)       | supported      |
 | OpenShift 4.7  (K8s 1.20)       | supported      |
 | OpenShift 4.8  (K8s 1.21)       | supported      |
+| OpenShift 4.9  (K8s 1.22)       | supported      |
 | KOPS vanilla 1.18               | supported      |
 | KOPS vanilla 1.19               | supported      |
 | KOPS vanilla 1.20               | supported      |
 | KOPS vanilla 1.21               | supported      |
+| KOPS vanilla 1.22               | supported      |
 | GKE 1.19                        | supported      |
 | GKE 1.20                        | supported      |
 | GKE 1.21                        | supported      |
-| Rancher 2.4 (K8s 1.17)          | deprecated     |
-| Rancher 2.4 (K8s 1.18)          | deprecated     |
+| GKE 1.22                        | supported      |
 | Rancher 2.5 (K8s 1.17)          | supported      |
 | Rancher 2.5 (K8s 1.18)          | supported      |
 | Rancher 2.5 (K8s 1.19)          | supported      |
 | Rancher 2.5 (K8s 1.20)          | supported      |
 | VMWare TKGI** 1.10 (K8s 1.19)   | supported      |
 | AKS 1.19                        | supported      |
+| AKS 1.20                        | supported      |
 | AKS 1.21                        | supported      |
+| AKS 1.22                        | supported      |
 | EKS 1.18                        | supported      |
+| EKS 1.19                        | supported      |
+| EKS 1.20                        | supported      |
 | EKS 1.21                        | supported      |
  
 \* No longer supported by the vendor  

--- a/content/kubernetes/release-notes/_index.md
+++ b/content/kubernetes/release-notes/_index.md
@@ -1,5 +1,6 @@
 ---
-Title: Release notes
+Title: Redis Enterprise Software for Kubernetes release notes
+linkTitle: Release notes
 description: Redis Enterprise Software for Kubernetes operator release notes. 
 weight: 90
 alwaysopen: false
@@ -11,18 +12,5 @@ aliases: [
     /kubernetes/release-notes/,
 ]
 ---
-## Redis Enterprise Software for Kubernetes operator release notes
 
-- [6.2.8-2 (November 2021)]({{<relref "/kubernetes/release-notes/k8s-6-2-8-2-2021-11.md">}})
-- [6.2.4-1 (September 2021)]({{<relref "/kubernetes/release-notes/k8s-6-2-4-1-2021-09.md">}})
-- [6.0.20-12 (July 2021)]({{<relref "/kubernetes/release-notes/k8s-6-0-20-12-2021-07.md">}})
-- [6.0.20-4 (May 2021)]({{<relref "/kubernetes/release-notes/k8s-6-0-20-4-2021-05.md">}})
-- [6.0.12-5 (February 2021)]({{<relref "/kubernetes/release-notes/k8s-6-0-12-5-2021-02.md">}})
-- [6.0.8-20 (December 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-8-20-2020-12.md">}})
-- [6.0.8-1 (October 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-8-1-2020-10.md">}})
-- [6.0.6-24 (August 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-6-24-2020-08.md">}})
-- [6.0.6-23 (August 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-6-23-2020-08.md">}})
-- [6.0.6-11 (July 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-6-11-2020-07.md">}})
-- [6.0.6-6 (June 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-6-6-2020-06.md">}})
-- [5.4.14-2 (March 2020)]({{<relref "/kubernetes/release-notes/k8s-6-0-6-6-2020-06.md">}})
-- [5.4.10-8 January 2020]({{<relref "/kubernetes/release-notes/k8s-5-4-10-8-january-2020.md">}})
+{{<table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes" columnSources="LinkTitle,Description" enableLinks="LinkTitle">}}

--- a/content/kubernetes/release-notes/k8s-5-4-10-8-january-2020.md
+++ b/content/kubernetes/release-notes/k8s-5-4-10-8-january-2020.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 5.4.10-8 (January 2020)
-linktitle: 5.4.10-8 (January 2020)
-description: Release notes for version 5.4.10-8
+linkTitle: 5.4.10-8 (January 2020)
+description: Support for the Redis Enterprise Software 5.4.10 and multiple enhancements.
 weight: 85
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/release-notes/k8s-5-4-14-2-2020-03.md
+++ b/content/kubernetes/release-notes/k8s-5-4-14-2-2020-03.md
@@ -1,6 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 5.4.14-2 (March 2020)
-description: Release notes for version 5.4.14-2
+linkTitle: 5.4.14-2 (March 2020)
+description: Support for Redis Enterprise Software 5.4.14, K8s 1.16, and OpenShift 4.3.
 linktitle: 5.4.14-2 (March 2020)
 weight: 84
 alwaysopen: false

--- a/content/kubernetes/release-notes/k8s-6-0-12-5-2021-02.md
+++ b/content/kubernetes/release-notes/k8s-6-0-12-5-2021-02.md
@@ -1,9 +1,9 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.12-5 (February 2021)
-linktitle: 6.0.12-5 (February 2021)
-description: Release notes for version 6.0.12-5
+linkTitle: 6.0.12-5 (February 2021)
+description: Support for RS 6.0.12-57, Amazon Kubernetes Service (AKS), and role permissions on custom resources. 
 weight: 70
-alwaysopen: false
+alwaysOpen: false
 categories: ["Platforms"]
 aliases: [
     /platforms/release-notes/k8s-6-0-12-5-2021-02.md,

--- a/content/kubernetes/release-notes/k8s-6-0-20-12-2021-07.md
+++ b/content/kubernetes/release-notes/k8s-6-0-20-12-2021-07.md
@@ -1,9 +1,9 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.20-12 (July 2021)
-linktitle: 6.0.20-12 (July 2021)
-description: Release notes for version 6.0.20-12
+linkTitle: 6.0.20-12 (July 2021)
+description: Support for RS 6.0.20-97, EKS, Hashicorp Vault, and added feature support for OpenShift OLM.
 weight: 68
-alwaysopen: false
+alwaysOpen: false
 categories: ["Platforms"]
 aliases: [
     /platforms/release-notes/k8s-6-0-20-12-2021-07.md,

--- a/content/kubernetes/release-notes/k8s-6-0-20-4-2021-05.md
+++ b/content/kubernetes/release-notes/k8s-6-0-20-4-2021-05.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.20-4 (May 2021)
 linktitle: 6.0.20-4 (May 2021)
-description: Release notes for version 6.0.20-4
+description: Support for 6.0.20-69, OpenShift 4.7, and K8s 1.20. Hashicorp Vault integration with REC and REDB secrets. 
 weight: 69
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/release-notes/k8s-6-0-6-11-2020-07.md
+++ b/content/kubernetes/release-notes/k8s-6-0-6-11-2020-07.md
@@ -1,9 +1,9 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.6-11 (July 2020)
-linktitle: 6.0.6-11 (July 2020)
-description: Release notes for version 6.0.6-11
+linkTitle: 6.0.6-11 (July 2020)
+description: Maintenance release; support RS 6.0.6-39 and various bug fixes.
 weight: 78
-alwaysopen: false
+alwaysOpen: false
 categories: ["Platforms"]
 aliases: [
     /platforms/release-notes/k8s-6-0-6-11-2020-07.md,

--- a/content/kubernetes/release-notes/k8s-6-0-6-23-2020-08.md
+++ b/content/kubernetes/release-notes/k8s-6-0-6-23-2020-08.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.6-23 (August 2020)
-linktitle: 6.0.6-23 (August 2020)
-description: Release notes for version 6.0.6-23
+linkTitle: 6.0.6-23 (August 2020)
+description: Support for Redis Enterprise Software 6.0.6-39, Rancher support, new database backup and alert options.
 weight: 76
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/release-notes/k8s-6-0-6-24-2020-08.md
+++ b/content/kubernetes/release-notes/k8s-6-0-6-24-2020-08.md
@@ -1,9 +1,9 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.6-24 (August 2020)
-linktitle: 6.0.6-24 (August 2020)
-description: Release notes for version 6.0.6-24
+linkTitle: 6.0.6-24 (August 2020)
+description: Various bug fixes.
 weight: 75
-alwaysopen: false
+alwaysOpen: false
 categories: ["Platforms"]
 aliases: [
     /platforms/release-notes/k8s-6-0-6-24-2020-08.md,

--- a/content/kubernetes/release-notes/k8s-6-0-6-6-2020-06.md
+++ b/content/kubernetes/release-notes/k8s-6-0-6-6-2020-06.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.6-6 (June 2020)
-linktitle: 6.0.6-6 June 2020
-description: Release notes for version 6.0.6-6
+linkTitle: 6.0.6-6 (June 2020)
+description: Support for RS 6.0.6, new database and admission controllers, various improvements and bug fixes.
 weight: 80
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/release-notes/k8s-6-0-8-1-2020-10.md
+++ b/content/kubernetes/release-notes/k8s-6-0-8-1-2020-10.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.8-1 (October 2020)
 linktitle: 6.0.8-1 (October 2020)
-description: Release notes for version 6.0.8-1
+description: Support for RS 6.0.8-28, OpenShift 4.5, K8s 1.18, and Gesher admission controller proxy. 
 weight: 74
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/release-notes/k8s-6-0-8-20-2020-12.md
+++ b/content/kubernetes/release-notes/k8s-6-0-8-20-2020-12.md
@@ -1,9 +1,9 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.0.8-20 (December 2020)
-linktitle: 6.0.8-20 (December 2020)
-description: Release notes for version 6.0.8-20
+linkTitle: 6.0.8-20 (December 2020)
+description: Support for RS 6.0.8, consumer namespaces, Gesher admission controller proxy, and custom resource validation via schema.
 weight: 72
-alwaysopen: false
+alwaysOpen: false
 categories: ["Platforms"]
 aliases: [
     /platforms/release-notes/k8s-6-0-8-20-2020-12.md,

--- a/content/kubernetes/release-notes/k8s-6-2-4-1-2021-09.md
+++ b/content/kubernetes/release-notes/k8s-6-2-4-1-2021-09.md
@@ -1,9 +1,9 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.2.4-1 (September 2021)
-linktitle: 6.2.4-1 (September 2021)
-description: Release notes for version 6.2.4-1
+linkTitle: 6.2.4-1 (September 2021)
+description: Support for RS 6.2.4 and OpenShift 4.8. Support for K8s 1.19 (EKS and AKS), K8s 1.20 (Rancher, EKS, AKS), K8s 1.21 (GKE and kOps).
 weight: 67
-alwaysopen: false
+alwaysOpen: false
 categories: ["Platforms"]
 aliases: [
     /platforms/release-notes/k8s-6-2-4-1-2021-09.md,

--- a/content/kubernetes/release-notes/k8s-6-2-8-10-2022-01.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-10-2022-01.md
@@ -1,0 +1,128 @@
+---
+Title: Redis Enterprise for Kubernetes Release Notes 6.2.8-10 (January 2022)
+linktitle: 6.2.8-10 (January 2022)
+description: Support for Istio as ingress controller, K8s 1.22 (AKS, kOps, GKE), OpenShift 4.9. 
+weight: 66
+alwaysopen: false
+categories: ["Platforms"]
+aliases: [
+    /kubernetes/release-notes/k8s-6-2-8-10-2022-01.md,
+    /kubernetes/release-notes/k8s-6-2-8-10-2022-01/,   ]
+---
+## Overview
+
+The Redis Enterprise K8s 6.2.8-10 release provides support for the [Redis Enterprise Software release 6.2.8]({{<relref "/rs/release-notes/rs-6-2-8-october-2021.md">}}) and includes several enhancements and bug fixes.
+
+The key new features, bug fixes, and known limitations are described below.
+
+## Images
+
+This release includes the following container images:
+
+* **Redis Enterprise**: `redislabs/redis:6.2.8-53` or  `redislabs/redis:6.2.8-53.rhel7-openshift`
+* **Operator**: `redislabs/operator:6.2.8-10`
+* **Services Rigger**: `redislabs/k8s-controller:6.2.8-10` or `redislabs/services-manager:6.2.8-10` (on the Red Hat registry)
+
+## Feature improvements
+
+* Istio gateway/virtual services are supported as ingress controllers. Note that for Active-Active databases, the operator doesn't create ingress rules, and those should be manually configured. The version of Istio that was tested is Istio 1.12.0  (RED-64020)
+* Support for K8s 1.22 (AKS, kOps, GKE) and OpenShift 4.9 (RED-64016)
+* Support for pod termination grace period customization in the REC (advanced use case) (RED-67217)
+* Improved security granularity of SCC configuration steps in documentation (RED-67321)
+* Changed behavior when two databases with the same name are created on the cluster. The operator avoids creating a service for them to prevent possible corruption (RED-64535)
+* Improved documentation about changing cluster credentials when using Hashicorp Vault (RED-65304)
+
+## Fixed bugs
+
+* Upgraded Go dependencies marked as vulnerable (RED-63858, RED-68651)
+* Avoided flooding operator logs with deprecation notices on K8s 1.21 (RED-67544)
+* Fixed log collector utility issues running on Microsoft Windows (RED-67682)
+* Fixed excessive updates to the RS cluster when using Windows line endings for TLS certificates (RED-67874)
+
+## Known limitations
+
+### Long cluster names cause routes to be rejected  (RED-25871)
+
+A cluster name longer than 20 characters will result in a rejected route configuration because the host part of the domain name will exceed 63 characters. The workaround is to limit cluster name to 20 characters or less.
+
+### Cluster CR (REC) errors are not reported after invalid updates (RED-25542)
+
+A cluster CR specification error is not reported if two or more invalid CR resources are updated in sequence.
+
+### An unreachable cluster has status running (RED-32805)
+
+When a cluster is in an unreachable state, the state is still `running` instead of being reported as an error.
+
+### Readiness probe incorrect on failures (RED-39300)
+
+STS Readiness probe does not mark a node as "not ready" when running `rladmin status` on node failure.
+
+### Role missing on replica sets (RED-39002)
+
+The `redis-enterprise-operator` role is missing permission on replica sets.
+
+### Private registries are not supported on OpenShift 3.11 (RED-38579)
+
+OpenShift 3.11 does not support DockerHub private registries. This is a known OpenShift issue.
+
+### Internal DNS and Kubernetes DNS may have conflicts (RED-37462)
+
+DNS conflicts are possible between the cluster `mdns_server` and the K8s DNS. This only impacts DNS resolution from within cluster nodes for Kubernetes DNS names.
+
+### 5.4.10 negatively impacts 5.4.6 (RED-37233)
+
+Kubernetes-based 5.4.10 deployments seem to negatively impact existing 5.4.6 deployments that share a Kubernetes cluster.
+
+### Node CPU usage is reported instead of pod CPU usage (RED-36884)
+
+In Kubernetes, the node CPU usage we report on is the usage of the Kubernetes worker node hosting the REC pod.
+
+### Clusters must be named "rec" in OLM-based deployments (RED-39825)
+
+In OLM-deployed operators, the deployment of the cluster will fail if the name is not "rec". When the operator is deployed via the OLM, the security context constraints (scc) are bound to a specific service account name (i.e., "rec"). The workaround is to name the cluster "rec".
+
+### REC clusters fail to start on Kubernetes clusters with unsynchronized clocks (RED-47254)
+
+When REC clusters are deployed on Kubernetes clusters with unsynchronized clocks, the REC cluster does not start correctly. The fix is to use NTP to synchronize the underlying K8s nodes.
+
+### Deleting an OpenShift project with an REC deployed may hang (RED-47192)
+
+When a REC cluster is deployed in a project (namespace) and has REDB resources, the
+REDB resources must be deleted first before the REC can be deleted. As such, until the
+REDB resources are deleted, the project deletion will hang. The fix is to delete the
+REDB resources first and the REC second. Afterwards, you may delete the project.
+
+### REC extraLabels are not applied to PVCs on K8s versions 1.15 or older (RED-51921)
+
+In K8s 1.15 or older, the PVC labels come from the match selectors and not the
+PVC templates. As such, these versions cannot support PVC labels. If this feature
+is required, the only fix is to upgrade the K8s cluster to a newer version.
+
+### Hashicorp Vault integration - no support for Gesher (RED-55080)
+
+There is no workaround at this time
+
+### REC might report error states on initial startup (RED-61707)
+
+There is no workaround at this time except to ignore the errors.
+
+### PVC size issues when using decimal value in spec (RED-62132)
+
+The workaround for this issue is to make sure you use integer values for the PVC size.
+
+## Compatibility Notes
+
+See [Supported Kubernetes distributions]({{< relref "/kubernetes/reference/supported_k8s_distributions.md" >}}) for the full list of supported distributions.
+
+### Now supported
+
+This release adds support for the following:
+
+* K8s 1.22 for GKE, AKS, and kOps
+* OpenShift 4.9 (uses K8s 1.22)
+
+### No longer supported
+
+This release removes support for the following:
+
+* Rancher 2.4 (previously deprecated)

--- a/content/kubernetes/release-notes/k8s-6-2-8-11-2022-01.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-11-2022-01.md
@@ -1,17 +1,17 @@
 ---
-Title: Redis Enterprise for Kubernetes Release Notes 6.2.8-10 (January 2022)
-linktitle: 6.2.8-10 (January 2022)
-description: Support for Istio as ingress controller, K8s 1.22 (AKS, kOps, GKE), OpenShift 4.9. 
+Title: Redis Enterprise for Kubernetes Release Notes 6.2.8-11 (January 2022)
+linktitle: 6.2.8-11 (January 2022)
+description: Support for Istio as ingress controller, K8s 1.22 (AKS, kOps, GKE), OpenShift 4.9 
 weight: 66
 alwaysopen: false
 categories: ["Platforms"]
 aliases: [
-    /kubernetes/release-notes/k8s-6-2-8-10-2022-01.md,
-    /kubernetes/release-notes/k8s-6-2-8-10-2022-01/,   ]
+    /kubernetes/release-notes/k8s-6-2-8-11-2022-01.md,
+    /kubernetes/release-notes/k8s-6-2-8-11-2022-01/,   ]
 ---
 ## Overview
 
-The Redis Enterprise K8s 6.2.8-10 release provides support for the [Redis Enterprise Software release 6.2.8]({{<relref "/rs/release-notes/rs-6-2-8-october-2021.md">}}) and includes several enhancements and bug fixes.
+The Redis Enterprise K8s 6.2.8-11 release provides support for the [Redis Enterprise Software release 6.2.8]({{<relref "/rs/release-notes/rs-6-2-8-october-2021.md">}}) and includes several enhancements and bug fixes.
 
 The key new features, bug fixes, and known limitations are described below.
 
@@ -20,8 +20,8 @@ The key new features, bug fixes, and known limitations are described below.
 This release includes the following container images:
 
 * **Redis Enterprise**: `redislabs/redis:6.2.8-53` or  `redislabs/redis:6.2.8-53.rhel7-openshift`
-* **Operator**: `redislabs/operator:6.2.8-10`
-* **Services Rigger**: `redislabs/k8s-controller:6.2.8-10` or `redislabs/services-manager:6.2.8-10` (on the Red Hat registry)
+* **Operator**: `redislabs/operator:6.2.8-11`
+* **Services Rigger**: `redislabs/k8s-controller:6.2.8-11` or `redislabs/services-manager:6.2.8-11` (on the Red Hat registry)
 
 ## Feature improvements
 
@@ -110,6 +110,10 @@ There is no workaround at this time except to ignore the errors.
 
 The workaround for this issue is to make sure you use integer values for the PVC size.
 
+### Following old revision of quick start guide causes issues creating an REDB due to unrecognized memory field name
+
+The workaround is to use the newer (current) revision of the quick start document available online.
+
 ## Compatibility Notes
 
 See [Supported Kubernetes distributions]({{< relref "/kubernetes/reference/supported_k8s_distributions.md" >}}) for the full list of supported distributions.
@@ -120,6 +124,10 @@ This release adds support for the following:
 
 * K8s 1.22 for GKE, AKS, and kOps
 * OpenShift 4.9 (uses K8s 1.22)
+
+### Deprecated
+
+* Rancher 2.5/K8s 1.17 support is deprecated
 
 ### No longer supported
 

--- a/content/kubernetes/release-notes/k8s-6-2-8-2-2021-11.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-2-2021-11.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.2.8-2 (November 2021)
 linktitle: 6.2.8-2 (November 2021)
-description: Release notes for version 6.2.8-2 of Redis Enterprise Software for Kubernetes. 
+description: Support for RS 6.2.8, certificate management, and Redis upgrade policy.
 weight: 66
 alwaysopen: false
 categories: ["Platforms"]


### PR DESCRIPTION
Updated pages: 

- https://docs.redis.com/staging/release-k8s-intrepid/kubernetes/release-notes/
- https://docs.redis.com/staging/release-k8s-intrepid/kubernetes/deployment/openshift/_index/
- https://docs.redis.com/staging/release-k8s-intrepid/kubernetes/deployment/openshift/openshift-cli/
- https://docs.redis.com/staging/release-k8s-intrepid/kubernetes/re-clusters/create-aa-database/
- https://docs.redis.com/staging/release-k8s-intrepid/kubernetes/re-databases/ingress_routing_with_istio/
- https://docs.redis.com/staging/release-k8s-intrepid/kubernetes/release-notes/_index/

Jiras:
DOC-994
DOC-1071
DOC-1091
DOC-995
DOC-1092
