### PR TITLE
DOC-1327: RS CLI Utilities - rladmin recover page

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/recover.md
@@ -1,0 +1,123 @@
+---
+Title: rladmin recover
+linkTitle: recover
+description: Recovers databases in recovery mode.
+weight: $weight
+alwaysopen: false
+toc: "true"
+headerRange: "[1-2]"
+categories: ["RS"]
+aliases:
+---
+
+`rladmin recover` recovers databases in recovery mode.
+
+## `recover all`
+
+Recovers all databases in recovery mode.
+
+```sh
+$ rladmin recover all
+            [ only_configuration ]
+```
+
+### Parameters
+
+| Parameters         | Type/Value | Description                                 |
+|--------------------|------------|---------------------------------------------|
+| only_configuration |            | Recover database configuration without data |
+
+### Returns
+
+Returns `Completed successfully` if the database was recovered. Otherwise, returns an error.
+
+### Example
+
+```sh
+
+```
+
+## `recover db`
+
+Recovers a specific database in recovery mode.
+
+```sh
+$ rladmin recover db { db<id> | <name> }
+                     [ only_configuration ]
+```
+
+### Parameters
+
+| Parameters         | Type/Value           | Description                                 |
+|--------------------|----------------------|---------------------------------------------|
+| db                 | db:\<id\> <br />name | Database to recover                         |
+| only_configuration |                      | Recover database configuration without data |
+
+### Returns
+
+Returns `Completed successfully` if the database was recovered. Otherwise, returns an error.
+
+### Example
+
+```sh
+
+```
+
+## `recover list`
+
+Shows a list of all databases that are currently in recovery mode.
+
+```sh
+$ rladmin list
+```
+
+### Parameters
+
+None.
+
+### Returns
+
+Displays a list of all recoverable databases. If no databases are in reovery mode, prints `No recoverable databases found`.
+
+### Example
+
+```sh
+$ rladmin recover list
+DATABASES IN RECOVERY STATE:
+DB:ID  NAME  TYPE   SHARDS  REPLICATION  PERSISTENCE  STATUS
+db:5   tr01  redis  1       enabled      aof          missing-files
+db:6   tr02  redis  4       enabled      snapshot     ready
+```
+
+## `recover s3_import`
+
+Imports all current database snapshot files from an AWS S3 bucket to a directory on the node.
+
+```sh
+$ rladmin recover s3_import
+                  s3_bucket <bucket_name>
+                  [ s3_prefix <prefix> ]
+                  s3_access_key_id <access_key>
+                  s3_secret_access_key <secret_access_key>
+                  local_path <path>
+```
+
+### Parameters
+
+| Parameters           | Type/Value | Description                                                      |
+|----------------------|------------|------------------------------------------------------------------|
+| s3_bucket            | string     | S3 Bucket name                                                   |
+| s3_prefix            | string     | S3 Prefix in the bucket                                          |
+| s3_access_key_id     | string     | S3 Access key ID                                                 |
+| s3_secret_access_key | string     | S3 secret access key                                             |
+| s3_secret_access_key | filepath   | Local import path - all database snapshots will be imported here |
+
+### Returns
+
+Returns `Completed successfully` if the database files were imported. Otherwise, returns an error.
+
+### Example
+
+```sh
+
+```

--- a/content/rs/references/cli-utilities/rladmin/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/recover.md
@@ -31,13 +31,6 @@ $ rladmin recover all
 
 Returns `Completed successfully` if the database was recovered. Otherwise, returns an error.
 
-### Example
-
-```sh
-$ rladmin recover all
-Completed successfully
-```
-
 ## `recover db`
 
 Recovers a specific database in recovery mode.
@@ -57,13 +50,6 @@ $ rladmin recover db { db<id> | <name> }
 ### Returns
 
 Returns `Completed successfully` if the database was recovered. Otherwise, returns an error.
-
-### Example
-
-```sh
-$ rladmin recover db db:5
-Completed successfully
-```
 
 ## `recover list`
 
@@ -89,37 +75,4 @@ DATABASES IN RECOVERY STATE:
 DB:ID  NAME  TYPE   SHARDS  REPLICATION  PERSISTENCE  STATUS
 db:5   tr01  redis  1       enabled      aof          missing-files
 db:6   tr02  redis  4       enabled      snapshot     ready
-```
-
-## `recover s3_import`
-
-Imports all current database snapshot files from an AWS S3 bucket to a directory on the node.
-
-```sh
-$ rladmin recover s3_import
-                  s3_bucket <bucket_name>
-                  [ s3_prefix <prefix> ]
-                  s3_access_key_id <access_key>
-                  s3_secret_access_key <secret_access_key>
-                  local_path <path>
-```
-
-### Parameters
-
-| Parameters           | Type/Value | Description                                                      |
-|----------------------|------------|------------------------------------------------------------------|
-| s3_bucket            | string     | S3 Bucket name                                                   |
-| s3_prefix            | string     | S3 Prefix in the bucket                                          |
-| s3_access_key_id     | string     | S3 Access key ID                                                 |
-| s3_secret_access_key | string     | S3 secret access key                                             |
-| s3_secret_access_key | filepath   | Local import path - all database snapshots will be imported here |
-
-### Returns
-
-Returns `Completed successfully` if the database files were imported. Otherwise, returns an error.
-
-### Example
-
-```sh
-
 ```

--- a/content/rs/references/cli-utilities/rladmin/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/recover.md
@@ -34,7 +34,8 @@ Returns `Completed successfully` if the database was recovered. Otherwise, retur
 ### Example
 
 ```sh
-
+$ rladmin recover all
+Completed successfully
 ```
 
 ## `recover db`
@@ -60,7 +61,8 @@ Returns `Completed successfully` if the database was recovered. Otherwise, retur
 ### Example
 
 ```sh
-
+$ rladmin recover db db:5
+Completed successfully
 ```
 
 ## `recover list`

--- a/content/rs/references/cli-utilities/rladmin/recover.md
+++ b/content/rs/references/cli-utilities/rladmin/recover.md
@@ -17,7 +17,7 @@ aliases:
 Recovers all databases in recovery mode.
 
 ```sh
-$ rladmin recover all
+rladmin recover all
             [ only_configuration ]
 ```
 
@@ -36,7 +36,7 @@ Returns `Completed successfully` if the database was recovered. Otherwise, retur
 Recovers a specific database in recovery mode.
 
 ```sh
-$ rladmin recover db { db<id> | <name> }
+rladmin recover db { db:<id> | <name> }
                      [ only_configuration ]
 ```
 
@@ -56,7 +56,7 @@ Returns `Completed successfully` if the database was recovered. Otherwise, retur
 Shows a list of all databases that are currently in recovery mode.
 
 ```sh
-$ rladmin list
+rladmin recover list
 ```
 
 ### Parameters
@@ -65,7 +65,7 @@ None.
 
 ### Returns
 
-Displays a list of all recoverable databases. If no databases are in reovery mode, prints `No recoverable databases found`.
+Displays a list of all recoverable databases. If no databases are in recovery mode, prints `No recoverable databases found`.
 
 ### Example
 


### PR DESCRIPTION
Staging link: https://docs.redis.com/staging/jira-doc-1327-actual/rs/references/cli-utilities/rladmin/recover/

Still waiting on a couple of things:
- I haven't been able to figure out how to get databases into recovery mode, so I haven't been able to run `rladmin recover` commands on the databases in my cluster. 
- Awaiting feedback from Alon or Amiram about the import from s3 feature - not sure if this is something we want to document or not. 