### PR TITLE
DOC-1232 update link to raw.githubusercontent.com

### DIFF
--- a/content/kubernetes/deployment/openshift/openshift-operatorhub.md
+++ b/content/kubernetes/deployment/openshift/openshift-operatorhub.md
@@ -48,11 +48,11 @@ this constraint installed, the operator cannot create Redis Enterprise clusters.
 
 The security context constraint for the operator needs to be **installed only once** and **must not be deleted**.
 
-The constraint [scc.yaml](https://raw.githubuser.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml)
+The constraint [scc.yaml](https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml)
 can be downloaded and installed by a cluster administrator with the commands:
 
 ```sh
-curl -O https://raw.githubuser.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml
+curl -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/master/openshift/scc.yaml
 oc apply -f scc.yaml
 ```
 


### PR DESCRIPTION
New supported domain is https://raw.githubusercontent.com because https://raw.githubuser.com is no longer secure. This was the only two instances of the incorrect link I found in our repo. 