### PR TITLE
Different output of slowlog get for Redis OSS

### DIFF
--- a/content/rc/faqs/_index.md
+++ b/content/rc/faqs/_index.md
@@ -80,6 +80,8 @@ Every effort is made to adhere, where possible, to the specifications of open so
 
 - Open source Redis supports key names up to 512MB.  Redis Enterprise Software and Redis Enterprise Cloud each limit key names to 64KB.  Key values can reach up to 512MB in all three services.
 
+- The output of the [SLOWLOG GET](https://redis.io/commands/slowlog-get) command is different in Open source Redis compared to Redis Enterprise Software and Redis Enterprise Cloud. In Open source Redis, the command prints: id, timestamp, time in microseconds, arguments array, client IP and port, and client name. In Redis Enterprise Software and Redis Enterprise Cloud the command results in id, timestamp, time in microseconds, and arguments array.
+
 ## How many databases can I create and manage?
 
 With Redis Enterprise Cloud, the number of databases depends on the subscription plan:


### PR DESCRIPTION
SLOWLOG GET command features different output for Redis OSS compared to Redis Enterprise/Cloud.

In OSS Redis, the slowlog get command gives the following fields:

1. A unique progressive identifier for every slow log entry.
2. The unix timestamp at which the logged command was processed.
3. The amount of time needed for its execution, in microseconds.
4. The array composing the arguments of the command.
5. Client IP address and port.
6. Client name if set via the CLIENT SETNAME command.

Whereas in our Redis Enterprise Cloud DB, the slowlog get command gives the following fields:

1. A unique progressive identifier for every slow log entry.
2. The unix timestamp at which the logged command was processed.
3. The amount of time needed for its execution, in microseconds.
4. The array composing the arguments of the command.

Hence the documentation to reflect it till we decide on how to proceed further.