### PR TITLE
Removed name option from rladmin cluster join

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -16,7 +16,7 @@ Adds a node to an existing cluster.
 ```sh
 rladmin cluster join 
         nodes <node IP address>
-        username <admin user> 
+        username <admin user email> 
         password <admin password>
         [ ephemeral_path <path> ]
         [ persistent_path <path> ]

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -15,7 +15,7 @@ Adds a node to an existing cluster.
 
 ```sh
 rladmin cluster join 
-        { name <cluster name> | nodes <node address> } 
+        nodes <node IP address>
         username <admin user> 
         password <admin password>
         [ ephemeral_path <path> ]
@@ -45,7 +45,6 @@ rladmin cluster join
 | external_addr | IP address | Sets a node's external IP address. If not provided, the node sets the address automatically. (optional) |
 | flash_enabled |  | Enables flash capabilities for a database (optional) |
 | flash_path | filepath (default:&nbsp;/var/opt/redislabs/flash) | Path to the flash storage location (in case the node does not support CAPI) (required if flash_enabled) |
-| name | string | Name of the cluster to join |
 | nodes | IP address | Internal IP address of an existing node in the cluster |
 | override_rack_id |  | Changes to a new rack, specified by `rack_id` (optional) |
 | override_repair |  | Enables joining a cluster with a dead node (optional) |
@@ -62,7 +61,7 @@ Returns `ok` if the node joined the cluster successfully. Otherwise, it returns 
 ### Example
 
 ```sh
-$ rladmin cluster join name cluster.local \
+$ rladmin cluster join nodes 192.0.2.2 \
         username admin@example.com \
         password admin-password
 Joining cluster... ok


### PR DESCRIPTION
[Staged preview](https://docs.redis.com/staging/jira-doc-1413/rs/references/cli-utilities/rladmin/cluster/join/)