### PR TITLE
Update _index.md

### DIFF
--- a/content/rs/getting-started/_index.md
+++ b/content/rs/getting-started/_index.md
@@ -11,7 +11,7 @@ aliases: /rs/getting-started/quick-setup/
 ---
 This guide helps you install Redis Enterprise Software on a Linux host to test its capabilities.
 
-When finished, you'll have a simple cluser with a single node:
+When finished, you'll have a simple cluster with a single node:
 
 - Step 1: Install Redis Enterprise Software
 - Step 2: Set up a Redis Enterprise Software cluster

--- a/content/rs/getting-started/_index.md
+++ b/content/rs/getting-started/_index.md
@@ -11,7 +11,7 @@ aliases: /rs/getting-started/quick-setup/
 ---
 This guide helps you install Redis Enterprise Software on a Linux host to test its capabilities.
 
-When finished, you'll have a simple clusert with a single node:
+When finished, you'll have a simple cluser with a single node:
 
 - Step 1: Install Redis Enterprise Software
 - Step 2: Set up a Redis Enterprise Software cluster


### PR DESCRIPTION
Under the heading "Get started with Redis Enterprise Software," updated a possible typo from "clustert" to "cluster."