### PR TITLE
K8s: REC options page text is in code blocks

### DIFF
--- a/content/kubernetes/reference/cluster-options.md
+++ b/content/kubernetes/reference/cluster-options.md
@@ -15,87 +15,84 @@ A Redis Enterprise cluster (REC) is defined in a custom resource definition (CRD
 
 The most common options you might specify are listed below. For a full list of options, see the [Redis Enterprise Cluster API](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md).
 
-### `name`: `rec`
+## `name`: `rec`
 
-    This is the cluster name that the operator uses to name various
-    resources in the Kubernetes cluster and also name the CRD.
+This is the cluster name that the operator uses to name various resources in the Kubernetes cluster and also name the CRD.
 
-    {{< note >}}
+{{< note >}}
 
-There is a binding between the SCC and the service account.
-You can create this binding manually, but we do not recommend it.
+There is a binding between the SCC and the service account. You can create this binding manually, but it is not recommended.
 
-    {{< /note >}}
+{{< /note >}}
 
-### [`nodes`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec): `nnn`
+## [`nodes`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec): `nnn`
 
-    This [must be an odd number](https://redislabs.com/redis-enterprise/technology/highly-available-redis/) that is 3 or higher.
+This [must be an odd number](https://redislabs.com/redis-enterprise/technology/highly-available-redis/) that is 3 or higher.
 
 ### [`uiServiceType`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec): `service_type`
 
-    This controls how the Redis Enterprise UI is exposed on the cluster.
-    The service_type must be either `ClusterIP` or `LoadBalancer` (default: `ClusterIP`).
-    This is an optional configuration based on [k8s service types](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/).
+This controls how the Redis Enterprise UI is exposed on the cluster. The service_type must be either `ClusterIP` or `LoadBalancer` (default: `ClusterIP`). It is an optional configuration based on [k8s service types](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/).
 
-### [`persistentSpec`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
+### [`persistentSpec`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec)
 
-    You can add a `storageClassName` that specifies the [Storage Class](https://kubernetes.io/docs/concepts/storage/storage-classes/) used for your nodes’ persistent disks. For example, AWS uses “gp2” as a default, GKE uses “standard” and Azure uses "default".
+You can add a `storageClassName` that specifies the [Storage Class](https://kubernetes.io/docs/concepts/storage/storage-classes/) used for your nodes’ persistent disks. For example, AWS uses “gp2” as a default, GKE uses “standard” and Azure uses "default".
 
-    Also, adding a `volumeSize` lets you control the size of the persistent volume attached to the Redis Enterprise pods.
+Also, adding a `volumeSize` lets you control the size of the persistent volume attached to the Redis Enterprise pods.
 
-    ```yaml
-    persistentSpec:
-      enabled: true
-      volumeSize: "10Gi"
-      storageClassName: "gp2"
-    ```
+```yaml
+persistentSpec:
+  enabled: true
+  volumeSize: "10Gi"
+  storageClassName: "gp2"
+```
 
-### [`redisEnterpriseNodeResources`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
+### [`redisEnterpriseNodeResources`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec)
 
 The [compute resources](https://docs.openshift.com/enterprise/3.2/dev_guide/compute_resources.html#dev-compute-resources) required for each node (see `limits` and `requests`). Kubernetes accepts only integers as sizing numbers for requests and limits.
 
 Resource limits are recommended to equal requests, see [quaranteed quality of service](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/topics.md#guaranteed-quality-of-service) for more info.
 
-- [`limits`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
+#### [`limits`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec)
 
-    The max resources (in integers) for a Redis node (similar to pod limits).
+The max resources (in integers) for a Redis node (similar to pod limits).
 
-  For example:
-      ```yaml
-       limits:
-         cpu: "4000m"
-         memory: 4Gi
-       ```
+For example:
 
-  The default is 4 cores (4000m) and 4GB (4Gi).
+```yaml
+limits:
+  cpu: "4000m"
+  memory: 4Gi
+```
 
-- [`requests`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec):
+The default is 4 cores (4000m) and 4GB (4Gi).
 
-  The minimum resources (in integers) for a Redis node  (similar to pod requests).
+#### [`requests`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec)
 
-  For example:
+The minimum resources (in integers) for a Redis node  (similar to pod requests).
 
-    ```yaml
-    requests:
-      cpu: "4000m"
-      memory: 4Gi
-      ```
+For example:
 
-    The default is 4 cores (4000m) and 4GB (4Gi).
+```yaml
+requests:
+   cpu: "4000m"
+   memory: 4Gi
+```
 
-### [`redisEnterpriseImageSpec`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#imagespec):
+The default is 4 cores (4000m) and 4GB (4Gi).
 
-    This configuration controls the Redis Enterprise version used, and where it is fetched from. This is an optional field. The Operator automatically uses the matching RHEL image version for the release.
+### [`redisEnterpriseImageSpec`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#imagespec)
 
-    The value is structured as follows with the [policy values from OpenShift](https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/builds_and_image_streams.html#image-pull-policy):
+This configuration controls the Redis Enterprise version used, and where it is fetched from. This is an optional field. The Operator automatically uses the matching RHEL image version for the release.
 
-    ```yaml
-    imagePullPolicy: IfNotPresent
+The value is structured as follows with the [policy values from OpenShift](https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/builds_and_image_streams.html#image-pull-policy):
+
+```yaml
+imagePullPolicy: IfNotPresent
     Repository: redislabs/redis
     versionTag: 6.0.6-39
-    ```
+```
 
-    The version tag is as it appears on your repository, such as in [DockerHub](https://hub.docker.com/r/redislabs/redis/).
+The version tag is as it appears on your repository, such as in [DockerHub](https://hub.docker.com/r/redislabs/redis/).
 
 ### `redisUpgradePolicy`
 
@@ -103,14 +100,14 @@ Resource limits are recommended to equal requests, see [quaranteed quality of se
 
 The supported values are:
 
-- `major` : limits Redis database version to the most recent major release
+- `major`: limits Redis database version to the most recent major release
 - `latest`: sets default database version to the latest minor release
 
 More info:
 - [Redis upgrade policy]({{<relref "/rs/installing-upgrading/upgrading.md#redis-upgrade-policy">}})
 - [Upgrade policy values]({{<relref "/rs/installing-upgrading/upgrading.md#upgrade-policy-values">}})
 
-## Sample REC custom resource
+### Sample REC custom resource
 
 ```yaml
 apiVersion: app.redislabs.com/v1


### PR DESCRIPTION
This PR removes fixes page formatting as requested in[ DOC-1351](https://redislabs.atlassian.net/browse/DOC-1351). 

[Preview](https://docs.redis.com/staging/DOC-1351/kubernetes/reference/cluster-options/)