### PR TITLE
DOC-1239 integrate cluster option notes

### DIFF
--- a/content/kubernetes/reference/cluster-options.md
+++ b/content/kubernetes/reference/cluster-options.md
@@ -58,7 +58,7 @@ Resource limits are recommended to equal requests, see [quaranteed quality of se
 
 - [`limits`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
 
-    The max resources for a Redis node in integers (similar to pod limits).
+    The max resources (in integers) for a Redis node (similar to pod limits).
 
   For example:
       ```yaml
@@ -71,7 +71,7 @@ Resource limits are recommended to equal requests, see [quaranteed quality of se
 
 - [`requests`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
 
-  The minimum resources for a Redis node in integers (similar to pod requests).
+  The minimum resources (in integers) for a Redis node  (similar to pod requests).
 
   For example:
 

--- a/content/kubernetes/reference/cluster-options.md
+++ b/content/kubernetes/reference/cluster-options.md
@@ -52,19 +52,13 @@ You can create this binding manually, but we do not recommend it.
 
 ### [`redisEnterpriseNodeResources`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
 
-The [compute resources](https://docs.openshift.com/enterprise/3.2/dev_guide/compute_resources.html#dev-compute-resources) required for each node (see `limits` and `requests`).
+The [compute resources](https://docs.openshift.com/enterprise/3.2/dev_guide/compute_resources.html#dev-compute-resources) required for each node (see `limits` and `requests`). Kubernetes accepts only integers as sizing numbers for requests and limits.
 
-{{< note >}}
-We recommend that resource limits equal requests ([Learn why](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/topics.md#guaranteed-quality-of-service)).
-{{< /note >}}
-
-{{< note >}}
-Please note that Kubernetes accepts only integers as sizing numbers for requests and limits
-{{< /note >}}
+Resource limits are recommended to equal requests, see [quaranteed quality of service](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/topics.md#guaranteed-quality-of-service) for more info.
 
 - [`limits`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
 
-    The max resources for a Redis node (similar to pod limits).
+    The max resources for a Redis node in integers (similar to pod limits).
 
   For example:
       ```yaml
@@ -77,7 +71,7 @@ Please note that Kubernetes accepts only integers as sizing numbers for requests
 
 - [`requests`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
 
-  The minimum resources for a Redis node (similar to pod requests).
+  The minimum resources for a Redis node in integers (similar to pod requests).
 
   For example:
 


### PR DESCRIPTION
Integrated redisEnterpriseNodeResources notes into main text. I also clarified that both limits and requests are integer values. 