### PR TITLE
DOC-1132: RS - Examples of "crdb create examples" using --encrypted rather than --encryption

### DIFF
--- a/content/rs/references/crdb-cli-reference.md
+++ b/content/rs/references/crdb-cli-reference.md
@@ -190,7 +190,7 @@ The configuration options that you can update are:
 |---|---|---|
 |`memory-size <ram_limit>`|string| Maximum memory in bytes| kilobytes (kb)| or gigabytes (gb)|
 |`causal-consistency <true \| false>`|boolean| Database updates are applied to all instances in the order they were received|
-|`encryption <true \| false>`| binary| Enable encryption|
+|`encryption <true \| false>`| boolean| Enable encryption|
 |`compression (0-6)`| integer| The level of compression of data: 0=Compression disabled| 1=Low compression and resource load| 6=High compression and resource load (Default: 3)|
 |`credentials id=<instance_id>,username=<username>,password=<password>`|string|Update the credentials for the participating cluster|
 |`featureset-version <true \| false>`|boolean|Update to latest FeatureSet version|

--- a/content/rs/references/crdb-cli-reference.md
+++ b/content/rs/references/crdb-cli-reference.md
@@ -120,7 +120,7 @@ The `crdb create` command supports several additional options:
 To create an Active-Active database with two shards in each instance and with encrypted traffic between the clusters:
 
 ```sh
-crdb-cli crdb create --name mycrdb --memory-size 100mb --port 12000 --instance fqdn=cluster1.local,username=test,password=test --instance fqdn=cluster2.local,username=test,password=test --shards-count 2 --encrypted true
+crdb-cli crdb create --name mycrdb --memory-size 100mb --port 12000 --instance fqdn=cluster1.local,username=test,password=test --instance fqdn=cluster2.local,username=test,password=test --shards-count 2 --encryption true
 ```
 
 To create an Active-Active database with two shards and with RediSearch 2.0.6 module:
@@ -132,7 +132,7 @@ crdb-cli crdb create --name mycrdb --memory-size 100mb --port 12000 --instance f
 To create an Active-Active database with two shards and with encrypted traffic between the clusters:
 
 ```sh
-crdb-cli crdb create --name mycrdb --memory-size 100mb --port 12000 --instance fqdn=cluster1.local,username=test,password=test --instance fqdn=cluster2.local,username=test,password=test --encrypted true --shards-count 2
+crdb-cli crdb create --name mycrdb --memory-size 100mb --port 12000 --instance fqdn=cluster1.local,username=test,password=test --instance fqdn=cluster2.local,username=test,password=test --encryption true --shards-count 2
 ```
 
 To create an Active-Active database with 1 shard in each instance and not wait for the response:

--- a/content/rs/references/crdb-cli-reference.md
+++ b/content/rs/references/crdb-cli-reference.md
@@ -189,13 +189,13 @@ The configuration options that you can update are:
 |Flag and argument| Argument type| Description|
 |---|---|---|
 |`memory-size <ram_limit>`|string| Maximum memory in bytes| kilobytes (kb)| or gigabytes (gb)|
-|`causal-consistency <true | false>`|boolean| Database updates are applied to all instances in the order they were received|
-|`encryption <true | false>`| binary| Enable encryption|
+|`causal-consistency <true \| false>`|boolean| Database updates are applied to all instances in the order they were received|
+|`encryption <true \| false>`| binary| Enable encryption|
 |`compression (0-6)`| integer| The level of compression of data: 0=Compression disabled| 1=Low compression and resource load| 6=High compression and resource load (Default: 3)|
 |`credentials id=<instance_id>,username=<username>,password=<password>`|string|Update the credentials for the participating cluster|
-|`featureset-version <true | false>`|boolean|Update to latest FeatureSet version|
-|`oss-cluster <true | false>`|boolean|Enable or disable OSS cluster mode|
-|`bigstore <true | false>`|boolean|Use Redis on Flash to add flash memory to the database|
+|`featureset-version <true \| false>`|boolean|Update to latest FeatureSet version|
+|`oss-cluster <true \| false>`|boolean|Enable or disable OSS cluster mode|
+|`bigstore <true \| false>`|boolean|Use Redis on Flash to add flash memory to the database|
 |`bigstore-ram-size <ram_limit>`|string|RAM limit for RoF database (bytes, MB, or GB)|
 |`with-module <module_name>`|text|The name of the module to add to the database|
 |`force`|no arguments|Increase the configuration version even if there are no configuration changes|


### PR DESCRIPTION
Staging Link: https://docs.redis.com/staging/jira-doc-1132/rs/references/crdb-cli-reference/

- Fixed code samples to use the "--encryption" argument instead of "--encrypted".
- I noticed that the table under "Updating the configuration of an Active-Active database" had some pipes that weren't escaped, which caused some formatting issues on the latest version of the site (see screenshot for current latest look). Escaped those pipes so that the table looks better.
![Screen Shot 2022-04-01 at 5 02 16 PM](https://user-images.githubusercontent.com/102550101/161340829-e67b05b7-8d70-42a5-8025-2a88cfbfea88.png)
- In that same table, the "--encryption" argument had the "binary" type when I assume it should be "boolean" (like the other true/false arguments).