### PR TITLE
DOC-1030: Reorder modules in TOC and other lists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     build-docs-staging:
         docker:
             # Hugo image
-            - image: cibuilds/hugo:0.72
+            - image: cibuilds/hugo:0.92.1
         working_directory: ~/project
         steps:
             # Checkout the code from the branch into the working_directory
@@ -54,7 +54,7 @@ jobs:
     # The build job for production branches that includes Google Tag Manager
     build-docs-prod:
         docker:
-            - image: cibuilds/hugo:0.72
+            - image: cibuilds/hugo:0.92.1
         working_directory: ~/project
         steps:
             # Checkout the code from the branch into the working_directory
@@ -88,7 +88,7 @@ jobs:
     # The build job for latest branch that includes Google Tag Manager
     build-docs-latest:
         docker:
-            - image: cibuilds/hugo:0.72
+            - image: cibuilds/0.92.1
         working_directory: ~/project
         steps:
             # Checkout the code from the branch into the working_directory

--- a/content/embeds/modules.html
+++ b/content/embeds/modules.html
@@ -17,77 +17,8 @@
             </section>
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
-                        href="https://redislabs.com/redis-enterprise/redis-search/redisearch-sizing-calculator/">Sizing calculator</a></li>
+                        href="https://redis.com/modules/redis-search/redisearch-sizing-calculator/">Sizing calculator</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisearch.io">Documentation</a></li>
-            </section>
-        </ul>
-    </div>
-    <div class="home-options__option">
-        <div class="tile-opener">
-        <a href="/modules/redisbloom/">
-            <div class="home-options__option__icon">
-                <img src="../theme-flex/img/icon-redis-bloom.svg" alt="RedisBloom Icon" style="border:0px;width:88px">
-            </div>
-            <h5>RedisBloom</h5>
-            <p>RedisBloom provides four data types: a scalable Bloom filter, a cuckoo filter,
-            a count-min-sketch, and a top-k.</p>
-        </a>
-        </div>
-        <hr>
-        <ul>
-            <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/release-notes/">Release notes</a></li>
-            </section>
-            <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/redisbloom-quickstart">Quick start</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisbloom.io">Documentation</a></li>
-            </section>
-        </ul>
-    </div>
-    <div class="home-options__option" style="transform: translateY(6px);">
-        <div class="tile-opener">
-        <a href="/modules/redistimeseries/">
-            <div class="home-options__option__icon">
-                <img src="../theme-flex/img/icon-redis-timeseries.svg" alt="RedisTimeSeries Icon" style="border:0px;width:80px;padding-top:2px">
-            </div>
-            <h5>RedisTimeSeries</h5>
-            <p>RedisTimeSeries adds a time series data structure to Redis.</p>
-        </a>
-        </div>
-        <hr>
-        <ul>
-            <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/release-notes/">Release notes</a></li>
-            </section>
-            <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
-                        href="https://redislabs.com/redis-enterprise/redis-time-series/time-series-calculator/">Sizing calculator</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redistimeseries.io">Documentation</a></li>
-            </section>
-        </ul>
-    </div>
-    <div class="home-options__option">
-        <div class="tile-opener">
-        <a href="/modules/redisgraph/">
-            <div class="home-options__option__icon">
-                <img src="../theme-flex/img/icon-redis-graph.svg" alt="RedisGraph Icon" style="border:0px;width:80px">
-            </div>
-            <h5>RedisGraph</h5>
-            <p>RedisGraph is the first queryable property graph database to use sparse matrices to represent the adjacency matrix in graphs and linear algebra to query the graph.</p>
-        </a>
-        </div>
-        <hr>
-        <ul>
-            <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/release-notes/">Release notes</a></li>
-            </section>
-            <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
-                        href="https://redislabs.com/redis-enterprise/redis-graph/redisgraph-calculator/">Sizing calculator</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisgraph.io">Documentation</a></li>
             </section>
         </ul>
     </div>
@@ -115,23 +46,70 @@
     </div>
     <div class="home-options__option">
         <div class="tile-opener">
-        <a href="/modules/redisai/">
+        <a href="/modules/redisgraph/">
             <div class="home-options__option__icon">
-                <img src="../theme-flex/img/icon-redis-ai.svg" alt="RedisAI Icon" style="border:0px;width:80px">
+                <img src="../theme-flex/img/icon-redis-graph.svg" alt="RedisGraph Icon" style="border:0px;width:80px">
             </div>
-            <h5>RedisAI</h5>
-            <p>RedisAI is a Redis module for executing deep learning/machine learning models and managing their data. (Redis Enterprise Software only)</p>
+            <h5>RedisGraph</h5>
+            <p>RedisGraph is the first queryable property graph database to use sparse matrices to represent the adjacency matrix in graphs and linear algebra to query the graph.</p>
         </a>
         </div>
         <hr>
         <ul>
             <section>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/">Introduction</a></li>
-                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/release-notes/">Release notes</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/">Introduction</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgraph/release-notes/">Release notes</a></li>
             </section>
             <section>
-                    <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/redisai-quickstart">Quick start</a></li>
-                    <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisai.io">Documentation</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
+                        href="https://redis.com/modules/redis-graph/redisgraph-sizing-calculator/">Sizing calculator</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisgraph.io">Documentation</a></li>
+            </section>
+        </ul>
+    </div>
+    <div class="home-options__option" style="transform: translateY(6px);">
+        <div class="tile-opener">
+        <a href="/modules/redistimeseries/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-timeseries.svg" alt="RedisTimeSeries Icon" style="border:0px;width:80px;padding-top:2px">
+            </div>
+            <h5>RedisTimeSeries</h5>
+            <p>RedisTimeSeries adds a time series data structure to Redis.</p>
+        </a>
+        </div>
+        <hr>
+        <ul>
+            <section>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/">Introduction</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redistimeseries/release-notes/">Release notes</a></li>
+            </section>
+            <section>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a
+                        href="https://redis.com/modules/redis-timeseries/time-series-sizing-calculator/">Sizing calculator</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redistimeseries.io">Documentation</a></li>
+            </section>
+        </ul>
+    </div>
+    <div class="home-options__option">
+        <div class="tile-opener">
+        <a href="/modules/redisbloom/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-bloom.svg" alt="RedisBloom Icon" style="border:0px;width:88px">
+            </div>
+            <h5>RedisBloom</h5>
+            <p>RedisBloom provides four data types: a scalable Bloom filter, a cuckoo filter,
+            a count-min-sketch, and a top-k.</p>
+        </a>
+        </div>
+        <hr>
+        <ul>
+            <section>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/">Introduction</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/release-notes/">Release notes</a></li>
+            </section>
+            <section>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisbloom/redisbloom-quickstart">Quick start</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisbloom.io">Documentation</a></li>
             </section>
         </ul>
     </div>
@@ -154,6 +132,28 @@
             <section>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisgears/redisgears-quickstart">Quick start</a></li>
                 <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisgears.io">Documentation</a></li>
+            </section>
+        </ul>
+    </div>
+    <div class="home-options__option">
+        <div class="tile-opener">
+        <a href="/modules/redisai/">
+            <div class="home-options__option__icon">
+                <img src="../theme-flex/img/icon-redis-ai.svg" alt="RedisAI Icon" style="border:0px;width:80px">
+            </div>
+            <h5>RedisAI</h5>
+            <p>RedisAI is a Redis module for executing deep learning/machine learning models and managing their data. (Redis Enterprise Software only)</p>
+        </a>
+        </div>
+        <hr>
+        <ul>
+            <section>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/">Introduction</a></li>
+                <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/release-notes/">Release notes</a></li>
+            </section>
+            <section>
+                    <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="/modules/redisai/redisai-quickstart">Quick start</a></li>
+                    <li><i class="fa fa-angle-right fa-lg category-icon"></i><a href="https://redisai.io">Documentation</a></li>
             </section>
         </ul>
     </div>

--- a/content/modules/enterprise-capabilities.md
+++ b/content/modules/enterprise-capabilities.md
@@ -21,8 +21,8 @@ The following table shows which modules are supported by Redis Enterprise Softwa
 | [RedisJSON]({{<relref "/modules/redisjson">}})   | Yes | Yes |
 | [RedisGraph]({{<relref "/modules/redisgraph">}}) | Yes | Yes |
 | [RedisTimeSeries]({{<relref "/modules/redistimeseries">}}) | Yes | Yes |
-| [RedisGears]({{<relref "/modules/redisgears">}}) | Yes | No |
 | [RedisBloom]({{<relref "/modules/redisbloom">}}) | Yes | Yes |
+| [RedisGears]({{<relref "/modules/redisgears">}}) | Yes | No |
 | [RedisAI]({{<relref "/modules/redisai">}})       | Yes | No |
 
 ## Module feature support
@@ -51,21 +51,21 @@ For details about individual modules, see the corresponding documentation.
 
 [^1]: The RedisGraph module supports clustering; however, individual graphs contained in a key reside in a single shard, which can affect pricing.  To learn more, [contact support](https://redis.com/company/support/).
 
-| Feature name/capability | [RedisTimeSeries]({{< relref  "/modules/redistimeseries" >}}) | [RedisGears]({{< relref  "/modules/redisgears" >}}) | [RedisBloom]({{< relref  "/modules/redisbloom" >}}) | [RedisAI]({{< relref "/modules/redisai" >}}) |
-|-------------------------|:------------:|:----------:|:------------:|:----------:| 
-| Active-Active (CRDB)    | No           | Yes (v1.0) | No           | No         | 
-| Backup/Restore          | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Clustering              | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Custom hashing policy   | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Eviction expiration     | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Failover/migration      | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Internode encryption    | Yes (v1.4.9) | Yes (v1.2) | Yes (v2.2.6) | Yes (v1.2) | 
-| Module datatypes        | Yes          | Yes        | Yes          | Yes        | 
-| Persistence (AOF)       | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Persistence (snapshot)  | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
-| Redis on Flash (RoF)    | No           | Yes (vTBD) | Yes (vTBD)   | No         | 
-| Replica Of              | Yes (v1.2)   | No         | Yes (v2.0)   | Yes (v1.0) | 
-| Reshard/rebalance       | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | No         | 
+| Feature name/capability | [RedisTimeSeries]({{< relref  "/modules/redistimeseries" >}}) | [RedisBloom]({{< relref  "/modules/redisbloom" >}}) | [RedisGears]({{< relref  "/modules/redisgears" >}}) | [RedisAI]({{< relref "/modules/redisai" >}}) |
+|-------------------------|:------------:|:------------:|:----------:|:----------:| 
+| Active-Active (CRDB)    | No           | No           | Yes (v1.0) | No         | 
+| Backup/Restore          | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Clustering              | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Custom hashing policy   | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Eviction expiration     | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Failover/migration      | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Internode encryption    | Yes (v1.4.9) | Yes (v2.2.6) | Yes (v1.2) | Yes (v1.2) | 
+| Module datatypes        | Yes          | Yes          | Yes        | Yes        | 
+| Persistence (AOF)       | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Persistence (snapshot)  | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0) | 
+| Redis on Flash (RoF)    | No           | Yes (vTBD)   | Yes (vTBD) | No         | 
+| Replica Of              | Yes (v1.2)   | Yes (v2.0)   | No         | Yes (v1.0) | 
+| Reshard/rebalance       | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | No         | 
 
 [^2]: In version 1.6, RediSearch supported Replica Of only between databases with the same number of shards.  This limitation was fixed in v2.0. 
 

--- a/content/modules/enterprise-capabilities.md
+++ b/content/modules/enterprise-capabilities.md
@@ -16,7 +16,7 @@ This article describes Redis Enterprise feature compatibility for Redis modules.
 The following table shows which modules are supported by Redis Enterprise Software and Redis Enterprise Cloud.
 
 | Module | Redis Enterprise<br/>Software | Redis Enterprise<br/>Cloud |
-|--------|:-------------------------:|:-----------------------:|
+|:-------|:-------------------------:|:-----------------------:|
 | [RediSearch]({{<relref "/modules/redisearch">}}) | Yes | Yes |
 | [RedisJSON]({{<relref "/modules/redisjson">}})   | Yes | Yes |
 | [RedisGraph]({{<relref "/modules/redisgraph">}}) | Yes | Yes |

--- a/content/modules/enterprise-capabilities.md
+++ b/content/modules/enterprise-capabilities.md
@@ -17,13 +17,13 @@ The following table shows which modules are supported by Redis Enterprise Softwa
 
 | Module | Redis Enterprise<br/>Software | Redis Enterprise<br/>Cloud |
 |--------|:-------------------------:|:-----------------------:|
-| [RedisAI]({{<relref "/modules/redisai">}})       | Yes | No |
-| [RedisBloom]({{<relref "/modules/redisbloom">}}) | Yes | Yes |
-| [RedisGears]({{<relref "/modules/redisgears">}}) | Yes | No |
-| [RedisGraph]({{<relref "/modules/redisgraph">}}) | Yes | Yes |
-| [RedisJSON]({{<relref "/modules/redisjson">}})   | Yes | Yes |
 | [RediSearch]({{<relref "/modules/redisearch">}}) | Yes | Yes |
+| [RedisJSON]({{<relref "/modules/redisjson">}})   | Yes | Yes |
+| [RedisGraph]({{<relref "/modules/redisgraph">}}) | Yes | Yes |
 | [RedisTimeSeries]({{<relref "/modules/redistimeseries">}}) | Yes | Yes |
+| [RedisGears]({{<relref "/modules/redisgears">}}) | Yes | No |
+| [RedisBloom]({{<relref "/modules/redisbloom">}}) | Yes | Yes |
+| [RedisAI]({{<relref "/modules/redisai">}})       | Yes | No |
 
 ## Module feature support
 
@@ -33,39 +33,39 @@ Version numbers indicate when the feature was first supported.  If you're using 
 
 For details about individual modules, see the corresponding documentation.
 
-| Feature name/capability | [RedisAI]({{< relref "/modules/redisai" >}}) | [RedisBloom]({{< relref  "/modules/redisbloom" >}})  | [RedisGears]({{< relref  "/modules/redisgears" >}}) | [RedisGraph]({{< relref  "/modules/redisgraph" >}})   | 
-|-------------------------|:----------:|:------------:|:----------:|:------------:|
-| Active-Active (CRDB)    | No         | No           | Yes (v1.0) | No           |
-| Backup/Restore          | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0)   |
-| Clustering              | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | Yes (v2.2.3)[^1] |
-| Custom hashing policy   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0)   |
-| Eviction expiration     | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | No           |
-| Failover/migration      | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0)   |
-| Internode encryption    | Yes (v1.2) | Yes (v2.2.6) | Yes (v1.2) | Yes (v2.4)   |
-| Module datatypes        | Yes        | Yes          | Yes        | Yes          |
-| Persistence (AOF)       | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | Yes (v2.0)   |
-| Persistence (snapshot)  | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | Yes (v1.0)   |
-| Redis on Flash (RoF)    | No         | Yes (vTBD)   | Yes (vTBD) | No           |
-| Replica Of              | Yes (v1.0) | Yes (v2.0)   | No         | Yes (v2.2)   |
-| Reshard/rebalance       | No         | Yes (v2.0)   | Yes (v1.0) | No           |
+| Feature name/capability | [RediSearch]({{< relref  "/modules/redisearch" >}}) | [RedisJSON]({{< relref  "/modules/redisjson" >}})    |  [RedisGraph]({{< relref  "/modules/redisgraph" >}})   | 
+|-------------------------|:--------------:|:------------:|:------------:|
+| Active-Active (CRDB)    | Yes (v2.0)     | No           | No           |
+| Backup/Restore          | Yes (v1.4)     | Yes (v1.0)   | Yes (v1.0)   |
+| Clustering              | Yes (v1.6)     | Yes (v1.0)   | Yes (v2.2.3)[^1] |
+| Custom hashing policy   | Yes (v2.0)     | Yes (v1.0)   | Yes (v1.0)   |
+| Eviction expiration     | Yes (v2.0)     | Yes (v1.0)   | No           |
+| Failover/migration      | Yes (v1.4)     | Yes (v1.0)   | Yes (v1.0)   |
+| Internode encryption    | Yes (v2.0.11)  | Yes (v1.0.8) | Yes (v2.4)   |
+| Module datatypes        | Yes            | Yes          | Yes          |
+| Persistence (AOF)       | Yes (v1.4)     | Yes (v1.0)   | Yes (v2.0)   |
+| Persistence (snapshot)  | Yes (v1.6)     | Yes (v1.0)   | Yes (v1.0)   |
+| Redis on Flash (RoF)    | Yes (v2.0)     | Yes (v1.0)   | No           |
+| Replica Of              | Yes (v1.6)[^2] | Yes (v1.0)   | Yes (v2.2)   |
+| Reshard/rebalance       | Yes (v2.0)     | Yes (v1.0)   | No           |
 
 [^1]: The RedisGraph module supports clustering; however, individual graphs contained in a key reside in a single shard, which can affect pricing.  To learn more, [contact support](https://redis.com/company/support/).
 
-| Feature name/capability | [RedisJSON]({{< relref  "/modules/redisjson" >}})    | [RediSearch]({{< relref  "/modules/redisearch" >}})    | [RedisTimeSeries]({{< relref  "/modules/redistimeseries" >}}) |
-|-------------------------|:------------:|:-------------:|:---------------:|
-| Active-Active (CRDB)    | No           | Yes (v2.0)    | No           | 
-| Backup/Restore          | Yes (v1.0)   | Yes (v1.4)    | Yes (v1.2)   | 
-| Clustering              | Yes (v1.0)   | Yes (v1.6)    | Yes (v1.2)   | 
-| Custom hashing policy   | Yes (v1.0)   | Yes (v2.0)    | Yes (v1.2)   | 
-| Eviction expiration     | Yes (v1.0)   | Yes (v2.0)    | Yes (v1.2)   | 
-| Failover/migration      | Yes (v1.0)   | Yes (v1.4)    | Yes (v1.2)   | 
-| Internode encryption    | Yes (v1.0.8) | Yes (v2.0.11) | Yes (v1.4.9) | 
-| Module datatypes        | Yes          | Yes           | Yes          | 
-| Persistence (AOF)       | Yes (v1.0)   | Yes (v1.4)    | Yes (v1.2)   | 
-| Persistence (snapshot)  | Yes (v1.0)   | Yes (v1.6)    | Yes (v1.2)   | 
-| Redis on Flash (RoF)    | Yes (v1.0)   | Yes (v2.0)    | No | 
-| Replica Of              | Yes (v1.0)   | Yes (v1.6)[^2]    | Yes (v1.2)   | 
-| Reshard/rebalance       | Yes (v1.0)   | Yes (v2.0)    | Yes (v1.2)   | 
+| Feature name/capability | [RedisTimeSeries]({{< relref  "/modules/redistimeseries" >}}) | [RedisGears]({{< relref  "/modules/redisgears" >}}) | [RedisBloom]({{< relref  "/modules/redisbloom" >}}) | [RedisAI]({{< relref "/modules/redisai" >}}) |
+|-------------------------|:------------:|:----------:|:------------:|:----------:| 
+| Active-Active (CRDB)    | No           | Yes (v1.0) | No           | No         | 
+| Backup/Restore          | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Clustering              | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Custom hashing policy   | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Eviction expiration     | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Failover/migration      | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Internode encryption    | Yes (v1.4.9) | Yes (v1.2) | Yes (v2.2.6) | Yes (v1.2) | 
+| Module datatypes        | Yes          | Yes        | Yes          | Yes        | 
+| Persistence (AOF)       | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Persistence (snapshot)  | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | Yes (v1.0) | 
+| Redis on Flash (RoF)    | No           | Yes (vTBD) | Yes (vTBD)   | No         | 
+| Replica Of              | Yes (v1.2)   | No         | Yes (v2.0)   | Yes (v1.0) | 
+| Reshard/rebalance       | Yes (v1.2)   | Yes (v1.0) | Yes (v2.0)   | No         | 
 
 [^2]: In version 1.6, RediSearch supported Replica Of only between databases with the same number of shards.  This limitation was fixed in v2.0. 
 

--- a/content/modules/redisai/_index.md
+++ b/content/modules/redisai/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RedisAI
 description:
-weight: 20
+weight: 80
 alwaysopen: false
 categories: ["Modules"]
 aliases: /redisai/

--- a/content/modules/redisbloom/_index.md
+++ b/content/modules/redisbloom/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RedisBloom
 description:
-weight: 30
+weight: 60
 alwaysopen: false
 categories: ["Modules"]
 aliases:

--- a/content/modules/redisearch/_index.md
+++ b/content/modules/redisearch/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RediSearch
 description:
-weight: 30
+weight: 20
 alwaysopen: false
 categories: ["Modules"]
 aliases:

--- a/content/modules/redisgears/_index.md
+++ b/content/modules/redisgears/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RedisGears
 description:
-weight: 40
+weight: 70
 alwaysopen: false
 categories: ["Modules"]
 aliases: /redisgears/

--- a/content/modules/redisgraph/_index.md
+++ b/content/modules/redisgraph/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RedisGraph
 description:
-weight: 50
+weight: 40
 alwaysopen: false
 categories: ["Modules"]
 aliases:

--- a/content/modules/redisjson/_index.md
+++ b/content/modules/redisjson/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RedisJSON
 description:
-weight: 60
+weight: 30
 alwaysopen: false
 categories: ["Modules"]
 aliases:

--- a/content/modules/redistimeseries/_index.md
+++ b/content/modules/redistimeseries/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: RedisTimeSeries
 description:
-weight: 80
+weight: 50
 alwaysopen: false
 categories: ["Modules"]
 aliases:


### PR DESCRIPTION
This change reorders the modules in the hero list, the TOC, and the enterprise capabilities doc (for consistency).