### PR TITLE
Reorg rladmin cluster commands

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/cluster/_index.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/_index.md
@@ -10,23 +10,12 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster` manages cluster configuration and administration. Most `rladmin cluster` commands are only for clusters that are already configured, while a few others are only for new clusters that have not been configured.
+Manages cluster configuration and administration. Most `rladmin cluster` commands are only for clusters that are already configured, while a few others are only for new clusters that have not been configured.
 
 ## Commands for configured clusters
 
-| Command | Description |
-| - | - |
-| [`cluster certificate`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/certificate">}}) | Sets the cluster certificate |
-| [`cluster config`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/config">}}) | Updates configuration for the cluster |
-| [`cluster reset_password`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/reset_password">}}) | Changes the password for a given email |
-| `cluster stats_archiver` | Enables/disables stats archiving |
-| [`cluster debug_info`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/debug_info">}}) | Creates a support package |
-| `cluster running_actions` | Lists all active tasks |
+{{<table-children columnNames="Command,Description" columnSources="linkTitle,Description" enableLinks="linkTitle" limitTags="configured">}}
 
 ## Commands for non-configured clusters
 
-| Command | Description |
-| - | - |
-| [`cluster create`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/create">}}) | Creates a new cluster |
-| [`cluster join`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/join">}}) | Adds a node to an existing cluster |
-| [`cluster recover`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/recover">}}) | Recovers a cluster from a backup file |
+{{<table-children columnNames="Command,Description" columnSources="linkTitle,Description" enableLinks="linkTitle" limitTags="non-configured">}}

--- a/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
@@ -5,6 +5,7 @@ description: Sets the cluster certificate.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["configured"]
 categories: ["RS"]
 aliases: 

--- a/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-Sets the cluster certificate to a specified file.
+Sets a cluster certificate to a specified PEM file.
 
 ```sh
 rladmin cluster certificate 
@@ -18,21 +18,30 @@ rladmin cluster certificate
        [ key_file <key filepath> ]
 ```
 
+To set a certificate for a specific service, use the corresponding certificate name:
+
+- `cm` for the admin console
+- `api` for the REST API
+- `proxy` for the proxy, which manages connections between clients and database endpoints
+- `syncer` for the syncer, which synchronizes data between clusters (using either Active-Active or Active-Passive replication)
+- `metrics_exporter` for the metrics exporter, which sends metrics to Prometheus
+
 ### Parameters
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| certificate name | string | Name of certificate to update |
+| certificate name | 'cm'<br /> 'api'<br /> 'proxy'<br /> 'syncer'<br /> 'metrics_exporter' | Name of certificate to update |
 | certificate_file | filepath | Path to the certificate file |
 | key_file | filepath | Path to the key file (optional) |
 
 ### Returns
 
-Reports that the certificate was set to the given file, or returns an error message.
+Reports that the certificate was set to the specified file. Returns an error message if the certificate fails to update.
 
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster certificate set proxy \
+       certificate_file /tmp/proxy.pem
+Set proxy certificate to contents of file /tmp/proxy.pem
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster certificate
 linkTitle: certificate
-description: Command description.
+description: Sets the cluster certificate.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,16 +9,26 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster certificate` sets the cluster certificate to a given file.
+
+```sh
+rladmin cluster certificate 
+       set <certificate name> 
+       certificate_file <certificate filepath> 
+       [ key_file <key filepath> ]
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| param1 | Description |
-| param2 | Description |
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
+| certificate name | string | Name of certificate to update |
+| certificate_file | filepath | Path to the certificate file |
+| key_file | filepath | Path to the key file (optional) |
 
 ### Returns
+
+Reports that the certificate was set to the given file, or returns an error message.
 
 ### Example
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster certificate` sets the cluster certificate to a given file.
+Sets the cluster certificate to a specified file.
 
 ```sh
 rladmin cluster certificate 

--- a/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
@@ -5,6 +5,7 @@ description: Sets the cluster certificate.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster config` updates the cluster configuration.
+Updates the cluster configuration.
 
 ```sh
  rladmin cluster config 
@@ -19,7 +19,7 @@ aliases:
         [ cnm_http_port <number> ]
         [ cnm_https_port <number>]
         [ data_cipher_list <openSSL cipher list> ]
-        [ debuginfo_path <path/to/directory> ]
+        [ debuginfo_path <filepath> ]
         [ handle_redirects { enabled | disabled } ]
         [ http_support { enabled | disabled } ]
         [ ipv6 { enabled | disabled } ]
@@ -38,32 +38,33 @@ aliases:
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| cipher_suites | | Cipher suites used for TLS connections to the admin console; specified in the format understood by the BoringSSL library |
+| cipher_suites | list of ciphers | Cipher suites used for TLS connections to the admin console; specified in the format understood by the BoringSSL library |
 | cm_port | integer | UI server listening port |
 | cm_session_timeout | integer | Timeout in minutes for the CM session
 | cmn_http_port | integer | HTTP REST API server listening port |
 | cnm_https_port | integer | HTTPS REST API server listening port |
-| data_cipher_list | | Cipher suites used by the the data plane; specified in the format understood by the OpenSSL library |
-| debuginfo_path | | Path to local directory to place file when generating support packages |
+| data_cipher_list | list of ciphers | Cipher suites used by the the data plane; specified in the format understood by the OpenSSL library |
+| debuginfo_path | filepath | Path to local directory to place file when generating support packages |
 | handle_redirects | 'enabled'<br />'disabled' | Enable or disable handling DNS redirects when DNS is not configured and running behind a load balancer |
 | http_support | 'enabled'<br />'disabled' | Enable or disable using HTTP for REST API connections (info cluster) |
 | ipv6 | 'enabled'<br />'disabled' | Enable or disable IPv6 connections to the RS admin console |
-| min_control_TLS_version | | The minimum version of TLS protocol which is supported at the control path |
-| min_data_TLS_version | | The minimum version of TLS protocol which is supported at the data path |
-| min_sentinel_TLS_version | | |
-| s3_url | | The URL of S3 export and import |
-| saslauthd_ldap_conf | | Updates LDAP authentication configuration for the cluster (see Cluster-based LDAP Authentication or Kubernetes LDAP configuration) |
-| sentinel_cipher_suites | | Cipher suites used by the sentinel service (supported ciphers are implemented by the golang.org cipher suites package) |
+| min_control_TLS_version | TLS protocol version | The minimum version of TLS protocol which is supported at the control path |
+| min_data_TLS_version | TLS protocol version | The minimum version of TLS protocol which is supported at the data path |
+| min_sentinel_TLS_version | TLS protocol version | The minimum version of TLS protocol which is supported in the sentinel service |
+| s3_url | string | The URL of S3 export and import |
+| saslauthd_ldap_conf | filepath | Updates LDAP authentication configuration for the cluster (see [cluster-based LDAP authentication]({{<relref "/rs/security/ldap/cluster-based-ldap-authentication">}}) or [Kubernetes LDAP configuration]({{<relref "/kubernetes/security/ldap-on-k8s">}})) |
+| sentinel_cipher_suites | list of ciphers | Cipher suites used by the sentinel service (supported ciphers are implemented by the [golang.org cipher suites package](https://golang.org/src/crypto/tls/cipher_suites.go)) |
 | sentinel_ssl_policy | 'allowed'<br />'required'<br />'disabled' | Define SSL policy for the Discovery Service: required/disabled/allowed |
-| services | 'cm_server'<br />'crdb_coordinator'<br />'crdb_worker'<br />'mdns_server'<br />'pdns_server'<br />'saslauthd'<br />'stats_archiver'<br /><br />'enabled'<br />'disabled' | |
-| upgrade_mode | 'enabled'<br />'disabled' | |
-
+| services | 'cm_server'<br />'crdb_coordinator'<br />'crdb_worker'<br />'mdns_server'<br />'pdns_server'<br />'saslauthd'<br />'stats_archiver'<br /><br />'enabled'<br />'disabled' | Enable or deactivate selected cluster services |
+| upgrade_mode | 'enabled'<br />'disabled' | Enable or deactivate upgrade mode on the cluster |
 
 ### Returns
+
+Reports whether the cluster was configured successfully. Displays an error message if the configuration attempt fails.
 
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster config cm_session_timeout_minutes 20
+Cluster configured successfully
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -5,6 +5,7 @@ description: Updates the cluster's configuration.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["configured"]
 categories: ["RS"]
 aliases: 
@@ -39,23 +40,23 @@ Updates the cluster configuration.
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| cipher_suites | list of ciphers | Cipher suites used for TLS connections to the admin console; specified in the format understood by the BoringSSL library |
+| cipher_suites | list of ciphers | Cipher suites used for TLS connections to the admin console (specified in the format understood by the BoringSSL library) |
 | cm_port | integer | UI server listening port |
 | cm_session_timeout | integer | Timeout in minutes for the CM session
 | cmn_http_port | integer | HTTP REST API server listening port |
 | cnm_https_port | integer | HTTPS REST API server listening port |
-| data_cipher_list | list of ciphers | Cipher suites used by the the data plane; specified in the format understood by the OpenSSL library |
-| debuginfo_path | filepath | Path to local directory to place file when generating support packages |
-| handle_redirects | 'enabled'<br />'disabled' | Enable or disable handling DNS redirects when DNS is not configured and running behind a load balancer |
-| http_support | 'enabled'<br />'disabled' | Enable or disable using HTTP for REST API connections (info cluster) |
-| ipv6 | 'enabled'<br />'disabled' | Enable or disable IPv6 connections to the RS admin console |
-| min_control_TLS_version | TLS protocol version | The minimum version of TLS protocol which is supported at the control path |
-| min_data_TLS_version | TLS protocol version | The minimum version of TLS protocol which is supported at the data path |
-| min_sentinel_TLS_version | TLS protocol version | The minimum version of TLS protocol which is supported in the sentinel service |
+| data_cipher_list | list of ciphers | Cipher suites used by the the data plane (specified in the format understood by the OpenSSL library) |
+| debuginfo_path | filepath | Local directory to place generated support package files |
+| handle_redirects | 'enabled'<br />'disabled' | Enable or turn off handling DNS redirects when DNS is not configured and running behind a load balancer |
+| http_support | 'enabled'<br />'disabled' | Enable or turn off using HTTP for REST API connections |
+| ipv6 | 'enabled'<br />'disabled' | Enable or turn off IPv6 connections to the admin console |
+| min_control_TLS_version | TLS protocol version | The minimum TLS protocol version that is supported for the control path |
+| min_data_TLS_version | TLS protocol version | The minimum TLS protocol version that is supported for the data path |
+| min_sentinel_TLS_version | TLS protocol version | The minimum TLS protocol version that is supported for the discovery service |
 | s3_url | string | The URL of S3 export and import |
 | saslauthd_ldap_conf | filepath | Updates LDAP authentication configuration for the cluster (see [cluster-based LDAP authentication]({{<relref "/rs/security/ldap/cluster-based-ldap-authentication">}}) or [Kubernetes LDAP configuration]({{<relref "/kubernetes/security/ldap-on-k8s">}})) |
-| sentinel_cipher_suites | list of ciphers | Cipher suites used by the sentinel service (supported ciphers are implemented by the [golang.org cipher suites package](https://golang.org/src/crypto/tls/cipher_suites.go)) |
-| sentinel_ssl_policy | 'allowed'<br />'required'<br />'disabled' | Define SSL policy for the Discovery Service: required/disabled/allowed |
+| sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [golang.org cipher suites package](https://golang.org/src/crypto/tls/cipher_suites.go)) |
+| sentinel_ssl_policy | 'allowed'<br />'required'<br />'disabled' | Define the SSL policy for the discovery service |
 | services | 'cm_server'<br />'crdb_coordinator'<br />'crdb_worker'<br />'mdns_server'<br />'pdns_server'<br />'saslauthd'<br />'stats_archiver'<br /><br />'enabled'<br />'disabled' | Enable or deactivate selected cluster services |
 | upgrade_mode | 'enabled'<br />'disabled' | Enable or deactivate upgrade mode on the cluster |
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -13,34 +13,51 @@ aliases:
 
 ```sh
  rladmin cluster config 
-        [ cipher_suites <BoringSSL_cipher_list> ]
+        [ cipher_suites <BoringSSL cipher list> ]
         [ cm_port <number> ]
         [ cm_session_timeout <minutes> ]
         [ cnm_http_port <number> ]
         [ cnm_https_port <number>]
-        [ data_cipher_list <data-cipher-suites-str> ]
+        [ data_cipher_list <openSSL cipher list> ]
         [ debuginfo_path <path/to/directory> ]
-        [ handle_redirects <enabled/disabled>]
-        [ http_support <enabled/disabled>]
-        [ ipv6 <enabled/disabled> ]
+        [ handle_redirects { enabled | disabled } ]
+        [ http_support { enabled | disabled } ]
+        [ ipv6 { enabled | disabled } ]
         [ min_control_TLS_version <control_tls_version>]
         [ min_data_TLS_version <data_tls_version> ]
         [ min_sentinel_TLS_version <sentinel_tls_version> ]
         [ s3_url <url> ]
         [ saslauthd_ldap_conf </tmp/ldap.conf> ]
-        [ sentinel_ssl_policy <allowed/required/disabled> ]
-        [ data_cipher_list <openSSL_cipher_list> ]
-        [ sentinel_cipher_suites <golang_cipher_list>]
-        [ services <cm_server | crdb_coordinator | crdb_worker | mdns_server | pdns_server | saslauthd | stats_archiver> <enabled | disabled> ]
-        [ upgrade_mode < enabled | disabled> ]
+        [ sentinel_ssl_policy { allowed | required | disabled} ]
+        [ sentinel_cipher_suites <golang cipher list>]
+        [ services { cm_server | crdb_coordinator | crdb_worker | mdns_server | pdns_server | saslauthd | stats_archiver } { enabled | disabled } ]
+        [ upgrade_mode { enabled | disabled } ]
 ```
 
 ### Parameters
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| param1 | Description |
-| param2 | Description |
+| cipher_suites | | Cipher suites used for TLS connections to the admin console; specified in the format understood by the BoringSSL library |
+| cm_port | | UI server listening port |
+| cm_session_timeout | | Timeout (in minutes) for the CM session
+| cmn_http_port | | HTTP REST API server listening port |
+| cnm_https_port | | HTTPS REST API server listening port |
+| data_cipher_list | | Cipher suites used by the the data plane; specified in the format understood by the OpenSSL library |
+| debuginfo_path | | Path to local directory to place file when generating support packages |
+| handle_redirects | | Enable or disable handling DNS redirects when DNS is not configured and running behind a load balancer |
+| http_support | | Enable or disable using HTTP for REST API connections (info cluster) |
+| ipv6 | | Enable or disable IPv6 connections to the RS admin console |
+| min_control_TLS_version | | The minimum version of TLS protocol which is supported at the control path |
+| min_data_TLS_version | | The minimum version of TLS protocol which is supported at the data path |
+| min_sentinel_TLS_version | | |
+| s3_url | | The URL of S3 export and import |
+| saslauthd_ldap_conf | | Updates LDAP authentication configuration for the cluster (see Cluster-based LDAP Authentication or Kubernetes LDAP configuration) |
+| sentinel_cipher_suites | | Cipher suites used by the sentinel service (supported ciphers are implemented by the golang.org cipher suites package) |
+| sentinel_ssl_policy | | Define SSL policy for the Discovery Service: required/disabled/allowed |
+| services | 'cm_server'<br />'crdb_coordinator'<br />'crdb_worker'<br />'mdns_server'<br />'pdns_server'<br />'saslauthd'<br />'stats_archiver'<br /><br />'enabled'<br />'disabled' | |
+| upgrade_mode | | |
+
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -5,6 +5,7 @@ description: Updates the cluster's configuration.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster config
 linkTitle: config
-description: Command description.
+description: Updates the cluster's configuration.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,12 +9,36 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster config` updates the cluster configuration.
+
+```sh
+ rladmin cluster config 
+        [ cipher_suites <BoringSSL_cipher_list> ]
+        [ cm_port <number> ]
+        [ cm_session_timeout <minutes> ]
+        [ cnm_http_port <number> ]
+        [ cnm_https_port <number>]
+        [ data_cipher_list <data-cipher-suites-str> ]
+        [ debuginfo_path <path/to/directory> ]
+        [ handle_redirects <enabled/disabled>]
+        [ http_support <enabled/disabled>]
+        [ ipv6 <enabled/disabled> ]
+        [ min_control_TLS_version <control_tls_version>]
+        [ min_data_TLS_version <data_tls_version> ]
+        [ min_sentinel_TLS_version <sentinel_tls_version> ]
+        [ s3_url <url> ]
+        [ saslauthd_ldap_conf </tmp/ldap.conf> ]
+        [ sentinel_ssl_policy <allowed/required/disabled> ]
+        [ data_cipher_list <openSSL_cipher_list> ]
+        [ sentinel_cipher_suites <golang_cipher_list>]
+        [ services <cm_server | crdb_coordinator | crdb_worker | mdns_server | pdns_server | saslauthd | stats_archiver> <enabled | disabled> ]
+        [ upgrade_mode < enabled | disabled> ]
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
 | param1 | Description |
 | param2 | Description |
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -26,7 +26,7 @@ aliases:
         [ min_control_TLS_version <control_tls_version>]
         [ min_data_TLS_version <data_tls_version> ]
         [ min_sentinel_TLS_version <sentinel_tls_version> ]
-        [ s3_url <url> ]
+        [ s3_url <URL> ]
         [ saslauthd_ldap_conf </tmp/ldap.conf> ]
         [ sentinel_ssl_policy { allowed | required | disabled} ]
         [ sentinel_cipher_suites <golang cipher list>]
@@ -39,24 +39,24 @@ aliases:
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
 | cipher_suites | | Cipher suites used for TLS connections to the admin console; specified in the format understood by the BoringSSL library |
-| cm_port | | UI server listening port |
-| cm_session_timeout | | Timeout (in minutes) for the CM session
-| cmn_http_port | | HTTP REST API server listening port |
-| cnm_https_port | | HTTPS REST API server listening port |
+| cm_port | integer | UI server listening port |
+| cm_session_timeout | integer | Timeout in minutes for the CM session
+| cmn_http_port | integer | HTTP REST API server listening port |
+| cnm_https_port | integer | HTTPS REST API server listening port |
 | data_cipher_list | | Cipher suites used by the the data plane; specified in the format understood by the OpenSSL library |
 | debuginfo_path | | Path to local directory to place file when generating support packages |
-| handle_redirects | | Enable or disable handling DNS redirects when DNS is not configured and running behind a load balancer |
-| http_support | | Enable or disable using HTTP for REST API connections (info cluster) |
-| ipv6 | | Enable or disable IPv6 connections to the RS admin console |
+| handle_redirects | 'enabled'<br />'disabled' | Enable or disable handling DNS redirects when DNS is not configured and running behind a load balancer |
+| http_support | 'enabled'<br />'disabled' | Enable or disable using HTTP for REST API connections (info cluster) |
+| ipv6 | 'enabled'<br />'disabled' | Enable or disable IPv6 connections to the RS admin console |
 | min_control_TLS_version | | The minimum version of TLS protocol which is supported at the control path |
 | min_data_TLS_version | | The minimum version of TLS protocol which is supported at the data path |
 | min_sentinel_TLS_version | | |
 | s3_url | | The URL of S3 export and import |
 | saslauthd_ldap_conf | | Updates LDAP authentication configuration for the cluster (see Cluster-based LDAP Authentication or Kubernetes LDAP configuration) |
 | sentinel_cipher_suites | | Cipher suites used by the sentinel service (supported ciphers are implemented by the golang.org cipher suites package) |
-| sentinel_ssl_policy | | Define SSL policy for the Discovery Service: required/disabled/allowed |
+| sentinel_ssl_policy | 'allowed'<br />'required'<br />'disabled' | Define SSL policy for the Discovery Service: required/disabled/allowed |
 | services | 'cm_server'<br />'crdb_coordinator'<br />'crdb_worker'<br />'mdns_server'<br />'pdns_server'<br />'saslauthd'<br />'stats_archiver'<br /><br />'enabled'<br />'disabled' | |
-| upgrade_mode | | |
+| upgrade_mode | 'enabled'<br />'disabled' | |
 
 
 ### Returns

--- a/content/rs/references/cli-utilities/rladmin/cluster/create.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/create.md
@@ -5,6 +5,7 @@ description: Creates a new cluster.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["non-configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/create.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/create.md
@@ -52,9 +52,13 @@ cluster create
 
 ### Returns
 
+Returns `ok` if the new cluster was created successfully. Otherwise, it returns an error message.
+
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster create name cluster.local \
+        username admin@example.com \
+        password admin-password
+Creating a new cluster... ok
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/create.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/create.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster create` creates a new cluster. The node from which the command is executed becomes the first node of the new cluster.
+Creates a new cluster. The node from which the command is executed becomes the first node of the new cluster.
 
 ```sh
 cluster create 
@@ -34,18 +34,21 @@ cluster create
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| addr | IP address | Internal IP addresses of the node |
-| ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to location of CCS snapshots |
-| ephemeral_path | filepath | Path to ephemeral storage location (defaults to /var/opt/redislabs) |
-| external_addr | IP address | External IP addresses of the node |
-| flash_enabled | | Enables flash storage |
-| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to flash storage location |
-| license_file | | Path to RLEC license file |
-| node_uid | | Unique node ID |
-| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to persistent storage location |
-| rack_aware | | Enables/disables rack awareness |
-| rack_id | | Rack ID of the rack |
-| register_dns_suffix | | Enables database mapping to both internal and external IP |
+| addr | IP address | Internal IP addresses of the node (optional) |
+| ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to location of CCS snapshots (optional) |
+| ephemeral_path | filepath | Path to ephemeral storage location (defaults to /var/opt/redislabs) (optional) |
+| external_addr | IP address | External IP addresses of the node (optional) |
+| flash_enabled | | Enables flash storage (optional) |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to flash storage location (optional) |
+| license_file | filepath | Path to RLEC license file (optional) |
+| name | string | Cluster name |
+| node_uid | integer | Unique node ID (optional) |
+| password | string | Admin user's password |
+| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to persistent storage location (optional) |
+| rack_aware | | Activates or deactivates rack awareness (optional) |
+| rack_id | string | Rack ID of the rack (optional) |
+| register_dns_suffix | | Enables database mapping to both internal and external IP (optional) |
+| username | email address | Admin user's email address |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/create.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/create.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster create
 linkTitle: create
-description: Command description.
+description: Creates a new cluster.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,12 +9,31 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster create` creates a new cluster. The node from which the command is executed becomes the first node of the new cluster.
+
+```sh
+cluster create 
+        name <cluster-name>
+        username <admin-email> 
+        password <admin-password> 
+        [ node_uid <node-uid> ] 
+        [ rack_aware ] 
+        [ rack_id <node-rack-id> ] 
+        [ license_file <file> ] 
+        [ ephemeral_path <path> ] 
+        [ persistent_path <path> ]
+        [ ccs_persistent_path <path> ] 
+        [ register_dns_suffix ] 
+        [ flash_enabled ] 
+        [ flash_path <path> ] 
+        [ addr <ip-address> ] 
+        [ external_addr <ip-addresses> ]
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
 | param1 | Description |
 | param2 | Description |
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/create.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/create.md
@@ -5,6 +5,7 @@ description: Creates a new cluster.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["non-configured"]
 categories: ["RS"]
 aliases: 
@@ -35,20 +36,20 @@ cluster create
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| addr | IP address | Internal IP addresses of the node (optional) |
-| ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to location of CCS snapshots (optional) |
-| ephemeral_path | filepath | Path to ephemeral storage location (defaults to /var/opt/redislabs) (optional) |
-| external_addr | IP address | External IP addresses of the node (optional) |
+| addr | IP address | The node's internal IP address (optional) |
+| ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to the location of CCS snapshots (optional) |
+| ephemeral_path | filepath (default:&nbsp;/var/opt/redislabs) | Path to the ephemeral storage location (optional) |
+| external_addr | IP address | The node's external IP address (optional) |
 | flash_enabled | | Enables flash storage (optional) |
-| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to flash storage location (optional) |
-| license_file | filepath | Path to RLEC license file (optional) |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to the flash storage location (optional) |
+| license_file | filepath | Path to the RLEC license file (optional) |
 | name | string | Cluster name |
 | node_uid | integer | Unique node ID (optional) |
 | password | string | Admin user's password |
-| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to persistent storage location (optional) |
+| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to the persistent storage location (optional) |
 | rack_aware | | Activates or deactivates rack awareness (optional) |
-| rack_id | string | Rack ID of the rack (optional) |
-| register_dns_suffix | | Enables database mapping to both internal and external IP (optional) |
+| rack_id | string | The rack's unique identifier (optional) |
+| register_dns_suffix | | Enables database mapping to both internal and external IP addresses (optional) |
 | username | email address | Admin user's email address |
 
 ### Returns

--- a/content/rs/references/cli-utilities/rladmin/cluster/create.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/create.md
@@ -13,12 +13,12 @@ aliases:
 
 ```sh
 cluster create 
-        name <cluster-name>
-        username <admin-email> 
-        password <admin-password> 
-        [ node_uid <node-uid> ] 
+        name <cluster name>
+        username <admin email> 
+        password <admin password> 
+        [ node_uid <node UID> ] 
         [ rack_aware ] 
-        [ rack_id <node-rack-id> ] 
+        [ rack_id <node rack ID> ] 
         [ license_file <file> ] 
         [ ephemeral_path <path> ] 
         [ persistent_path <path> ]
@@ -26,16 +26,26 @@ cluster create
         [ register_dns_suffix ] 
         [ flash_enabled ] 
         [ flash_path <path> ] 
-        [ addr <ip-address> ] 
-        [ external_addr <ip-addresses> ]
+        [ addr <IP address> ] 
+        [ external_addr <IP address> ]
 ```
 
 ### Parameters
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| param1 | Description |
-| param2 | Description |
+| addr | IP address | Internal IP addresses of the node |
+| ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to location of CCS snapshots |
+| ephemeral_path | filepath | Path to ephemeral storage location (defaults to /var/opt/redislabs) |
+| external_addr | IP address | External IP addresses of the node |
+| flash_enabled | | Enables flash storage |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to flash storage location |
+| license_file | | Path to RLEC license file |
+| node_uid | | Unique node ID |
+| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to persistent storage location |
+| rack_aware | | Enables/disables rack awareness |
+| rack_id | | Rack ID of the rack |
+| register_dns_suffix | | Enables database mapping to both internal and external IP |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
@@ -5,6 +5,7 @@ description: Creates a support package.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["configured"]
 categories: ["RS"]
 aliases: 

--- a/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
@@ -5,6 +5,7 @@ description: Creates a support package.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
@@ -9,17 +9,22 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster debug_info` downloads a support package to the specified path. If you do not specify a path, it downloads the package to the default path specified in the cluster configuration file.
+Downloads a support package to the specified path. If you do not specify a path, it downloads the package to the default path specified in the cluster configuration file.
 
 ```sh
-rladmin cluster debug_info [ path <path> ]
+rladmin cluster debug_info
+        [ node <ID> ]
+        [ path <path> ]
+        [ sanitized ]
 ```
 
 ### Parameters
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
+| node | integer | Downloads a support package for the specified node |
 | path | filepath | Specifies the location where the support package should download |
+| sanitized | | Removes sensitive data (passwords, certificates, etc.) from the support package |
 
 ### Returns
 
@@ -28,6 +33,9 @@ Reports the progress of the support package download.
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster debug_info node 1 sanitized
+Preparing the debug info files package
+Downloading...
+[==================================================]
+Downloading complete. File /tmp/debuginfo.20220511-215637.node-1.tar.gz is saved.
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/debug_info.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster debug_info
 linkTitle: debug_info
-description: Command description.
+description: Creates a support package.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,16 +9,21 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster debug_info` downloads a support package to the specified path. If you do not specify a path, it downloads the package to the default path specified in the cluster configuration file.
+
+```sh
+rladmin cluster debug_info [ path <path> ]
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| param1 | Description |
-| param2 | Description |
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
+| path | filepath | Specifies the location where the support package should download |
 
 ### Returns
+
+Reports the progress of the support package download.
 
 ### Example
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -5,6 +5,7 @@ description: Adds a node to an existing cluster.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["non-configured"]
 categories: ["RS"]
 aliases: 
@@ -37,20 +38,20 @@ rladmin cluster join
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
 | accept_servers | 'enabled'<br />'disabled' | Allows allocation of resources on the new node when enabled (optional) |
-| addr | IP address | Sets a node's internal address. If not provided, the node sets the address automatically. (optional) |
+| addr | IP address | Sets a node's internal IP address. If not provided, the node sets the address automatically. (optional) |
 | ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to the CCS snapshot location (the default is the same as persistent_path) (optional) |
 | cmn_http_port | integer | Joins a cluster that has a non-default cnm_http_port (optional) |
-| ephemeral_path | filepath | Path to an ephemeral storage location (optional) |
-| external_addr | IP address | Sets a node's external address. If not provided, the node sets the address automatically. (optional) |
+| ephemeral_path | filepath | Path to the ephemeral storage location (optional) |
+| external_addr | IP address | Sets a node's external IP address. If not provided, the node sets the address automatically. (optional) |
 | flash_enabled |  | Enables flash capabilities for a database (optional) |
-| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to a flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to the flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
 | name | string | Name of the cluster to join |
 | nodes | IP address | Internal IP address of an existing node in the cluster |
 | override_rack_id |  | Changes to a new rack, specified by `rack_id` (optional) |
 | override_repair |  | Enables joining a cluster with a dead node (optional) |
 | password | string | Admin user's password |
-| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to a persistent storage location (optional) |
-| rack_id | string | Switches to this rack ID (optional) |
+| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to the persistent storage location (optional) |
+| rack_id | string | Moves the node to the specified rack (optional) |
 | replace_node | integer | Replaces the specified node with the new node (optional) |
 | username | email address | Admin user's email address |
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -5,6 +5,7 @@ description: Adds a node to an existing cluster.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["non-configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -55,9 +55,13 @@ rladmin cluster join
 
 ### Returns
 
+Returns `ok` if the node joined the cluster successfully. Otherwise, it returns an error message.
+
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster join name cluster.local \
+        username admin@example.com \
+        password admin-password
+Joining cluster... ok
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster join
 linkTitle: join
-description: Command description.
+description: Adds a node to an existing cluster.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,12 +9,32 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster join` adds a node to an existing cluster.
+
+```sh
+rladmin cluster join 
+        name <cluster-name> | nodes <node-address> 
+        username <admin-user> 
+        password <admin-password>
+        [ ephemeral_path <path> ]
+        [ persistent_path <path> ]
+        [ ccs_persistent_path <path> ]
+        [ rack_id <node-rack-id> ]
+        [ override_rack_id ]
+        [ replace_node <node-uid> ]
+        [ flash_enabled ]
+        [ flash_path <path> ]
+        [ addr <ip-address> ]
+        [ external_addr <ip-addresses> ]
+        [ override_repair ]
+        [ accept_servers <enable | disable> ]
+        [ cmn_http_port <port> ]
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
 | param1 | Description |
 | param2 | Description |
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -13,21 +13,21 @@ aliases:
 
 ```sh
 rladmin cluster join 
-        name <cluster-name> | nodes <node-address> 
-        username <admin-user> 
-        password <admin-password>
+        { name <cluster name> | nodes <node address> } 
+        username <admin user> 
+        password <admin password>
         [ ephemeral_path <path> ]
         [ persistent_path <path> ]
         [ ccs_persistent_path <path> ]
-        [ rack_id <node-rack-id> ]
+        [ rack_id <node rack ID> ]
         [ override_rack_id ]
-        [ replace_node <node-uid> ]
+        [ replace_node <node UID> ]
         [ flash_enabled ]
         [ flash_path <path> ]
-        [ addr <ip-address> ]
-        [ external_addr <ip-addresses> ]
+        [ addr <IP address> ]
+        [ external_addr <IP address> ]
         [ override_repair ]
-        [ accept_servers <enable | disable> ]
+        [ accept_servers { enabled | disabled } ]
         [ cmn_http_port <port> ]
 ```
 
@@ -35,8 +35,23 @@ rladmin cluster join
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| param1 | Description |
-| param2 | Description |
+| accept_servers | 'enabled'<br />'disabled' | Allows allocation of resources on the new node when enabled (optional) |
+| addr | IP address | Sets a node's internal address. If not provided, the node sets the address automatically. (optional) |
+| ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to the CCS snapshot location (the default is the same as persistent_path) (optional) |
+| cmn_http_port | integer | Joins a cluster that has a non-default cnm_http_port (optional) |
+| ephemeral_path | filepath | Path to an ephemeral storage location (optional) |
+| external_addr | IP address | Sets a node's external address. If not provided, the node sets the address automatically. (optional) |
+| flash_enabled |  | Enables flash capabilities for a database (optional) |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to a flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
+| name | string | Name of the cluster to join |
+| nodes |  | Internal IP address of an existing node in the cluster |
+| override_rack_id |  | Changes to a new rack, specified by `rack_id` (optional) |
+| override_repair |  | Enables joining a cluster with a dead node (optional) |
+| password |  | Admin user's password |
+| persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to a persistent storage location (optional) |
+| rack_id |  | Switches to this rack ID (optional) |
+| replace_node |  | Replaces the specified node with the new node (optional) |
+| username | email address | Admin user's email address |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster join` adds a node to an existing cluster.
+Adds a node to an existing cluster.
 
 ```sh
 rladmin cluster join 
@@ -44,13 +44,13 @@ rladmin cluster join
 | flash_enabled |  | Enables flash capabilities for a database (optional) |
 | flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to a flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
 | name | string | Name of the cluster to join |
-| nodes |  | Internal IP address of an existing node in the cluster |
+| nodes | IP address | Internal IP address of an existing node in the cluster |
 | override_rack_id |  | Changes to a new rack, specified by `rack_id` (optional) |
 | override_repair |  | Enables joining a cluster with a dead node (optional) |
-| password |  | Admin user's password |
+| password | string | Admin user's password |
 | persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to a persistent storage location (optional) |
-| rack_id |  | Switches to this rack ID (optional) |
-| replace_node |  | Replaces the specified node with the new node (optional) |
+| rack_id | string | Switches to this rack ID (optional) |
+| replace_node | integer | Replaces the specified node with the new node (optional) |
 | username | email address | Admin user's email address |
 
 ### Returns

--- a/content/rs/references/cli-utilities/rladmin/cluster/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/recover.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster recover` recovers a cluster from a backup file. The default location of the configuration backup file is `/var/opt/redislabs/persist/ccs/ccs-redis.rdb`.
+Recovers a cluster from a backup file. The default location of the configuration backup file is `/var/opt/redislabs/persist/ccs/ccs-redis.rdb`.
 
 ```sh
 rladmin cluster recover 
@@ -33,14 +33,14 @@ rladmin cluster recover
 | addr | IP address | Sets a node's internal address. If not provided, the node sets the address automatically. (optional) |
 | ccs_persistent_path | filepath | Path to the location of CCS snapshots (default is the same as persistent_path) (optional) |
 | external_addr | IP address | Sets a node's external address. If not provided, the node sets the address automatically. (optional) |
-| ephemeral_path | filepath (default:&nbsp;/var/opt/redislabs) | Path to an ephemeral storage location |
-| filename | | Backup file to use for recovery |
+| ephemeral_path | filepath (default:&nbsp;/var/opt/redislabs) | Path to an ephemeral storage location (optional) |
+| filename | filepath | Backup file to use for recovery |
 | flash_enabled | | Enables flash storage (optional) |
 | flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to a flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
 | node_uid | integer (default:&nbsp;1) | Specifies which node will recover first and become master (optional) |
 | override_rack_id | | Changes to a new rack, specified by `rack_id` (optional) |
 | persistent_path | filepath | Path to a persistent storage location (optional) |
-| rack_id |  | Switches to this rack ID (optional) |
+| rack_id | string | Switches to this rack ID (optional) |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/recover.md
@@ -5,6 +5,7 @@ description: Recovers a cluster from a backup file.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["non-configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/recover.md
@@ -44,9 +44,11 @@ rladmin cluster recover
 
 ### Returns
 
+Returns `ok` if the cluster recovered successfully. Otherwise, it returns an error message.
+
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster recover filename /tmp/persist/ccs/ccs-redis.rdb node_uid 1 rack_id 5
+Initiating cluster recovery... ok
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/recover.md
@@ -9,11 +9,11 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster recover` recovers a cluster from a backup file. Configuration backup file’s default location is `/var/opt/redislabs/persist/ccs/ccs-redis.rdb`.
+`rladmin cluster recover` recovers a cluster from a backup file. The default location of the configuration backup file is `/var/opt/redislabs/persist/ccs/ccs-redis.rdb`.
 
 ```sh
 rladmin cluster recover 
-        filename <recovery-file-name> 
+        filename <recovery filename> 
         [ ephemeral_path <path> ] 
         [ persistent_path <path> ]
         [ ccs_persistent_path <path> ]
@@ -22,25 +22,25 @@ rladmin cluster recover
         [ node_uid <number> ] 
         [ flash_enabled ] 
         [ flash_path <path> ] 
-        [ addr <ip-address> ] 
-        [ external_addr <ip-addresses> ]
+        [ addr <IP address> ] 
+        [ external_addr <IP address> ]
 ```
 
 ### Parameters
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| filename | | Backup file to use for recovery |
-| ephemeral_path | filepath | Description |
-| persistent_path | filepath | Specifies a path for persistent storage (optional) |
-| ccs_persistent_path | filepath | Specifies the path where the CCS snapshots will be saved (optional) |
-| rack_id |  | Switches to this rack ID (optional) |
-| override_rack_id | | Changes to a new rack, specified by `rack_id` (optional) |
-| node_uid | integer (Default:&nbsp;1) | Specifies which node will recover first and become master (optional) |
-| flash_enabled | | Enables flash storage in a supporting node |
-| flash_path | | Specifies a path for flash storage |
 | addr | IP address | Sets a node's internal address. If not provided, the node sets the address automatically. (optional) |
+| ccs_persistent_path | filepath | Path to the location of CCS snapshots (default is the same as persistent_path) (optional) |
 | external_addr | IP address | Sets a node's external address. If not provided, the node sets the address automatically. (optional) |
+| ephemeral_path | filepath (default:&nbsp;/var/opt/redislabs) | Path to an ephemeral storage location |
+| filename | | Backup file to use for recovery |
+| flash_enabled | | Enables flash storage (optional) |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to a flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
+| node_uid | integer (default:&nbsp;1) | Specifies which node will recover first and become master (optional) |
+| override_rack_id | | Changes to a new rack, specified by `rack_id` (optional) |
+| persistent_path | filepath | Path to a persistent storage location (optional) |
+| rack_id |  | Switches to this rack ID (optional) |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/recover.md
@@ -5,6 +5,7 @@ description: Recovers a cluster from a backup file.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["non-configured"]
 categories: ["RS"]
 aliases: 
@@ -31,17 +32,17 @@ rladmin cluster recover
 
 | Parameter | Type/Value | Description |
 |-----------|------------|-------------|
-| addr | IP address | Sets a node's internal address. If not provided, the node sets the address automatically. (optional) |
+| addr | IP address | Sets a node's internal IP address. If not provided, the node sets the address automatically. (optional) |
 | ccs_persistent_path | filepath | Path to the location of CCS snapshots (default is the same as persistent_path) (optional) |
-| external_addr | IP address | Sets a node's external address. If not provided, the node sets the address automatically. (optional) |
+| external_addr | IP address | Sets a node's external IP address. If not provided, the node sets the address automatically. (optional) |
 | ephemeral_path | filepath (default:&nbsp;/var/opt/redislabs) | Path to an ephemeral storage location (optional) |
 | filename | filepath | Backup file to use for recovery |
 | flash_enabled | | Enables flash storage (optional) |
-| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to a flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
+| flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to the flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
 | node_uid | integer (default:&nbsp;1) | Specifies which node will recover first and become master (optional) |
 | override_rack_id | | Changes to a new rack, specified by `rack_id` (optional) |
-| persistent_path | filepath | Path to a persistent storage location (optional) |
-| rack_id | string | Switches to this rack ID (optional) |
+| persistent_path | filepath | Path to the persistent storage location (optional) |
+| rack_id | string | Switches to the specified rack (optional) |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/recover.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster recover
 linkTitle: recover
-description: Command description.
+description: Recovers a cluster from a backup file.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,14 +9,38 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster recover` recovers a cluster from a backup file. Configuration backup file’s default location is `/var/opt/redislabs/persist/ccs/ccs-redis.rdb`.
+
+```sh
+rladmin cluster recover 
+        filename <recovery-file-name> 
+        [ ephemeral_path <path> ] 
+        [ persistent_path <path> ]
+        [ ccs_persistent_path <path> ]
+        [ rack_id <ID> ] 
+        [ override_rack_id ] 
+        [ node_uid <number> ] 
+        [ flash_enabled ] 
+        [ flash_path <path> ] 
+        [ addr <ip-address> ] 
+        [ external_addr <ip-addresses> ]
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| param1 | Description |
-| param2 | Description |
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
+| filename | | Backup file to use for recovery |
+| ephemeral_path | filepath | Description |
+| persistent_path | filepath | Specifies a path for persistent storage (optional) |
+| ccs_persistent_path | filepath | Specifies the path where the CCS snapshots will be saved (optional) |
+| rack_id |  | Switches to this rack ID (optional) |
+| override_rack_id | | Changes to a new rack, specified by `rack_id` (optional) |
+| node_uid | integer (Default:&nbsp;1) | Specifies which node will recover first and become master (optional) |
+| flash_enabled | | Enables flash storage in a supporting node |
+| flash_path | | Specifies a path for flash storage |
+| addr | IP address | Sets a node's internal address. If not provided, the node sets the address automatically. (optional) |
+| external_addr | IP address | Sets a node's external address. If not provided, the node sets the address automatically. (optional) |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
@@ -5,6 +5,7 @@ description: Changes the password for a given email.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["configured"]
 categories: ["RS"]
 aliases: 

--- a/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
@@ -5,6 +5,7 @@ description: Changes the password for a given email.
 weight: $weight
 alwaysopen: false
 toc: "true"
+tags: ["configured"]
 categories: ["RS"]
 aliases: 
 ---

--- a/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
@@ -9,7 +9,7 @@ categories: ["RS"]
 aliases: 
 ---
 
-`rladmin cluster reset_password` changes the password for the user associated with the specified email address.
+Changes the password for the user associated with the specified email address.
 
 Enter a new password when prompted. Then enter the same password when prompted a second time to confirm the password change.
 
@@ -30,6 +30,8 @@ Reports whether the password change succeeded or an error occurred.
 ### Example
 
 ```sh
-$ rladmin command x
-response
+$ rladmin cluster reset_password user@example.com
+New password: 
+New password (again): 
+Password changed.
 ```

--- a/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/reset_password.md
@@ -1,7 +1,7 @@
 ---
 Title: rladmin cluster reset_password
 linkTitle: reset_password
-description: Command description.
+description: Changes the password for a given email.
 weight: $weight
 alwaysopen: false
 toc: "true"
@@ -9,16 +9,23 @@ categories: ["RS"]
 aliases: 
 ---
 
-Command description.
+`rladmin cluster reset_password` changes the password for the user associated with the specified email address.
+
+Enter a new password when prompted. Then enter the same password when prompted a second time to confirm the password change.
+
+```sh
+rladmin cluster reset_password <user email>
+```
 
 ### Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| param1 | Description |
-| param2 | Description |
+| Parameter | Type/Value | Description |
+|-----------|------------|-------------|
+| user email | email address | The email address of the user that needs a password reset |
 
 ### Returns
+
+Reports whether the password change succeeded or an error occurred. 
 
 ### Example
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/running_actions.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/running_actions.md
@@ -5,6 +5,7 @@ description: Lists all active tasks.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["configured"]
 categories: ["RS"]
 aliases: 

--- a/content/rs/references/cli-utilities/rladmin/cluster/running_actions.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/running_actions.md
@@ -1,0 +1,33 @@
+---
+Title: rladmin cluster running_actions
+linkTitle: running_actions
+description: Lists all active tasks.
+weight: $weight
+alwaysopen: false
+toc: "true"
+tags: ["configured"]
+categories: ["RS"]
+aliases: 
+---
+
+Lists all active tasks running on the cluster.
+
+```sh
+rladmin cluster running_actions
+```
+
+### Parameters
+
+None
+
+### Returns
+
+Returns details about any active tasks running on the cluster. 
+
+### Example
+
+```sh
+$ rladmin cluster running_actions
+Got 1 tasks:
+1) Task: maintenance_on (ce391d81-8d51-4ce2-8f63-729c7ac2589e) Node: 1 Status: running
+```

--- a/content/rs/references/cli-utilities/rladmin/cluster/stats_archiver.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/stats_archiver.md
@@ -1,0 +1,35 @@
+---
+Title: rladmin cluster stats_archiver
+linkTitle: stats_archiver
+description: Enables/deactivates the stats archiver.
+weight: $weight
+alwaysopen: false
+toc: "true"
+tags: ["configured"]
+categories: ["RS"]
+aliases: 
+---
+
+Enables or deactivates the stats archiver, which logs statistics in CSV (comma-separated values) format.
+
+```sh
+rladmin cluster stats_archiver { enabled | disabled }
+```
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| enabled | Turn on the stats archiver |
+| disabled | Turn off the stats archiver |
+
+### Returns
+
+Returns the updated status of the stats archiver. 
+
+### Example
+
+```sh
+$ rladmin cluster stats_archiver enabled 
+Status: enabled
+```

--- a/content/rs/references/cli-utilities/rladmin/cluster/stats_archiver.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/stats_archiver.md
@@ -5,6 +5,7 @@ description: Enables/deactivates the stats archiver.
 weight: $weight
 alwaysopen: false
 toc: "true"
+headerRange: "[1-2]"
 tags: ["configured"]
 categories: ["RS"]
 aliases: 

--- a/layouts/shortcodes/table-children.html
+++ b/layouts/shortcodes/table-children.html
@@ -4,6 +4,7 @@
 {{ $columnSources := split $columnSourcesStr "," }}
 {{ $enableLinksStr :=  .Get "enableLinks" }}
 {{ $enableLinks := split $enableLinksStr "," }}
+{{ $limitTags := .Get "limitTags" }}
 {{ $children := .Page.Pages }}
 
 <table>
@@ -17,6 +18,18 @@
 
     <tbody>
         {{ range $i, $child := $children }}
+
+        {{ $addRow := true }}
+        {{ if $limitTags }}
+            {{ $childTags := $child.Param "tags" }}
+            {{ if in $childTags $limitTags }}
+                {{ $addRow = true }}
+            {{ else }}
+                {{ $addRow = false }}
+            {{ end }}
+        {{ end }}
+
+        {{ if $addRow }}
         <tr>
             {{ range $j, $cSource := $columnSources }}
                     {{ if in $enableLinks $cSource }}
@@ -26,6 +39,7 @@
                     {{ end }}
             {{ end }}
         </tr>
+        {{ end }}
         {{ end }}
     </tbody>
 </table>


### PR DESCRIPTION
[Staged preview](https://docs.redis.com/staging/jira-doc-1316/rs/references/cli-utilities/rladmin/cluster/)

This PR also includes an update to the `table-children` shortcode. This change allows you to limit which child pages appear in a generated table.

For example, I added either `tags: ["configured"]` or `tags: ["non-configured"]` to the front matter of each `rladmin cluster` command page.

To generate a table that only includes commands that are tagged as "configured," I used this shortcode on the `rladmin cluster` index page and set the new optional field `limitTags` to "configured":

```sh
{{<table-children columnNames="Command,Description" columnSources="linkTitle,Description" enableLinks="linkTitle" limitTags="configured">}}
```