### PR TITLE
DOC-1096 K8s revision to private repo content 

### DIFF
--- a/content/kubernetes/deployment/container-images.md
+++ b/content/kubernetes/deployment/container-images.md
@@ -21,12 +21,11 @@ are all distributed as separate container images.
 Your Kubernetes deployment will pull these images as needed.
  You can control where these images are
 pulled from within the operator deployment and also via the
-Redis Enterprise custom resource.
+Redis Enterprise custom resources.
 
 In general, images for deployments that do not have a registry domain
 name (e.g., `gcr.io` or `localhost:5000`) are pulled from the default registry associated
-with the Kubernetes cluster. As such, an
-undecorated reference to `redislabs/redis` will likely pull from DockerHub
+with the Kubernetes cluster. A plain reference to `redislabs/redis` will likely pull from DockerHub
 (except on OpenShift where it pulls from Red Hat).
 
 For security reasons (e.g., in air-gapped environments), you may want to pull the images
@@ -35,110 +34,88 @@ your control.
 
 {{<warning>}}It is very important that the images you are pushing to the private registry have the same exact version tag as the original images. {{</warning>}}
 
-Furthermore, because [Docker now rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
+Furthermore, because [Docker rate limits public pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/),
 you may want to consider pulling images from a
 private registry to avoid deployment failures when you hit your DockerHub rate limit.
 
-
-The information below will enable you to track and prescribe the right
-solution for where your deployments pull container images.
+The information below will help you track and configure where your deployments pull container images.
 
 {{< note >}}
+**IMPORTANT**
 
-Before you deploy private repositories for managing container
-images for the Redis Enterprise operator and cluster, take care to note:
-
- * Each version of the Redis Enterprise operator is mapped to a specific version
-   of Redis Enterprise Software. The semantic versions always match (e.g., 6.0.8), although the specific release numbers
-   may be different (e.g., 6.0.8-1 is the operator version for RS 6.0.8-28).
- * A specific operator version only supports a specific Redis Enterprise
-   version. Other combinations of operator and Redis Enterprise versions are
-   **not supported**.
+* Each version of the Redis Enterprise operator is mapped to a specific version of Redis Enterprise Software. The semantic versions always match (e.g., 6.0.8), although the specific release numbers may be different (e.g., 6.0.8-1 is the operator version for RS 6.0.8-28).
+* A specific operator version only supports a specific Redis Enterprise version. Other combinations of operator and Redis Enterprise versions are **not supported**.
 {{< /note >}}
 
-## Determining container image sources
+## Find container sources
 
-Every pod in your deployed application has a source registry. You
-can determine the sources by running this command:
+Every pod in your deployed application has a source registry. Any image not prefixed by a registry domain name (e.g., "gcr.io") will pull from the default registry for the Kubernetes cluster (i.e., DockerHub). You can use the commands below to discover the pull sources for the images on your cluster.
+
+To list all the images used by your cluster:
 
 ```
 kubectl get pods --all-namespaces -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' | uniq -c
 ```
 
-The output lists all of the images used by your cluster. You can
-limit this command to specific namespaces by replacing the `--all-namespaces` parameter with
-a set of `-n {namespace}` parameters, where each `{namespace}` is a specific
-namespace of interest on your cluster.
-
-Any image not prefixed by a registry domain name (e.g., "gcr.io") will pull
-from the default registry for the Kubernetes cluster (i.e., DockerHub).
-
-To specifically determine the pull source for the Redis Enterprise Operator itself, run the following command:
-simple filter:
+To specifically determine the pull source for the Redis Enterprise operator itself, run the following command:
 
 ```
 kubectl get pods --all-namespaces -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' | uniq -c | grep redislabs
 ```
 
-## Rating limiting with DockerHub
+You can limit this command to specific namespaces by replacing the `--all-namespaces` parameter with
+a set of `-n {namespace}` parameters, where each `{namespace}` is a specific
+namespace of interest on your cluster.
 
-Docker [rate limits image pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/).
-Anonymous users are allowed 100 pulls every 6 hours; for authenticated users, the limit is 200 pulls every 6 hours.
+## Rate limiting with DockerHub
+
+Docker has [rate limits for image pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/).
+Anonymous users are allowed a certain number of pulls every 6 hours. For authenticated users, the limit larger.
 These rate limits may affect your Kubernetes cluster in a number of ways:
 
- * The cluster nodes will likely be treated as a one anonymous user.
- * The number of pulls during an initial or subsequent deployment might
-   exceed the rate limit for other deployment dependencies, including our operator, Redis Enterprise Software, or for other non-Redis pods.
- * Pull failures may prevent your deployment from downloading the required images in a timely manner. Delays here can affect the stability of deployments like StatefulSet, which is used by the Redis Enterprise operator.
+* The cluster nodes will likely be treated as a one anonymous user.
+* The number of pulls during a deployment might exceed the rate limit for other deployment dependencies, including our operator, Redis Enterprise Software, or other non-Redis pods.
+* Pull failures may prevent your deployment from downloading the required images in a timely manner. Delays here can affect the stability of deployments used by the Redis Enterprise operator.
 
 For these reasons, you should seriously consider where your images
-are pulled from to avoid failures caused by rate limiting. The easiest solution
+are pulled from to **avoid failures caused by rate limiting**. The easiest solution
 is to push the required images to a private container registry under your control.
 
-## Managing image sources
+## Manage image sources
 
 The images for Redis Enterprise Software and its Kubernetes operator are distributed on DockerHub,
-Red Hat, and other public registries. Your organization may
-require these images to be copied to other container registries used by your Kubernetes
-clusters.
+Red Hat, and other public registries. These images can be copied to a private registry and your deployment can pull images from there.
 
-### Creating a private container registry
+### Create a private container registry
 
 You can set up a private container registry in a couple of ways:
 
- * On-premise via [Docker registry](https://docs.docker.com/registry/deploying/),
-   [Red Hat Quay](https://www.redhat.com/en/technologies/cloud-computing/quay), or other providers
- * Cloud provider based registries (e.g., Azure Container Registry, Google Container Registry, etc.).
+* On-premise via [Docker registry](https://docs.docker.com/registry/deploying/), [Red Hat Quay](https://www.redhat.com/en/technologies/cloud-computing/quay), or other providers
+* Cloud provider based registries (e.g., Azure Container Registry, Google Container Registry, etc.).
 
 Once you have set up a private container registry, you will identify the container registry using:
 
- * A domain name
- * A port (optional)
- * An repository path (optional)
+* A domain name
+* A port (optional)
+* An repository path (optional)
 
-You use this information to reference the images you
-push to your private registry. For example, a Google Container Registry
-will start with `gcr.io/{project-id}` where `{project-id}` is the cloud project
-identifier that prefixes the repository path for your container images.
+### Push Redis Enterprise images to a private container registry
 
-### Pushing Redis Enterprise images to a private container registry
+Important images for a Redis Enterprise Software deployment include:
 
-A Kubernetes deployment uses a variety of images. Some of the important images for a Redis Enterprise Software deployment include:
+* Redis Enterprise Software
+* Bootstrapping a Redis Enterprise cluster node (in the operator image)
+* The Service Rigger
+* The Redis Enterprise Software operator
 
- * Redis Enterprise Software
- * Bootstrapping a Redis Enterprise cluster node (in the operator image)
- * The Service Rigger
- * The Redis Enterprise Software operator
-
-Once you have created a private container registry, you will need to push
-all these images to your private container registry. In general,
+You will need to push all these images to your private container registry. In general,
 to push the images you must:
 
- 1. Pull the various images locally for the Redis Enterprise Software, Service Rigger, and the operator.
+ 1. [Pull](https://docs.docker.com/engine/reference/commandline/pull/) the various images locally for the Redis Enterprise Software, the Service Rigger, and the operator.
  2. Tag the local images with the private container registry, repository, and version tag.
- 3. Push the newly tagged images.
+ 3. [Push](https://docs.docker.com/engine/reference/commandline/push/) the newly tagged images.
 
-For example, here are the commands for pushing the images for Redis Enterprise Software and its operator to your private container registry:
+The example below shows the commands for pushing the images for Redis Enterprise Software and its operator to a private container registry:
 
 ```
 PRIVATE_REPO=...your repo...
@@ -158,33 +135,29 @@ docker push ${PRIVATE_REPO}/redislabs/k8s-controller:${OPERATOR_VERSION}
 ## Using a private container registry
 
 Once you push your images to your private container registry, you need to
-configure your deployments to use the private container registry and repository
-for the various container images for a Redis Enterprise Software and operator
-deployment. There are two different deployments to consider:
+configure your deployments to that registry for Redis Enterprise Software and operator
+deployments. There are two different deployments to consider:
 
  1. The Redis Enterprise operator
  2. The Redis Enterprise pods and Service Rigger created by the operator
 
-For (1), the operator container image is configured directly by the operator deployment
-bundle. Whereas, for (2), the Redis Enterprise cluster pod (RS and bootstrapper) and Service Rigger
-images are configured in the Redis Enterprise Custom Resource.
+The operator container image is configured directly by the operator deployment
+bundle. The Redis Enterprise cluster pod (RS and bootstrapper) and Service Rigger
+images are configured in the Redis Enterprise custom resource.
 
-Also, depending on your Kubernetes platform, your private container registry may
+Depending on your Kubernetes platform, your private container registry may
 require authentication. If you are using a private container registry associated with
-your K8s cluster, you may be able to pull the images without credentials. For
-example, a GKE cluster in the same project as the GCR container registry will have the
-necessary authorization to pull the images. Otherwise, you may
+your K8s cluster, you may be able to pull the images without credentials. Otherwise, you may
 need to add a [pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to your namespace
-and then tell Kubernetes and the operator to use the pull secret.
+and then configure Kubernetes and the operator to use the pull secret.
 
 See the following two sections for how to specify registry credentials.
 
-### Specifying the operator image
+### Specify the operator image
 
-The operator bundle (e.g., see the [6.0.8-1 bundle.yaml](https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/6.0.8-1/bundle.yaml))
-contains the operator deployment and the reference to the operator image (redislabs/operator). To use a private container registry, you must
-change this image reference before you deploy the operator. This image
-should point to the same repository and tag pushed to the private container registry:
+The operator bundle contains the operator deployment and the reference to the operator image (redislabs/operator). To use a private container registry, you must
+change this image reference **before** you deploy the operator. The 'containers:image' spec
+should point to the same repository and tag pushed to the private container registry.
 
 ```
 ${PRIVATE_REPO}/redislabs/operator:${OPERATOR_VERSION}
@@ -216,7 +189,7 @@ spec:
 
 Note that if you apply this change to modify an existing operator deployment,
 the operator's pod will restart. As the operator is stateless, the restart will
-not not affect any existing cluster managed by the operator.
+not affect any existing cluster managed by the operator.
 
 If your container registry requires a pull secret, you may specify the standard `imagePullSecrets`
  on the operator deployment:
@@ -230,7 +203,7 @@ spec:
       - name: regcred
 ```
 
-### Specifying the Redis Enterprise cluster images
+### Specify the Redis Enterprise cluster images
 
 A Redis Enterprise cluster managed by the operator consists of three
 container images:

--- a/content/kubernetes/deployment/container-images.md
+++ b/content/kubernetes/deployment/container-images.md
@@ -47,6 +47,7 @@ The information below will help you track and configure where your deployments p
 * A specific operator version only supports a specific Redis Enterprise version. Other combinations of operator and Redis Enterprise versions are **not supported**.
 {{< /note >}}
 
+
 ## Find container sources
 
 Every pod in your deployed application has a source registry. Any image not prefixed by a registry domain name (e.g., "gcr.io") will pull from the default registry for the Kubernetes cluster (i.e., DockerHub). You can use the commands below to discover the pull sources for the images on your cluster.
@@ -66,20 +67,6 @@ kubectl get pods --all-namespaces -o jsonpath="{..image}" |tr -s '[[:space:]]' '
 You can limit this command to specific namespaces by replacing the `--all-namespaces` parameter with
 a set of `-n {namespace}` parameters, where each `{namespace}` is a specific
 namespace of interest on your cluster.
-
-## Rate limiting with DockerHub
-
-Docker has [rate limits for image pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/).
-Anonymous users are allowed a certain number of pulls every 6 hours. For authenticated users, the limit larger.
-These rate limits may affect your Kubernetes cluster in a number of ways:
-
-* The cluster nodes will likely be treated as a one anonymous user.
-* The number of pulls during a deployment might exceed the rate limit for other deployment dependencies, including our operator, Redis Enterprise Software, or other non-Redis pods.
-* Pull failures may prevent your deployment from downloading the required images in a timely manner. Delays here can affect the stability of deployments used by the Redis Enterprise operator.
-
-For these reasons, you should seriously consider where your images
-are pulled from to **avoid failures caused by rate limiting**. The easiest solution
-is to push the required images to a private container registry under your control.
 
 ## Create a private container registry
 
@@ -254,3 +241,17 @@ spec:
     repository: gcr.io/yourproject/redislabs/k8s-controller
     versionTag: 6.0.8-1
 ```
+
+## Rate limiting with DockerHub
+
+Docker has [rate limits for image pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/).
+Anonymous users are allowed a certain number of pulls every 6 hours. For authenticated users, the limit larger.
+These rate limits may affect your Kubernetes cluster in a number of ways:
+
+* The cluster nodes will likely be treated as a one anonymous user.
+* The number of pulls during a deployment might exceed the rate limit for other deployment dependencies, including our operator, Redis Enterprise Software, or other non-Redis pods.
+* Pull failures may prevent your deployment from downloading the required images in a timely manner. Delays here can affect the stability of deployments used by the Redis Enterprise operator.
+
+For these reasons, you should seriously consider where your images
+are pulled from to **avoid failures caused by rate limiting**. The easiest solution
+is to push the required images to a private container registry under your control.

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -66,7 +66,7 @@ The Redis Enterprise operator [definition and reference materials](https://githu
 operator implementation is published as a Docker container. The operator
 definitions are [packaged as a single generic YAML file](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/bundle.yaml).
 
-### Download the bundle
+### Download the operator bundle
 
 To ensure that you pull the correct version of the bundle, check versions tags listed with the [operator releases on GitHub](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases)
 or by [using the GitHub API](https://docs.github.com/en/rest/reference/repos#releases).
@@ -80,7 +80,7 @@ or by [using the GitHub API](https://docs.github.com/en/rest/reference/repos#rel
 
 If you need a different release, replace `VERSION` in the above with a specific release tag.
 
-### Apply the bundle
+### Deploy the operator bundle
 
 ```sh
 kubectl apply -f bundle.yaml
@@ -97,7 +97,7 @@ kubectl apply -f bundle.yaml
   deployment.apps/redis-enterprise-operator created
   ```
 
-#### Verify that the operator is running
+#### Verify the operator is running
 
 Check the operator deployment to verify it's running in your namespace:
 
@@ -123,14 +123,14 @@ for more information on the various options available.
 
 You can test the operator by creating a minimal cluster by following this procedure:
 
-1. Create a file called `simple-cluster.yaml` that defines a Redis Enterprise cluster with three nodes:
+1. Create a file called `test-rec.yaml` that defines a Redis Enterprise cluster with three nodes:
 
     ```sh
-    cat <<EOF > simple-cluster.yaml
+    cat <<EOF > test-rec.yaml
     apiVersion: "app.redislabs.com/v1"
     kind: "RedisEnterpriseCluster"
     metadata:
-      name: "test-cluster"
+      name: "test-rec"
     spec:
       nodes: 3
     EOF
@@ -138,17 +138,10 @@ You can test the operator by creating a minimal cluster by following this proced
 
     This will request a cluster with three Redis Enterprise nodes using the
     default requests (i.e., 2 CPUs and 4GB of memory per node).
-    If you want to test with a larger configuration, you can
-    specify the node resources. For example, this configuration increases the memory:
 
-    ```sh
-    cat <<EOF > simple-cluster.yaml
-    apiVersion: "app.redislabs.com/v1"
-    kind: "RedisEnterpriseCluster"
-    metadata:
-      name: "test-cluster"
-    spec:
-      nodes: 3
+    To test with a larger configuration, use the example below to add node resources to the `spec` section of your test cluster (`test-rec.yaml`).
+
+    ```yaml
       redisEnterpriseNodeResources:
         limits:
           cpu: 2000m
@@ -156,22 +149,21 @@ You can test the operator by creating a minimal cluster by following this proced
         requests:
           cpu: 2000m
           memory: 16Gi
-    EOF
     ```
 
     See the [Redis Enterprise hardware requirements]({{< relref "/rs/administering/designing-production/hardware-requirements.md">}}) for more
     information on sizing Redis Enterprise node resource requests.
   
-1. Create the CRD in the namespace with the file `simple-cluster.yaml`:
+1. Apply your custom resource definition (CRD) file in the same namespace as `test-rec.yaml`.
 
     ```sh
-    kubectl apply -f simple-cluster.yaml
+    kubectl apply -f test-rec.yaml
     ```
 
     You should see a result similar to this:
 
     ```sh
-    redisenterprisecluster.app.redislabs.com/test-cluster created
+    redisenterprisecluster.app.redislabs.com/test-rec created
     ```
 
 1. You can verify the creation of the with:
@@ -184,18 +176,20 @@ You can test the operator by creating a minimal cluster by following this proced
 
     ```sh
     NAME           AGE
-    test-cluster   1m
+    test-rec   1m
     ```
 
    At this point, the operator will go through the process of creating various
-   services and pod deployments. You can track the progress by examining the
+   services and pod deployments.
+
+   You can track the progress by examining the
    StatefulSet associated with the cluster:
 
    ```sh
-   kubectl rollout status sts/test-cluster
+   kubectl rollout status sts/test-rec
    ```
 
-   or by simply looking at the status of all of the resources in your namespace:
+   or by looking at the status of all of the resources in your namespace:
 
    ```sh
    kubectl get all

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -66,21 +66,19 @@ The Redis Enterprise operator implementation is published as a Docker container.
 
 The operator [definition and reference materials](https://github.com/RedisLabs/redis-enterprise-k8s-docs) are available on GitHub. The operator definitions are [packaged as a single generic YAML file](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/bundle.yaml).
 
-{<note>}
+{{<note>}}
 If you do not pull images from DockerHub or another public registry, you'll need additional configuration in your operator deployment file and your Redis Enterprise cluster resource file. See [Manage image sources]({{<relref "/kubernetes/deployment/container-images.md#manage-image-sources">}}) for more info.
-{</note>}
+{{</note>}}
 
 ### Download the operator bundle
 
 To ensure that you pull the correct version of the bundle, check versions tags listed with the [operator releases on GitHub](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases)
 or by [using the GitHub API](https://docs.github.com/en/rest/reference/repos#releases).
 
-1. Download the bundle for the latest release:
-
-    ```sh
-    VERSION=`curl --silent https://api.github.com/repos/RedisLabs/redis-enterprise-k8s-docs/releases/latest | grep tag_name | awk -F'"' '{print $4}'`
-    curl --silent -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/$VERSION/bundle.yaml
-    ```
+```sh
+VERSION=`curl --silent https://api.github.com/repos/RedisLabs/redis-enterprise-k8s-docs/releases/latest | grep tag_name | awk -F'"' '{print $4}'`
+curl --silent -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/$VERSION/bundle.yaml
+```
 
 If you need a different release, replace `VERSION` in the above with a specific release tag.
 

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -112,7 +112,9 @@ NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
 redis-enterprise-operator   1/1     1            1           0m36s
 ```
 
-### Test the operator
+## Test the operator
+
+### Create a Redis Enterprise cluster (REC)
 
 A cluster is created by creating a custom resource with the kind "RedisEnterpriseCluster"
 that contains the specification of the cluster option. See the
@@ -160,8 +162,7 @@ You can test the operator by creating a minimal cluster by following this proced
     See the [Redis Enterprise hardware requirements]({{< relref "/rs/administering/designing-production/hardware-requirements.md">}}) for more
     information on sizing Redis Enterprise node resource requests.
   
-
-2. Create the CRD in the namespace with the file `simple-cluster.yaml`:
+1. Create the CRD in the namespace with the file `simple-cluster.yaml`:
 
     ```sh
     kubectl apply -f simple-cluster.yaml
@@ -173,7 +174,7 @@ You can test the operator by creating a minimal cluster by following this proced
     redisenterprisecluster.app.redislabs.com/test-cluster created
     ```
 
-3. You can verify the creation of the with:
+1. You can verify the creation of the with:
 
     ```sh
     kubectl get rec
@@ -200,9 +201,15 @@ You can test the operator by creating a minimal cluster by following this proced
    kubectl get all
    ```
 
+### Enable the Admission Controller
+
 <!---ADD Admission Controller and namespace limiting webhook steps here--->
 
-4. Once the cluster is running, you can create a test database. First, define the database with the following YAML file:
+### Create a Redis Enterprise Database (REDB)
+
+Once the cluster is running, you can create a test database. 
+
+1. Define the database with a sample REDB custom resource YAML file.
 
    ```sh
    cat <<EOF > smalldb.yaml
@@ -215,14 +222,13 @@ You can test the operator by creating a minimal cluster by following this proced
    EOF
    ```
 
-   Next, apply the database:
+1. Apply the REDB resource file.
 
    ```sh
    kubectl apply -f smalldb.yaml
    ```
 
-5. The connectivity information for the database is now stored in a Kubernetes
-   secret using the same name but prefixed with `redb-`:
+1. The connectivity information for the database is now stored in a Kubernetes secret using the same name but prefixed with `redb-`:
 
    ```sh
    kubectl get secret/redb-smalldb -o yaml
@@ -231,19 +237,3 @@ You can test the operator by creating a minimal cluster by following this proced
    From this secret you can get the service name, port, and password for the
    default user.
 
-## Operator overview {#overview}
-
-The Redis Enterprise operator uses [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) (CRDs) to create and manage Redis Enterprise clusters (REC) and Redis Enterprise databases (REDB).
-
-The operator is a deployment that runs within a given namespace. These operator pods must run with sufficient privileges to create the Redis Enterprise cluster resources within that namespace.
-
-When the operator is installed, the following resources are created:
-
-* a service account under which the operator will run
-* a set of roles to define the privileges necessary for the operator to perform its tasks
-* a set of role bindings to authorize the service account for the correct roles (see above)
-* the CRD for a Redis Enterprise cluster (REC)
-* the CRD for a Redis Enterprise database (REDB)
-* the operator itself (a deployment)
-
-The operator currently runs within a single namespace and is scoped to operate only on the Redis Enterprise cluster in that namespace.

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -195,9 +195,9 @@ You can test the operator by creating a minimal cluster by following this proced
 
 <!--- Once the cluster is up, the cluster GUI and API could be used to configure databases. It is recommended to use the K8s REDB API that is configured through the following steps. To configure the cluster using the cluster GUI/API, use the ui service created by the operator and the default credentials as set in a secret. The secret name is the same as the cluster name within the namespace.--->
 
-## Enable the Admission Controller
+## Enable the admission controller
 
-The Admission Controller dynamically validates REDB resources configured by the operator. It is strongly recommended that you use the Admission Controller on your Redis Enterprise Cluster (REC). The admission controller only needs to be configured once per operator deployment.
+The admission controller dynamically validates REDB resources configured by the operator. It is strongly recommended that you use the admission controller on your Redis Enterprise Cluster (REC). The admission controller only needs to be configured once per operator deployment.
 
 As part of the REC creation process, the operator stores the admission controller certificate in a Kubernetes secret called `admission-tls`. You may have to wait a few minutes after creating your REC to see the secret has been created.
 

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -62,9 +62,13 @@ Throughout this guide, you should assume that each command is applied to the nam
 
 ## Install the operator
 
-The Redis Enterprise operator [definition and reference materials](https://github.com/RedisLabs/redis-enterprise-k8s-docs) are available on GitHub, while the
-operator implementation is published as a Docker container. The operator
-definitions are [packaged as a single generic YAML file](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/bundle.yaml).
+The Redis Enterprise operator implementation is published as a Docker container. For more information about image sources, see [Manage container images]({{<relref "/kubernetes/deployment/container-images.md">}})
+
+The operator [definition and reference materials](https://github.com/RedisLabs/redis-enterprise-k8s-docs) are available on GitHub. The operator definitions are [packaged as a single generic YAML file](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/bundle.yaml).
+
+{<note>}
+If you do not pull images from DockerHub or another public registry, you'll need additional configuration in your operator deployment file and your Redis Enterprise cluster resource file. See [Manage image sources]({{<relref "/kubernetes/deployment/container-images.md#manage-image-sources">}}) for more info.
+{</note>}
 
 ### Download the operator bundle
 

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -197,7 +197,7 @@ You can test the operator by creating a minimal cluster by following this proced
 
 ## Enable the Admission Controller
 
-The Admission Controller dynamically validates REDB resources configured by the operator. It is strongly recommended that you use the Admission Controller on your Redis Enterprise Cluster (REC).
+The Admission Controller dynamically validates REDB resources configured by the operator. It is strongly recommended that you use the Admission Controller on your Redis Enterprise Cluster (REC). The admission controller only needs to be configured once per operator deployment.
 
 As part of the REC creation process, the operator stores the admission controller certificate in a Kubernetes secret called `admission-tls`. You may have to wait a few minutes after creating your REC to see the secret has been created.
 
@@ -280,14 +280,12 @@ The webhook will intercept requests from all namespaces unless you edit it to ta
       evictionPolicy: illegal
     EOF
     ```
+
   You should see your request was denied by the `admission webhook "redb.admission.redislabs"`.
-    
+
     ```sh
     Error from server: error when creating "STDIN": admission webhook "redb.admission.redislabs" denied the request: eviction_policy: u'illegal' is not one of [u'volatile-lru', u'volatile-ttl', u'volatile-random', u'allkeys-lru', u'allkeys-random', u'noeviction', u'volatile-lfu', u'allkeys-lfu']
     ```
-
-
-
 
 ## Create a Redis Enterprise Database (REDB)
 

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -195,9 +195,11 @@ You can test the operator by creating a minimal cluster by following this proced
    kubectl get all
    ```
 
+<!--- Once the cluster is up, the cluster GUI and API could be used to configure databases. It is recommended to use the K8s REDB API that is configured through the following steps. To configure the cluster using the cluster GUI/API, use the ui service created by the operator and the default credentials as set in a secret. The secret name is the same as the cluster name within the namespace.--->
+
 ### Enable the Admission Controller
 
-<!---ADD Admission Controller and namespace limiting webhook steps here--->
+
 
 ### Create a Redis Enterprise Database (REDB)
 

--- a/content/kubernetes/release-notes/k8s-6-2-8-15-2022-01.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-15-2022-01.md
@@ -1,0 +1,113 @@
+---
+Title: Redis Enterprise for Kubernetes Release Notes 6.2.8-15 (January 2022)
+linktitle: 6.2.8-15 (January 2022)
+description: Maintenance release with bug fixes
+weight: 65
+alwaysopen: false
+categories: ["Platforms"]
+aliases: [
+    /kubernetes/release-notes/k8s-6-2-8-15-2022-01.md,
+    /kubernetes/release-notes/k8s-6-2-8-15-2022-01/,   ]
+---
+## Overview
+
+The Redis Enterprise K8s 6.2.8-15 is a maintenance release for the [Redis Enterprise Software release 6.2.8]({{<relref "/rs/release-notes/rs-6-2-8-october-2021.md">}}) and includes bug fixes.
+
+The key new features, bug fixes, and known limitations are described below.
+
+## Images
+
+This release includes the following container images:
+
+* **Redis Enterprise**: `redislabs/redis:6.2.8-64` or  `redislabs/redis:6.2.8-64.rhel7-openshift`
+* **Operator**: `redislabs/operator:6.2.8-15`
+* **Services Rigger**: `redislabs/k8s-controller:6.2.8-15` or `redislabs/services-manager:6.2.8-15` (on the Red Hat registry)
+
+## Fixed bugs
+
+* Upgrading with the bundle using `kubectl apply -f` fails giving error (RED-69570):
+
+    ```sh
+    The CustomResourceDefinition "redisenterpriseclusters.app.redislabs.com" is invalid: spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema.
+    ```
+
+* Removed unneeded certificates from the Redis Enterprise Software container (RED-69661, RED-60086)
+
+## Known limitations
+
+### Long cluster names cause routes to be rejected  (RED-25871)
+
+A cluster name longer than 20 characters will result in a rejected route configuration because the host part of the domain name will exceed 63 characters. The workaround is to limit cluster name to 20 characters or less.
+
+### Cluster CR (REC) errors are not reported after invalid updates (RED-25542)
+
+A cluster CR specification error is not reported if two or more invalid CR resources are updated in sequence.
+
+### An unreachable cluster has status running (RED-32805)
+
+When a cluster is in an unreachable state, the state is still `running` instead of being reported as an error.
+
+### Readiness probe incorrect on failures (RED-39300)
+
+STS Readiness probe does not mark a node as "not ready" when running `rladmin status` on node failure.
+
+### Role missing on replica sets (RED-39002)
+
+The `redis-enterprise-operator` role is missing permission on replica sets.
+
+### Private registries are not supported on OpenShift 3.11 (RED-38579)
+
+OpenShift 3.11 does not support DockerHub private registries. This is a known OpenShift issue.
+
+### Internal DNS and Kubernetes DNS may have conflicts (RED-37462)
+
+DNS conflicts are possible between the cluster `mdns_server` and the K8s DNS. This only impacts DNS resolution from within cluster nodes for Kubernetes DNS names.
+
+### 5.4.10 negatively impacts 5.4.6 (RED-37233)
+
+Kubernetes-based 5.4.10 deployments seem to negatively impact existing 5.4.6 deployments that share a Kubernetes cluster.
+
+### Node CPU usage is reported instead of pod CPU usage (RED-36884)
+
+In Kubernetes, the node CPU usage we report on is the usage of the Kubernetes worker node hosting the REC pod.
+
+### Clusters must be named "rec" in OLM-based deployments (RED-39825)
+
+In OLM-deployed operators, the deployment of the cluster will fail if the name is not "rec". When the operator is deployed via the OLM, the security context constraints (scc) are bound to a specific service account name (i.e., "rec"). The workaround is to name the cluster "rec".
+
+### REC clusters fail to start on Kubernetes clusters with unsynchronized clocks (RED-47254)
+
+When REC clusters are deployed on Kubernetes clusters with unsynchronized clocks, the REC cluster does not start correctly. The fix is to use NTP to synchronize the underlying K8s nodes.
+
+### Deleting an OpenShift project with an REC deployed may hang (RED-47192)
+
+When a REC cluster is deployed in a project (namespace) and has REDB resources, the
+REDB resources must be deleted first before the REC can be deleted. As such, until the
+REDB resources are deleted, the project deletion will hang. The fix is to delete the
+REDB resources first and the REC second. Afterwards, you may delete the project.
+
+### REC extraLabels are not applied to PVCs on K8s versions 1.15 or older (RED-51921)
+
+In K8s 1.15 or older, the PVC labels come from the match selectors and not the
+PVC templates. As such, these versions cannot support PVC labels. If this feature
+is required, the only fix is to upgrade the K8s cluster to a newer version.
+
+### Hashicorp Vault integration - no support for Gesher (RED-55080)
+
+There is no workaround at this time
+
+### REC might report error states on initial startup (RED-61707)
+
+There is no workaround at this time except to ignore the errors.
+
+### PVC size issues when using decimal value in spec (RED-62132)
+
+The workaround for this issue is to make sure you use integer values for the PVC size.
+
+### Following old revision of quick start guide causes issues creating an REDB due to unrecognized memory field name
+
+The workaround is to use the newer (current) revision of the quick start document available online.
+
+## Compatibility Notes
+
+See [Supported Kubernetes distributions]({{< relref "/kubernetes/reference/supported_k8s_distributions.md" >}}) for the full list of supported distributions.


### PR DESCRIPTION
Minor line edits and renaming of "Manage container images" article. Also added a note and pointer to image article from quick start. 

Staging site: 
https://docs.redis.com/staging/jira-doc-1096/kubernetes/deployment/container-images/
https://docs.redis.com/staging/jira-doc-1096/kubernetes/deployment/quick-start/#install-the-operator