### PR TITLE
Add flag that advises using the internal endpoint

### DIFF
--- a/content/rc/security/vpc-peering.md
+++ b/content/rc/security/vpc-peering.md
@@ -72,4 +72,4 @@ The VPC peering configuration requires you to initiate VPC peering on your Redis
 
 Now the VPC Peering request is accepted. Its status in the VPC Peering tab in the Redis Cloud subscription is updated to 'Peer Established'.
 
-**Make sure to switchover your application connection string to the private endpoint instead of the public endpoint once the peering is established**
+Once peering is established, we recommend switching your application connection string to the private endpoint. 

--- a/content/rc/security/vpc-peering.md
+++ b/content/rc/security/vpc-peering.md
@@ -72,3 +72,4 @@ The VPC peering configuration requires you to initiate VPC peering on your Redis
 
 Now the VPC Peering request is accepted. Its status in the VPC Peering tab in the Redis Cloud subscription is updated to 'Peer Established'.
 
+**Make sure to switchover your application connection string to the private endpoint instead of the public endpoint once the peering is established**


### PR DESCRIPTION
While this documentation gives all of the relevant details on setting up VPC peering, it should also include a note (possibly highlighted or in a section that draws the eyes of the user) that the application connection string needs to be altered to point to the internal endpoint now. While this might seem obvious, there have been a couple of cases where customers enabled VPC peering, but didn't switchover the endpoints. This has led to these customers incurring large network costs due to the egress traffic traversing public internet. Again, this is in rare cases where there is high egress traffic, but it's easy enough to add the note and will likely prevent these future issues.