### PR TITLE
Review feedback Doc-941

### DIFF
--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -236,7 +236,7 @@ As part of the REC creation process, the operator stores the admission controlle
     kubectl patch ValidatingWebhookConfiguration redb-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
-### Limit the webhook to the relevant namespaces
+### Limit the webhook to the relevant namespaces {#webhook}
 
 The webhook will intercept requests from all namespaces unless you edit it to target a specific namespace. You can do this by adding the `namespaceSelector` section to the webhook spec to target a label on the namespace.
 

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -21,7 +21,7 @@ When you delete a database, your data and the REDB custom resource are also dele
 
 To delete a Redis Enterprise cluster managed by the operator:
 
-1. Delete all the databases in your cluster
+1. Delete all the databases in your cluster.
 
 1. Run `kubectl delete rec <your-rec-name>` from your K8s cluster.
 

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -74,7 +74,7 @@ If the operator isn't running, or some other fatal error occurs, the finalizer i
 
 If this happens, you can remove the finalizer manually.
 
-{{<warning>}} If you remove the finalizer manually, there is not guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
+{{<warning>}} If you remove the finalizer manually, there is no guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
 
 ```sh
 kubectl patch rec <your-rec-name> --type=json -p \

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -30,8 +30,9 @@ When you delete your cluster, your databases and the REC custom resource are als
 ## Delete the operator
 
 To delete the operator from your K8s cluster and namespace, you can delete the operator bundle with:
--`kubectl delete -f bundle.yaml` for vanilla K8s deployments
--`kubectl delete -f openshift.bundle.yaml` for OpenShift deployments 
+
+- `kubectl delete -f bundle.yaml` for vanilla K8s deployments
+- `kubectl delete -f openshift.bundle.yaml` for OpenShift deployments 
 
 This will remove the operator and its custom resource definitions (CRDs) from your K8s cluster.
 

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -11,7 +11,7 @@ aliases: [
 ]
 ---
 
-## Delete a database
+## Delete a database (REDB)
 
 To delete a database managed by the Redis Enterprise Kubernetes operator, run `kubectl delete redb <your-db-name>` from your K8s cluster.
 

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -49,7 +49,7 @@ kubectl delete -f admission-service.yaml
 kubectl delete -f operator.yaml
 ```
 
-You will also need to remove [the `namespaceSelector` section from the validating webhook]({{relref "kubernetes/deployment/quick-start#webhook"}}).
+You will also need to remove [the `namespaceSelector` section from the validating webhook]({{relref "/kubernetes/deployment/quick-start#webhook"}}).
 
 ### Troubleshoot REDB deletion
 

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -49,7 +49,7 @@ kubectl delete -f admission-service.yaml
 kubectl delete -f operator.yaml
 ```
 
-You will also need to remove [the `namespaceSelector` section from the validating webhook]({{relref "/kubernetes/deployment/quick-start#webhook"}}).
+You will also need to remove [the `namespaceSelector` section from the validating webhook]({{<relref "/kubernetes/deployment/quick-start#webhook">}}).
 
 ### Troubleshoot REDB deletion
 

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -17,21 +17,6 @@ To delete a database managed by the Redis Enterprise Kubernetes operator, run `k
 
 When you delete a database, your data and the REDB custom resource are also deleted.
 
-### Troubleshoot REDB deletion
-
-The operator attaches a finalizer to the Redis Enterprise database (REDB) object. This makes sure the database is deleted before the REDB custom resource is removed from the K8s cluster.
-
-If the finalizer isn't removed automatically by the operator, you won't be able to delete your REDB resource.
-
-If this happens, you can remove the finalizer manually.
-
-{{<warning>}} If you remove the finalizer manually, there is not guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
-
-```sh
-kubectl patch redb <your-db-name> --type=json -p \
-    '[{"op":"remove","path":"/metadata/finalizers","value":"finalizer.redisenterprisedatabases.app.redislabs.com"}]'
-```
-
 ## Delete a Redis Enterprise cluster (REC)
 
 To delete a Redis Enterprise cluster managed by the operator:
@@ -42,26 +27,15 @@ To delete a Redis Enterprise cluster managed by the operator:
 
 When you delete your cluster, your databases and the REC custom resource are also deleted. However, persistent volume claims (PVCs) for your cluster are not deleted in the process. If you want to delete your PVCs, you'll have to delete them manually.
 
-### Troubleshoot REC deletion
-
-The operator attaches a finalizer to the Redis Enterprise cluster (REC) object. This makes sure the Redis cluster is deleted before the REC custom resource is removed from the K8s cluster.
-
-If the finalizer isn't removed automatically by the operator, you won't be able to delete your REC resource.
-
-If this happens, you can remove the finalizer manually.
-
-{{<warning>}} If you remove the finalizer manually, there is not guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
-
-```sh
-kubectl patch rec <your-rec-name> --type=json -p \
-    '[{"op":"remove","path":"/metadata/finalizers","value":"redbfinalizer.redisenterpriseclusters.app.redislabs.com"}]'
-```
-
 ## Delete the operator
 
-To delete the operator from your K8s cluster and namespace, you can delete the operator bundle with `kubectl delete -f bundle.yaml`. This will remove the operator and its custom resource definitions (CRDs) from your K8s cluster.
+To delete the operator from your K8s cluster and namespace, you can delete the operator bundle with:
+-`kubectl delete -f bundle.yaml` for vanilla K8s deployments
+-`kubectl delete -f openshift.bundle.yaml` for OpenShift deployments 
 
-{{<warning>}} The Redis Enterprise CRDs are non-namespaced resources, meaning they are shared across your entire K8s cluster. Deleting CRDs in one namespace will delete custom resources in every other namespace across the K8s cluster.{{</warning>}}
+This will remove the operator and its custom resource definitions (CRDs) from your K8s cluster.
+
+{{< warning >}} The Redis Enterprise CRDs are non-namespaced resources, meaning they are shared across your entire K8s cluster. Deleting CRDs in one namespace will delete custom resources in every other namespace across the K8s cluster.{{</warning>}}
 
 If you have Redis Enterprise clusters running in different namespaces on the same K8s cluster, deleting the entire operator bundle might cause data loss.
 
@@ -73,4 +47,36 @@ kubectl delete -f role_binding.yaml
 kubectl delete -f service_account.yaml
 kubectl delete -f admission-service.yaml
 kubectl delete -f operator.yaml
+```
+
+You will also need to remove [the `namespaceSelector` section from the validating webhook]({{relref "kubernetes/deployment/quick-start#webhook"}}).
+
+### Troubleshoot REDB deletion
+
+The operator attaches a finalizer to the Redis Enterprise database (REDB) object. This makes sure the database is deleted before the REDB custom resource is removed from the K8s cluster.
+
+If the operator isn't running, or some other fatal error occurs, the finalizer isn't removed automatically by the operator. In this case, you won't be able to delete your REDB resource.
+
+If this happens, you can remove the finalizer manually.
+
+{{<warning>}} If you remove the finalizer manually, there is not guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
+
+```sh
+kubectl patch redb <your-db-name> --type=json -p \
+    '[{"op":"remove","path":"/metadata/finalizers","value":"finalizer.redisenterprisedatabases.app.redislabs.com"}]'
+```
+
+### Troubleshoot REC deletion
+
+The operator attaches a finalizer to the Redis Enterprise cluster (REC) object. This makes sure the Redis cluster is deleted before the REC custom resource is removed from the K8s cluster.
+
+If the operator isn't running, or some other fatal error occurs, the finalizer isn't removed automatically by the operator. In this case, you won't be able to delete your REDB resource.
+
+If this happens, you can remove the finalizer manually.
+
+{{<warning>}} If you remove the finalizer manually, there is not guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
+
+```sh
+kubectl patch rec <your-rec-name> --type=json -p \
+    '[{"op":"remove","path":"/metadata/finalizers","value":"redbfinalizer.redisenterpriseclusters.app.redislabs.com"}]'
 ```

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -31,7 +31,7 @@ When you delete your cluster, your databases and the REC custom resource are als
 
 To delete the operator from your K8s cluster and namespace, you can delete the operator bundle with:
 
-- `kubectl delete -f bundle.yaml` for vanilla K8s deployments
+- `kubectl delete -f bundle.yaml` for non-OpenShift K8s deployments
 - `kubectl delete -f openshift.bundle.yaml` for OpenShift deployments 
 
 This will remove the operator and its custom resource definitions (CRDs) from your K8s cluster.

--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -59,7 +59,7 @@ If the operator isn't running, or some other fatal error occurs, the finalizer i
 
 If this happens, you can remove the finalizer manually.
 
-{{<warning>}} If you remove the finalizer manually, there is not guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
+{{<warning>}} If you remove the finalizer manually, there is no guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
 
 ```sh
 kubectl patch redb <your-db-name> --type=json -p \


### PR DESCRIPTION
Three changes that came out of our 3/31/22 sync: 
- add mention of separate bundle for OpenShift
- add more info that finalizer only fails when operator isn't working right
- when deleting from a specific namespace, must edit the webhook
- moved troubleshooting section to bottom of article

[Staged Preview](https://docs.redislabs.com/staging/jira-doc-941-rev/kubernetes/re-clusters/delete_custom_resources/)