### PR TITLE
Added release notes for RediSearch and RedisJSON

### DIFF
--- a/content/modules/redisearch/release-notes/redisearch-2.2-release-notes.md
+++ b/content/modules/redisearch/release-notes/redisearch-2.2-release-notes.md
@@ -10,10 +10,33 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RediSearch v2.2.7 requires:
+RediSearch v2.2.9 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
+
+## v2.2.9 (March 2022)
+
+This is a maintenance release for RediSearch 2.2.
+
+Update urgency: `MODERATE`: Program an upgrade of the server, but it's not urgent.
+
+Details:
+
+- Improvements:
+
+  - [#2605](https://github.com/RediSearch/RediSearch/pull/2605) Added support for `tls-key-file-pass` capability (MOD-2086)
+  - [#2583](https://github.com/RediSearch/RediSearch/pull/2583) Release index-specific information off the main thread (performance enhancement)
+
+- Bug fixes:
+
+  - [#2436](https://github.com/RediSearch/RediSearch/pull/2436) When indexing JSON documents, filters cause no documents to be indexed (MOD-2214)
+  - [#2507](https://github.com/RediSearch/RediSearch/pull/2507) `QUANTILE` aggregation function outputting wrong values (MOD-2432)
+  - [#2521](https://github.com/RediSearch/RediSearch/pull/2521) `contains()` with an empty string argument leaves Redis hanging at CPU 100% indefinitely (MOD-2428)
+  - [#2560](https://github.com/RediSearch/RediSearch/pull/2560) Free prefix and cursor efficiently for cases with many indices (MOD-2080)
+  - [#2541](https://github.com/RediSearch/RediSearch/pull/2541) Numeric types for `FT.INFO` on coordinator
+  - [#2553](https://github.com/RediSearch/RediSearch/pull/2553) Fix union high iterator
+  - [#2404](https://github.com/RediSearch/RediSearch/pull/2404) Update coordination strategy of `FlatSearchCommandHandler`
 
 ## v2.2.7 (February 2022)
 

--- a/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
+++ b/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
@@ -10,10 +10,31 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisJSON v2.0.5 requires:
+RedisJSON v2.0.7 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
+
+## v2.0.7 (March 2022)
+
+This is a maintenance release for RedisJSON 2.0.
+
+Update urgency: `LOW` - No need to upgrade unless there are new features you want to use.
+
+Details:
+
+- Improvements:
+
+  - [#632](https://github.com/RedisJSON/RedisJSON/pull/632), [#605](https://github.com/RedisJSON/RedisJSON/pull/605) Support [`JSON.CLEAR`](https://oss.redis.com/redisjson/commands/#jsonclear) for string, bool, and numeric scalars (MOD-2394)
+  - [#637](https://github.com/RedisJSON/RedisJSON/pull/637) Add `intershard_tls_pass` support (MOD-2522)
+  - [#594](https://github.com/RedisJSON/RedisJSON/pull/594) Support for `MEMORY USAGE` and memory info in `JSON.DEBUG` (MOD- 2079)
+
+- Bug fixes:
+
+  - [#646](https://github.com/RedisJSON/RedisJSON/pull/646), [#644](https://github.com/RedisJSON/RedisJSON/pull/644) Do not fail `JSON.MGET` on wrong/unregistered key type (MOD-2511)
+  - [#643](https://github.com/RedisJSON/RedisJSON/pull/643) Null-terminate JSON string in `rdb_save`
+  - [#591](https://github.com/RedisJSON/RedisJSON/pull/591) Avoid crash on overflow in `JSON.NUMINCRBY` or `JSON.NUMMULTBY` (MOD-2513)
+  - [#593](https://github.com/RedisJSON/RedisJSON/pull/593) Return no updates when performing `JSON.SET` with `NX` to an existing array element (MOD-2512)
 
 ## v2.0.6 (December 2021)
 


### PR DESCRIPTION
[RediSearch 2.2.9 release notes](https://docs.redis.com/staging/modules_release_notes/modules/redisearch/release-notes/redisearch-2.2-release-notes/)
[RedisJSON 2.0.7 release notes](https://docs.redis.com/staging/modules_release_notes/modules/redisjson/release-notes/redisjson-2.0-release-notes/)