### PR TITLE
Fixes Redis Gears tutorial link

### DIFF
--- a/content/modules/redisgears/python/quickstart.md
+++ b/content/modules/redisgears/python/quickstart.md
@@ -137,4 +137,4 @@ redis.cloud:6379> GET age:maximum
 
 ## Next steps
 
-You should now have a basic idea of how to run RedisGears functions for batch and event processing. But there's a lot more to RedisGears than this. To better understand it, see the [RedisGears tutorial](https://oss.redislabs.com/redisgears/intro.html). If you're interested in write-behind caching, see our [write-behind caching]({{<relref "/modules/redisgears/python/recipes/write-behind">}}) overview.
+You should now have a basic idea of how to run RedisGears functions for batch and event processing. But there's a lot more to RedisGears than this. To better understand it, see the [RedisGears tutorial](https://oss.redis.com/redisgears/intro.html). If you're interested in write-behind caching, see our [write-behind caching]({{<relref "/modules/redisgears/python/recipes/write-behind">}}) overview.


### PR DESCRIPTION
Fixes deadlink on RedisGears tutorial by pointing to oss.redis.com instead of oss.redislabs.com.