### PR TITLE
Update _index.md

### DIFF
--- a/content/rs/_index.md
+++ b/content/rs/_index.md
@@ -27,7 +27,7 @@ Redis Enterprise is available as software and as a hosted [cloud service]({{< re
 
 You can run Redis Enterprise Software in an on-premises data center or on your preferred cloud platform. 
 
-Redis Enterprise also works with [various container orchestrations systems]({{< relref "/platforms/_index.md" >}}), such as Kubernetes. See our docs on [Kubernetes]({{< relref "/platforms/kubernetes/_index.md" >}}), [Openshift]({{< relref "/platforms/openshift/_index.md" >}}), [PKS]({{< relref "/platforms/pks/_index.md" >}}), and [PCF]({{< relref "/platforms/pcf/_index.md" >}}) for more details.
+Redis Enterprise also works with various container-orchestration systems, such as Kubernetes. See our docs on [Kubernetes]({{< relref "/kubernetes/_index.md" >}}), [Openshift]({{< relref "/kubernetes/deployment/openshift/_index.md" >}}), [VMWare Tanzu Kubernetes Grid Integrated Edition (formerly Pivotal PKS)]({{< relref "/kubernetes/deployment/tanzu/_index.md" >}}), and [PCF]({{< relref "/kubernetes/deployment/tanzu/pcf/_index.md" >}}) for more details.
 
 For development and testing, you can also run Redis Enterprise using [Docker containers]({{< relref "/rs/getting-started/getting-started-docker.md" >}}).
 


### PR DESCRIPTION
Attempting to update the links on line 30 so that, when a browser loads this page and a user clicks one of the links in question, those links don't redirect back to this same page.

I removed the very first link because I couldn't find its intended target in RedisLabs / redislabs-docs. That link just redirected to the Kubernetes page. Kubernetes has its own link already in the same sentence.

I tried testing the updated links by manually replacing the URLs in question. For example, for the Openshift link, I tried replacing https://docs.redis.com/latest/rs/ in the browser's URL bar with https://docs.redis.com/kubernetes/deployment/openshift/_index.md instead. That led to a 404 error, so I then tried https://docs.redis.com/kubernetes/deployment/openshift/ instead. That led to an unexpected substitution where the browser tried to go to https://docs.redis.com/latest/platforms/kubernetesdeployment/openshift/ (notice the missing forward slash between the "kubernetes" and "deployment" parts of the link). Lastly, I tried https://docs.redis.com/platforms/kubernetes/deployment/openshift/_index.md instead, which ultimately worked.

Because of this unexpected substitution behavior that's going on, I'm not completely confident about my proposed link updates. I wrote up this lengthy comment in the hopes that more knowledgeable contributors will figure out what's going on and provide updated links that work on the first try.