### PR TITLE
DOC-1266 RS - Change username to user email for password reset command

### DIFF
--- a/content/rs/security/admin-console-security/user-security.md
+++ b/content/rs/security/admin-console-security/user-security.md
@@ -162,7 +162,7 @@ If you set the lockout duration to 0, then the account can be unlocked only when
 To unlock a user account or reset a user password from the CLI, run:
 
 ```sh
-rladmin cluster reset_password <username>
+rladmin cluster reset_password <user email>
 ```
 
 To unlock a user account or reset a user password from the REST API, run:


### PR DESCRIPTION
Staging link: https://docs.redis.com/staging/jira-doc-1266/rs/security/admin-console-security/user-security/

Changed username to user email for the rladmin password reset command.