### PR TITLE
Documented that OSS Cluster API + RediSearch is not supported

### DIFF
--- a/content/modules/enterprise-capabilities.md
+++ b/content/modules/enterprise-capabilities.md
@@ -37,7 +37,7 @@ For details about individual modules, see the corresponding documentation.
 |-------------------------|:--------------:|:------------:|:------------:|
 | Active-Active (CRDB)    | Yes (v2.0)     | No           | No           |
 | Backup/Restore          | Yes (v1.4)     | Yes (v1.0)   | Yes (v1.0)   |
-| Clustering              | Yes (v1.6)     | Yes (v1.0)   | Yes (v2.2.3)[^1] |
+| Clustering              | Yes (v1.6)[^3] | Yes (v1.0)   | Yes (v2.2.3)[^1] |
 | Custom hashing policy   | Yes (v2.0)     | Yes (v1.0)   | Yes (v1.0)   |
 | Eviction expiration     | Yes (v2.0)     | Yes (v1.0)   | No           |
 | Failover/migration      | Yes (v1.4)     | Yes (v1.0)   | Yes (v1.0)   |
@@ -50,6 +50,10 @@ For details about individual modules, see the corresponding documentation.
 | Reshard/rebalance       | Yes (v2.0)     | Yes (v1.0)   | No           |
 
 [^1]: The RedisGraph module supports clustering; however, individual graphs contained in a key reside in a single shard, which can affect pricing.  To learn more, [contact support](https://redis.com/company/support/).
+
+[^2]: In version 1.6, RediSearch supported Replica Of only between databases with the same number of shards.  This limitation was fixed in v2.0. 
+
+[^3]: The ability to use the [OSS Cluster API]({{<relref "/rs/administering/designing-production/networking/using-oss-cluster-api">}}) with RediSearch depends on individual client support.
 
 | Feature name/capability | [RedisTimeSeries]({{< relref  "/modules/redistimeseries" >}}) | [RedisBloom]({{< relref  "/modules/redisbloom" >}}) | [RedisGears]({{< relref  "/modules/redisgears" >}}) | [RedisAI]({{< relref "/modules/redisai" >}}) |
 |-------------------------|:------------:|:------------:|:----------:|:----------:| 
@@ -67,7 +71,6 @@ For details about individual modules, see the corresponding documentation.
 | Replica Of              | Yes (v1.2)   | Yes (v2.0)   | No         | Yes (v1.0) | 
 | Reshard/rebalance       | Yes (v1.2)   | Yes (v2.0)   | Yes (v1.0) | No         | 
 
-[^2]: In version 1.6, RediSearch supported Replica Of only between databases with the same number of shards.  This limitation was fixed in v2.0. 
 
 ## Feature descriptions
 

--- a/content/modules/enterprise-capabilities.md
+++ b/content/modules/enterprise-capabilities.md
@@ -53,7 +53,7 @@ For details about individual modules, see the corresponding documentation.
 
 [^2]: In version 1.6, RediSearch supported Replica Of only between databases with the same number of shards.  This limitation was fixed in v2.0. 
 
-[^3]: The ability to use the [OSS Cluster API]({{<relref "/rs/administering/designing-production/networking/using-oss-cluster-api">}}) with RediSearch depends on individual client support.
+[^3]: You cannot use RediSearch with the [OSS Cluster API]({{<relref "/rs/administering/designing-production/networking/using-oss-cluster-api">}}).
 
 | Feature name/capability | [RedisTimeSeries]({{< relref  "/modules/redistimeseries" >}}) | [RedisBloom]({{< relref  "/modules/redisbloom" >}}) | [RedisGears]({{< relref  "/modules/redisgears" >}}) | [RedisAI]({{< relref "/modules/redisai" >}}) |
 |-------------------------|:------------:|:------------:|:----------:|:----------:| 

--- a/content/modules/redisearch/_index.md
+++ b/content/modules/redisearch/_index.md
@@ -50,6 +50,10 @@ By moving the index out of the keyspace and structuring the data as hashes, Redi
 When half of the data moves to the new shard, the index related to that data is created synchronously and RediSearch removes the keys from the index when it detects that the keys were deleted.
 Because the index on the new shard is created synchronously though, it's expected that the resharding process will take longer than resharding of a database without RediSearch.
 
+## Limitations
+
+- You cannot use RediSearch with the [OSS Cluster API]({{<relref "/rs/administering/designing-production/networking/using-oss-cluster-api">}}).
+
 ## Related links
 
 - [Getting Started with RediSearch 2.0](https://redislabs.com/blog/getting-started-with-redisearch-2-0/)

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -1,5 +1,6 @@
 ---
-Title: Using the OSS Cluster API
+Title: Use the OSS Cluster API
+linkTitle: Use the OSS Cluster API
 description:
 weight: $weight
 alwaysopen: false
@@ -19,11 +20,13 @@ Before you enable Redis OSS Cluster API for a database, make sure that:
 - The database proxy policy is `all-master-shards`.
 - The database proxy policy does not use node `include` or `exclude`.
 
+## Enable OSS Cluster API support
+
 When you enable the Redis OSS Cluster API from the command line or RS admin console,
 [multi-key commands]({{< relref "/rc/databases/configuration/clustering#multikey-operations" >}}) are only allowed when all keys are mapped to the same slot.
 To verify that your database meets this requirement, make sure that the `CLUSTER KEYSLOT` reply is the same for all keys in the [multi-key command]({{< relref "/rs/concepts/high-availability/clustering#multikey-operations" >}}).
 
-## Enabling OSS Cluster API support from the admin console
+### Enable from the admin console
 
 For a Redis Enterprise Software (RS) database, to enable the OSS Cluster API from the admin console:
 
@@ -39,10 +42,10 @@ The Redis OSS Cluster API setting applies to the specified database only, not to
     - For an existing database, click **Update**.
     - For a new database, configure the database settings and click **Activate**.
 
-## Enabling OSS Cluster API support from the command line
+### Enable from the command line
 
 You can use the rladmin CLI to enable OSS Cluster API for RS databases, including Active-Passive (Replica Of) databases.
-For Active-Active (CRDB) databases, [use the crdb-cli tool](#enabling-oss-cluster-api-support-for-active-active-databases-from-the-command-line).
+For Active-Active (CRDB) databases, [use the crdb-cli tool](#enable-for-active-active-databases-from-the-command-line).
 
 For an RS database, to enable the OSS Cluster API from the command line:
 
@@ -65,7 +68,7 @@ For an RS database, to enable the OSS Cluster API from the command line:
 The Redis OSS Cluster API setting applies to the specified database only, not to the entire cluster.
     {{< /note >}}
 
-## Enabling OSS Cluster API support for Active-Active databases from the command line
+### Enable for Active-Active databases from the command line
 
 For a new RS Active-Active database, to enable the OSS Cluster API from the command line:
 
@@ -97,9 +100,9 @@ For a new RS Active-Active database, to enable the OSS Cluster API from the comm
 The Redis OSS Cluster API setting applies to all of the instances of the Active-Active database.
     {{< /note >}}
 
-## Disabling OSS Cluster API support
+## Turn off OSS Cluster API support
 
-If you need to disable OSS Cluster API support for a database, run:
+If you need to turn off OSS Cluster API support for a database, run:
 
 - From the RS admin console:
     1. Go to: **databases**

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -7,6 +7,10 @@ categories: ["RS"]
 ---
 {{< embed-md "oss-cluster-api-intro.md"  >}}
 
+{{<note>}}
+The ability to use the OSS Cluster API with RediSearch depends on individual client support.
+{{</note>}}
+
 ## Prerequisites
 
 Before you enable Redis OSS Cluster API for a database, make sure that:

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -8,10 +8,6 @@ categories: ["RS"]
 ---
 {{< embed-md "oss-cluster-api-intro.md"  >}}
 
-{{<note>}}
-You cannot use [RediSearch]({{<relref "/modules/redisearch">}}) with the OSS Cluster API.
-{{</note>}}
-
 ## Prerequisites
 
 Before you enable Redis OSS Cluster API for a database, make sure that:
@@ -19,6 +15,7 @@ Before you enable Redis OSS Cluster API for a database, make sure that:
 - The database uses the standard hashing policy.
 - The database proxy policy is `all-master-shards`.
 - The database proxy policy does not use node `include` or `exclude`.
+- The database does not use [RediSearch]({{<relref "/modules/redisearch">}}).
 
 ## Enable OSS Cluster API support
 

--- a/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
+++ b/content/rs/administering/designing-production/networking/using-oss-cluster-api.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 {{< embed-md "oss-cluster-api-intro.md"  >}}
 
 {{<note>}}
-The ability to use the OSS Cluster API with RediSearch depends on individual client support.
+You cannot use [RediSearch]({{<relref "/modules/redisearch">}}) with the OSS Cluster API.
 {{</note>}}
 
 ## Prerequisites

--- a/content/rs/concepts/data-access/oss-cluster-api.md
+++ b/content/rs/concepts/data-access/oss-cluster-api.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 {{< embed-md "oss-cluster-api-intro.md"  >}}
 
 {{<note>}}
-The ability to use the OSS Cluster API with RediSearch depends on individual client support.
+You cannot use [RediSearch]({{<relref "/modules/redisearch">}}) with the OSS Cluster API.
 {{</note>}}
 
 You can use Redis OSS Cluster API along with other Redis Enterprise Software high availability

--- a/content/rs/concepts/data-access/oss-cluster-api.md
+++ b/content/rs/concepts/data-access/oss-cluster-api.md
@@ -8,6 +8,10 @@ categories: ["RS"]
 ---
 {{< embed-md "oss-cluster-api-intro.md"  >}}
 
+{{<note>}}
+The ability to use the OSS Cluster API with RediSearch depends on individual client support.
+{{</note>}}
+
 You can use Redis OSS Cluster API along with other Redis Enterprise Software high availability
 to get high performance with low latency
 and let applications stay current with cluster topology changes, including add node, remove node, and node failover.

--- a/content/rs/concepts/data-access/oss-cluster-api.md
+++ b/content/rs/concepts/data-access/oss-cluster-api.md
@@ -8,10 +8,6 @@ categories: ["RS"]
 ---
 {{< embed-md "oss-cluster-api-intro.md"  >}}
 
-{{<note>}}
-You cannot use [RediSearch]({{<relref "/modules/redisearch">}}) with the OSS Cluster API.
-{{</note>}}
-
 You can use Redis OSS Cluster API along with other Redis Enterprise Software high availability
 to get high performance with low latency
 and let applications stay current with cluster topology changes, including add node, remove node, and node failover.


### PR DESCRIPTION
Staged previews of the updates:

[RS: Use the OSS Cluster API](https://docs.redis.com/staging/jira-doc-1171/rs/administering/designing-production/networking/using-oss-cluster-api/)
[Modules: Enterprise feature compatibility](https://docs.redis.com/staging/jira-doc-1171/modules/enterprise-capabilities#footnotes)
[Modules: RediSearch landing page](https://docs.redis.com/staging/jira-doc-1171/modules/redisearch/)