### PR TITLE
Kubernetes: ```yaml``` markup in code snippet

### DIFF
--- a/content/kubernetes/re-databases/db-controller.md
+++ b/content/kubernetes/re-databases/db-controller.md
@@ -51,10 +51,10 @@ Your Redis Enterprise database custom resource must be of the `kind: RedisEnterp
 
     To create a REDB in a different namespace from your REC, you need to specify the cluster with `redisEnterpriseCluster` in the `spec` section of your RedisEnterpriseDatabase custom resource.
 
-        ```yaml
-          redisEnterpriseCluster:
-            name: rec
-        ```
+     ```YAML
+     redisEnterpriseCluster:
+       name: rec
+     ```
 
 1. Apply the file in the namespace you want your database to be in.
 


### PR DESCRIPTION
This PR corrects the formatting issue in a YAML code snippet, as described in [DOC-1291](https://redislabs.atlassian.net/browse/DOC-1291). 

[Preview](https://docs.redis.com/staging/jira-doc-1291/kubernetes/re-databases/db-controller/)