### PR TITLE
typo

### DIFF
--- a/content/kubernetes/deployment/openshift/openshift-operatorhub.md
+++ b/content/kubernetes/deployment/openshift/openshift-operatorhub.md
@@ -48,11 +48,11 @@ this constraint installed, the operator cannot create Redis Enterprise clusters.
 
 The security context constraint for the operator needs to be **installed only once** and **must not be deleted**.
 
-The constraint [scc.yaml](https://raw.githubuser.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml)
+The constraint [scc.yaml](curl -O https://github.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml)
 can be downloaded and installed by a cluster administrator with the commands:
 
 ```sh
-curl -O https://raw.githubuser.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml
+curl -O https://github.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml
 oc apply -f scc.yaml
 ```
 


### PR DESCRIPTION
raw.githubuser.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml
should be replaced by
github.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml