### PR TITLE
Changes in Ingress spec in Kubernetes 1.19

### DIFF
--- a/content/kubernetes/re-databases/set-up-ingress-controller.md
+++ b/content/kubernetes/re-databases/set-up-ingress-controller.md
@@ -88,12 +88,12 @@ Install one of the supported ingress controllers:
         http:
           paths:
           - path: /
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: <db-name>
                 port:
-                  number: <db-port>
+                  name: redis
     ```  
 
     For HAProxy, insert the following into the `annotations` section:  

--- a/content/kubernetes/re-databases/set-up-ingress-controller.md
+++ b/content/kubernetes/re-databases/set-up-ingress-controller.md
@@ -88,9 +88,12 @@ Install one of the supported ingress controllers:
         http:
           paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: <db-name>
-              servicePort: <db-port>
+              service:
+                name: <db-name>
+                port:
+                  number: <db-port>
     ```  
 
     For HAProxy, insert the following into the `annotations` section:  


### PR DESCRIPTION
pathType is now mandatory; provided a default of Prefix.
serviceName has been replaced by service.name
servicePort has been replaced by service.port.number