### PR TITLE
RS reorg: Connections section

### DIFF
--- a/content/rs/concepts/data-access/discovery-service.md
+++ b/content/rs/concepts/data-access/discovery-service.md
@@ -26,7 +26,7 @@ connecting to databases.
 The Discovery Service is available for querying on each node of the
 cluster, listening on port 8001. To employ it, your application utilizes
 a [Redis Sentinel enabled client
-library]({{< relref "/rs/administering/designing-production/supported-clients-browsers.md" >}})
+library]({{< relref "/rs/connections/supported-clients-browsers.md" >}})
 to connect to the Discovery Service and request the endpoint for the
 given database. The Discovery Service replies with the database's
 endpoint for that database. In case of a node failure, the Discovery

--- a/content/rs/connections/_index.md
+++ b/content/rs/connections/_index.md
@@ -6,3 +6,7 @@ weight: 70
 categories: ["RS"]
 ---
 Learn how to connect your application to a Redis database hosted by Redis Enterprise Software and test your connection.
+
+[Supported connection clients]({{< relref "/rs/connections/supported-clients-browsers.md" >}})
+
+[Testing client connectivity]({{< relref "/rs/connections/testing-client-connectivity.md" >}})

--- a/content/rs/connections/_index.md
+++ b/content/rs/connections/_index.md
@@ -1,0 +1,8 @@
+---
+Title: Manage client connections
+linkTitle: Connections
+description:
+weight: 70
+categories: ["RS"]
+---
+Learn how to connect your application to a Redis database hosted by Redis Enterprise Software and test your connection.

--- a/content/rs/connections/_index.md
+++ b/content/rs/connections/_index.md
@@ -9,4 +9,4 @@ Learn how to connect your application to a Redis database hosted by Redis Enterp
 
 [Supported connection clients]({{< relref "/rs/connections/supported-clients-browsers.md" >}})
 
-[Testing client connectivity]({{< relref "/rs/connections/testing-client-connectivity.md" >}})
+[Test client connectivity]({{< relref "/rs/connections/testing-client-connectivity.md" >}})

--- a/content/rs/connections/supported-clients-browsers.md
+++ b/content/rs/connections/supported-clients-browsers.md
@@ -2,10 +2,11 @@
 Title: Supported connection clients
 description:
 weight: $weight
-alwaysopen: false
 categories: ["RS"]
 aliases: rs/administering/designing-production/supported-clients-browsers/
          rs/administering/designing-production/supported-clients-browsers.md
+         rs/connections/supported-clients-browsers/
+         rs/connections/supported-clients-browsers.md
 ---
 You can connect to Redis Enterprise Software databases programmatically using client libraries.
 

--- a/content/rs/connections/testing-client-connectivity.md
+++ b/content/rs/connections/testing-client-connectivity.md
@@ -1,9 +1,13 @@
 ---
-Title: Testing Client Connectivity
+Title: Testing client connectivity
 description: 
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
+aliases: rs/administering/troubleshooting/testing-client-connectivity/
+         rs/administering/troubleshooting/testing-client-connectivity.md
+         rs/connections/testing-client-connectivity/
+         rs/connections/testing-client-connectivity.md
 ---
 In various scenarios, such as after creating a new cluster or upgrading
 the cluster, it is highly advisable to verify client connectivity to the

--- a/content/rs/connections/testing-client-connectivity.md
+++ b/content/rs/connections/testing-client-connectivity.md
@@ -1,5 +1,5 @@
 ---
-Title: Testing client connectivity
+Title: Test client connectivity
 description: 
 weight: $weight
 alwaysopen: false


### PR DESCRIPTION
This PR adds a **Connections** section to RS and moves two topics from **Administering** (**Supported client browsers** and **Testing client connectivity**), as specified in [DOC-1229](https://redislabs.atlassian.net/browse/DOC-1229). 

[Preview](https://docs.redis.com/staging/jira-doc-1229b/rs/connections/)