### PR TITLE
RS: rladmin page should clarify that username must be a mail

### DIFF
--- a/content/rs/references/rladmin.md
+++ b/content/rs/references/rladmin.md
@@ -158,7 +158,7 @@ rladmin cluster debug_info [ path <path> ]
 ```text
 cluster create 
         name <cluster-name>
-        username <admin-user> 
+        username <admin-email> 
         password <admin-password> 
         [ node_uid <node-uid> ] 
         [ rack_aware ] 


### PR DESCRIPTION
This PR fixes `cluster create` input on the RS rladmin page from user name to user email, as specified in [DOC-1129](https://redislabs.atlassian.net/browse/DOC-1129).

[Preview](https://docs.redis.com/staging/jira-doc-1129/rs/references/rladmin/#cluster-create)