### PR TITLE
Added RedisGraph v2.8.11 release notes

### DIFF
--- a/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
+++ b/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
@@ -10,10 +10,22 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisGraph v2.8.10 requires:
+RedisGraph v2.8.11 requires:
 
 - Minimum Redis compatibility version (database): 6.2.0
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v2.8.11 (March 2022)
+
+This is a maintenance release for RedisGraph 2.8.
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
+
+Details:
+
+- Bug fixes:
+
+    - [#2259](https://github.com/RedisGraph/RedisGraph/issues/2259), [#2258](https://github.com/RedisGraph/RedisGraph/pull/2258) Fix memory leak and potential crash on [RDB](https://redis.io/docs/manual/persistence/) saving
 
 ## v2.8.10 (March 2022)
 


### PR DESCRIPTION
[Staged preview](https://docs.redis.com/staging/graph-release-notes/modules/redisgraph/release-notes/redisgraph-2.8-release-notes/)