### PR TITLE
DOC-1307 - Modules: RedisJSON v. 2.0.8 Release notes

### DIFF
--- a/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
+++ b/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
@@ -10,7 +10,7 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisJSON v2.0.7 requires:
+RedisJSON v2.0.8 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0

--- a/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
+++ b/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
@@ -15,6 +15,18 @@ RedisJSON v2.0.7 requires:
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
 
+## v2.0.8 (April 2022)
+
+This is a maintenance release for RedisJSON 2.0.
+
+Update urgency: `LOW` - No need to upgrade unless there are new features you want to use.
+
+Details:
+
+- Bug fixes:
+
+  - [#691](https://github.com/RedisJSON/RedisJSON/pull/691), [#667](https://github.com/RedisJSON/RedisJSON/issues/667) Duplicate results in JSONPath query
+
 ## v2.0.7 (March 2022)
 
 This is a maintenance release for RedisJSON 2.0.


### PR DESCRIPTION
Staging link: https://docs.redis.com/staging/jira-doc-1307/modules/redisjson/release-notes/redisjson-2.0-release-notes/

Added the [RedisJSON v. 2.0.8 release notes](https://github.com/RedisJSON/RedisJSON/releases/tag/v2.0.8).