### PR TITLE
Fixed parameter type for starttls entry in example JSON body

### DIFF
--- a/content/rs/references/rest-api/requests/cluster/ldap.md
+++ b/content/rs/references/rest-api/requests/cluster/ldap.md
@@ -60,7 +60,7 @@ Returns an [LDAP object]({{<relref "/rs/references/rest-api/objects/ldap">}}).
    "data_plane": false,
    "dn_group_attr": "MemberOf",
    "dn_group_query": {},
-   "starttls": "disabled",
+   "starttls": false,
    "uris": ["ldap://ldap.example.org:636"],
    "user_dn_query": {},
    "user_dn_template": "cn=%u, ou=users,dc=example,dc=org"


### PR DESCRIPTION
In the example JSON body, the `starttls` entry is boolean, so I fixed the documentation to use `false` instead of `"disabled"`