### PR TITLE
DOC-1415: Identify existing REST API Examples in RS docs and simplify the presentation

### DIFF
--- a/content/rs/administering/access-control/password-rotation.md
+++ b/content/rs/administering/access-control/password-rotation.md
@@ -35,7 +35,7 @@ The new password cannot already exist as a password for the user and must meet t
 
 To rotate the password of a user account:
 
-1. Add an additional password to a user account with [`POST v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#add-password" >}}):
+1. Add an additional password to a user account with [`POST /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#add-password" >}}):
 
     ```sh
     POST https://[host][:port]/v1/users/password
@@ -45,7 +45,7 @@ To rotate the password of a user account:
     After you run this command, you can authenticate with both the old and the new password.
 
 1. Update the password in all database connections that connect with the user account.
-1. Delete the original password with [`DELETE v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#delete-password" >}}):
+1. Delete the original password with [`DELETE /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#delete-password" >}}):
 
     ```sh
     DELETE https://[host][:port]/v1/users/password

--- a/content/rs/administering/access-control/password-rotation.md
+++ b/content/rs/administering/access-control/password-rotation.md
@@ -35,22 +35,22 @@ The new password cannot already exist as a password for the user and must meet t
 
 To rotate the password of a user account:
 
-1. Add an additional password to a user account with this POST command:
+1. Add an additional password to a user account with [`POST v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#add-password" >}}):
 
-```sh
-POST https://[host][:port]/v1/users/password
-'{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}'
-```
+    ```sh
+    POST https://[host][:port]/v1/users/password
+    '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}'
+    ```
 
     After you run this command, you can authenticate with both the old and the new password.
 
 1. Update the password in all database connections that connect with the user account.
-1. Delete the original password with this DELETE command:
+1. Delete the original password with [`DELETE v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#delete-password" >}}):
 
-```sh
-DELETE https://[host][:port]/v1/users/password
-'{"username":"<username>", "old_password":"<an_existing_password>"}'
-```
+    ```sh
+    DELETE https://[host][:port]/v1/users/password
+    '{"username":"<username>", "old_password":"<an_existing_password>"}'
+    ```
 
 If there is only one valid password for a user account, you cannot delete that password.
 
@@ -59,7 +59,7 @@ If there is only one valid password for a user account, you cannot delete that p
 You can also replace all existing passwords for a user account with a single password that is not an existing password.
 This can be helpful if you suspect that your passwords are compromised and you want to quickly resecure the account.
 
-To replace all existing passwords for a user account with a single new password, use this PUT command:
+To replace all existing passwords for a user account with a single new password, use [`PUT /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#update-password" >}}):
 
 ```sh
 PUT https://[host][:port]/v1/users/password

--- a/content/rs/administering/access-control/password-rotation.md
+++ b/content/rs/administering/access-control/password-rotation.md
@@ -37,9 +37,10 @@ To rotate the password of a user account:
 
 1. Add an additional password to a user account with this POST command:
 
-    ```sh
-    curl -k -v -X POST -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}' https://<RS_server_address>:9443/v1/users/password
-    ```
+```sh
+POST https://[host][:port]/v1/users/password
+'{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}'
+```
 
     After you run this command, you can authenticate with both the old and the new password.
 
@@ -47,7 +48,8 @@ To rotate the password of a user account:
 1. Delete the original password with this DELETE command:
 
 ```sh
-curl -k -v -X DELETE -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>"}' https://<RS_server_address>:9443/v1/users/password
+DELETE https://[host][:port]/v1/users/password
+'{"username":"<username>", "old_password":"<an_existing_password>"}'
 ```
 
 If there is only one valid password for a user account, you cannot delete that password.
@@ -60,7 +62,8 @@ This can be helpful if you suspect that your passwords are compromised and you w
 To replace all existing passwords for a user account with a single new password, use this PUT command:
 
 ```sh
-curl -k -v -X PUT -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}' https://<RS_server_address>:9443/v1/users/password
+PUT https://[host][:port]/v1/users/password
+'{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}'
 ```
 
 All of the existing passwords are deleted and only the new password is valid.

--- a/content/rs/administering/cluster-operations/maintenance-mode.md
+++ b/content/rs/administering/cluster-operations/maintenance-mode.md
@@ -182,7 +182,7 @@ The `maintenance_on` request returns a JSON response body:
 Send a <nobr>`POST /nodes/{node_uid}/actions/maintenance_off`</nobr> request to turn off maintenance mode:
 
 ```
-POST https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_off
+POST https://[host][:port]/v1/nodes/node_id/actions/maintenance_off
      '{"skip_shards_restore":false}'
 ```
 
@@ -204,7 +204,7 @@ You can send a request to [<nobr>GET `/nodes/{node_uid}/actions/{action}`</nobr>
 This request returns the status of the `maintenance_on` action:
 
 ```
-GET https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_on
+GET https://[host][:port]/v1/nodes/node_id/actions/maintenance_on
 ```
 
 The response body:

--- a/content/rs/administering/cluster-operations/maintenance-mode.md
+++ b/content/rs/administering/cluster-operations/maintenance-mode.md
@@ -182,7 +182,7 @@ The `maintenance_on` request returns a JSON response body:
 Send a <nobr>`POST /nodes/{node_uid}/actions/maintenance_off`</nobr> request to turn off maintenance mode:
 
 ```
-POST https://[host][:port]/v1/nodes/node_id/actions/maintenance_off
+POST https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_off
      '{"skip_shards_restore":false}'
 ```
 
@@ -204,7 +204,7 @@ You can send a request to [<nobr>GET `/nodes/{node_uid}/actions/{action}`</nobr>
 This request returns the status of the `maintenance_on` action:
 
 ```
-GET https://[host][:port]/v1/nodes/node_id/actions/maintenance_on
+GET https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_on
 ```
 
 The response body:

--- a/content/rs/administering/cluster-operations/maintenance-mode.md
+++ b/content/rs/administering/cluster-operations/maintenance-mode.md
@@ -5,7 +5,7 @@ description: Prepare a node for maintenance
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
-aliases: 
+aliases:
         /rs/administering/cluster-operations/shutting-down-node.md
         /rs/administering/cluster-operations/shutting-down-node/
 ---
@@ -23,7 +23,7 @@ Maintenance mode does not protect against quorum loss. If you turn on maintenanc
     {{</warning>}}
 
 1. Takes a snapshot of the node configuration to record which shards and endpoints are on the node.
-1. Marks the node as a quorum node to prevent shards and endpoints from migrating to it. 
+1. Marks the node as a quorum node to prevent shards and endpoints from migrating to it.
     {{<note>}}
 If you run [`rladmin status`]({{<relref "/rs/references/rladmin#status">}}), the node's shards field is now yellow to show that shards cannot migrate to it.
     {{</note>}}
@@ -153,7 +153,7 @@ After turning on maintenance mode for node 2, Redis Enterprise saves a snapshot 
 
 Now node 2 has `0/0` shards because shards cannot migrate to it while it is in maintenance mode.
 
-## Toggle maintenance mode via API 
+## Toggle maintenance mode via API
 
 You can also turn maintenance mode on or off via [REST API requests]({{<relref "/rs/references/rest-api">}}) to [<nobr>POST `/nodes/{node_uid}/actions/{action}`</nobr>]({{<relref "/rs/references/rest-api/requests/nodes/actions#post-node-action">}}).
 
@@ -162,10 +162,8 @@ You can also turn maintenance mode on or off via [REST API requests]({{<relref "
 Send a <nobr>`POST /nodes/{node_uid}/actions/maintenance_on`</nobr> request to turn on maintenance mode:
 
 ```
-curl -X POST https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_on 
--k -u <user>:<password> 
---data '{"keep_slave_shards":true}' 
--H "Content-Type: application/json"
+POST https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_on
+     '{"keep_slave_shards":true}'
 ```
 
 The `keep_slave_shards` boolean flag [prevents replica shard migration](#prevent-replica-shard-migration) when set to `true`.
@@ -184,10 +182,8 @@ The `maintenance_on` request returns a JSON response body:
 Send a <nobr>`POST /nodes/{node_uid}/actions/maintenance_off`</nobr> request to turn off maintenance mode:
 
 ```
-curl -X POST https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_off 
--k -u <user>:<password> 
---data '{"skip_shards_restore":false}' 
--H "Content-Type: application/json"
+POST https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_off
+     '{"skip_shards_restore":false}'
 ```
 
 The `skip_shards_restore` boolean flag allows the `maintenance_off` action to [skip shard restoration](#skip-shard-restoration) when set to `true`.
@@ -208,8 +204,7 @@ You can send a request to [<nobr>GET `/nodes/{node_uid}/actions/{action}`</nobr>
 This request returns the status of the `maintenance_on` action:
 
 ```
-curl https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_on 
--k -u <user>:<password>
+GET https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_on
 ```
 
 The response body:

--- a/content/rs/administering/cluster-operations/removing-node.md
+++ b/content/rs/administering/cluster-operations/removing-node.md
@@ -82,12 +82,12 @@ To remove a node using the admin console:
 1. Once the process finishes, the node is no longer shown in
     the UI.
 
-To remove a node using the REST API, use the [`/v1/nodes/node_id/actions/remove`]({{< relref "/rs/references/rest-api/requests/nodes/actions#post-node-action" >}}) endpoint with the JSON data and the "Content-Type: application/json" header.
+To remove a node using the REST API, use the [`/v1/nodes/<node_id>/actions/remove`]({{< relref "/rs/references/rest-api/requests/nodes/actions#post-node-action" >}}) endpoint with the JSON data and the "Content-Type: application/json" header.
 
 For example:
 
 ```sh
-POST https://[host][:port]/v1/nodes/node_id/actions/remove
+POST https://[host][:port]/v1/nodes/<node_id>/actions/remove
 "{}"
 ```
 

--- a/content/rs/administering/cluster-operations/removing-node.md
+++ b/content/rs/administering/cluster-operations/removing-node.md
@@ -82,12 +82,12 @@ To remove a node using the admin console:
 1. Once the process finishes, the node is no longer shown in
     the UI.
 
-To remove a node using the REST API, use the `/v1/nodes/<node_id>/actions/remove` endpoint with the JSON data and the "Content-Type: application/json" header.
+To remove a node using the REST API, use the [`/v1/nodes/node_id/actions/remove`]({{< relref "/rs/references/rest-api/requests/nodes/actions#post-node-action" >}}) endpoint with the JSON data and the "Content-Type: application/json" header.
 
 For example:
 
 ```sh
-POST "Content-Type: application/json" https://[host][:port]/v1/nodes/node_id/actions/remove
+POST https://[host][:port]/v1/nodes/node_id/actions/remove
 "{}"
 ```
 

--- a/content/rs/administering/cluster-operations/removing-node.md
+++ b/content/rs/administering/cluster-operations/removing-node.md
@@ -82,12 +82,13 @@ To remove a node using the admin console:
 1. Once the process finishes, the node is no longer shown in
     the UI.
 
-To remove a node using the REST API, use the `/v1/nodes/3/actions/remove` endpoint with the JSON data and the "Content-Type: application/json" header.
+To remove a node using the REST API, use the `/v1/nodes/<node_id>/actions/remove` endpoint with the JSON data and the "Content-Type: application/json" header.
 
 For example:
 
 ```sh
-curl -X POST -H "Content-Type: application/json" -i -k -u user@redislabs.com:password https://localhost:9443/v1/nodes/3/actions/remove --data "{}"
+POST "Content-Type: application/json" https://[host][:port]/v1/nodes/node_id/actions/remove
+"{}"
 ```
 
 {{< note >}}

--- a/content/rs/administering/troubleshooting/disabling-services.md
+++ b/content/rs/administering/troubleshooting/disabling-services.md
@@ -9,9 +9,9 @@ The Redis Enterprise Software cluster nodes host a range of services that suppor
 In most deployments, either all of these services are required,
 or there are enough memory resources on the nodes for the database requirements.
 
-In a deployment with limited memory resources, certain services can be turned off from API endpoint to free system memory or using the `rladmin` command.
+In a deployment with limited memory resources, you can use the REST API or `rladmin` to turn off certain services to free system memory.
 Before you turn off a service, make sure that your deployment does not depend on that service.
-After you turn off a service, you can re-enable in the same way.
+After you turn off a service, you can re-enable it in the same way.
 
 The services that you can disable are:
 
@@ -30,7 +30,7 @@ To disable a service with the `rladmin cluster config` command, use the `service
 To turn off a service with the API, use the [PUT `/v1/cluster/services_configuration`]({{< relref "/rs/references/rest-api/requests/cluster/services_configuration#put-cluster-services_config" >}}) endpoint with the name of the service and the operating mode (enabled/disabled) in JSON format.
 
 For example:
-- To turn off the RS Admin Console, issue this PUT request:
+- To turn off the Redis Enterprise admin console, use this `PUT` request:
 
     ```sh
     PUT https://[host][:port]/v1/cluster/services_configuration

--- a/content/rs/administering/troubleshooting/disabling-services.md
+++ b/content/rs/administering/troubleshooting/disabling-services.md
@@ -1,6 +1,6 @@
 ---
 Title: Disabling Services to Free System Memory
-description: 
+description:
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
@@ -23,7 +23,7 @@ The services that you can disable are:
 
 To disable a service with the `rladmin cluster config` command, use the `services` parameter and the name of the service, followed by `disabled`.
 ```text
- rladmin cluster config 
+ rladmin cluster config
         [ services <service_name> <enabled | disabled> ]
 ```
 
@@ -34,10 +34,8 @@ For example:
 - To disable the RS Admin Console, issue this PUT request:
 
     ```sh
-    curl --request PUT \
-    --url https://localhost:9443/v1/cluster/services_configuration \
-    --header 'content-type: application/json' \
-    --data '{
+    PUT https://[host][:port]/v1/cluster/services_configuration
+    '{
         "cm_server":{
             "operating_mode":"disabled"
         }
@@ -47,10 +45,8 @@ For example:
 - To disable the CRDB services and enable the `stats_archiver` for cluster component statistics, issue this PUT request:
 
     ```sh
-    curl --request PUT \
-    --url https://localhost:9443/v1/cluster/services_configuration \
-    --header 'content-type: application/json' \
-    --data '{
+    PUT https://[host][:port]/v1/cluster/services_configuration
+    '{
         "crdb_coordinator":{
             "operating_mode":"disabled"
         },

--- a/content/rs/administering/troubleshooting/disabling-services.md
+++ b/content/rs/administering/troubleshooting/disabling-services.md
@@ -9,9 +9,9 @@ The Redis Enterprise Software cluster nodes host a range of services that suppor
 In most deployments, either all of these services are required,
 or there are enough memory resources on the nodes for the database requirements.
 
-In a deployment with limited memory resources, certain services can be disabled from API endpoint to free system memory or using the `rladmin` command.
-Before you disable a service, make sure that your deployment does not depend on that service.
-After you disable a service, you can re-enable in the same way.
+In a deployment with limited memory resources, certain services can be turned off from API endpoint to free system memory or using the `rladmin` command.
+Before you turn off a service, make sure that your deployment does not depend on that service.
+After you turn off a service, you can re-enable in the same way.
 
 The services that you can disable are:
 
@@ -27,11 +27,10 @@ To disable a service with the `rladmin cluster config` command, use the `service
         [ services <service_name> <enabled | disabled> ]
 ```
 
-To disable a service with the API, use the `/v1/cluster/services/configuration` endpoint
-with the name of the service and the operating mode (enabled/disabled) in JSON format.
+To turn off a service with the API, use the [PUT `/v1/cluster/services_configuration`]({{< relref "/rs/references/rest-api/requests/cluster/services_configuration#put-cluster-services_config" >}}) endpoint with the name of the service and the operating mode (enabled/disabled) in JSON format.
 
 For example:
-- To disable the RS Admin Console, issue this PUT request:
+- To turn off the RS Admin Console, issue this PUT request:
 
     ```sh
     PUT https://[host][:port]/v1/cluster/services_configuration
@@ -42,7 +41,7 @@ For example:
     }'
     ```
 
-- To disable the CRDB services and enable the `stats_archiver` for cluster component statistics, issue this PUT request:
+- To turn off the CRDB services and turn on the `stats_archiver` for cluster component statistics, issue this PUT request:
 
     ```sh
     PUT https://[host][:port]/v1/cluster/services_configuration

--- a/content/rs/databases/import-export/flush-db-crdb.md
+++ b/content/rs/databases/import-export/flush-db-crdb.md
@@ -107,7 +107,7 @@ To flush data from an Active-Active database:
     1. To flush the Active-Active database, use [`PUT /v1/crdbs/{guid}/flush`]({{< relref "/rs/references/rest-api/requests/crdbs/flush#put-crdbs-flush" >}}):
 
         ```sh
-        PUT https://[host][:port]/v1/crdbs/guid/flush
+        PUT https://[host][:port]/v1/crdbs/<guid>/flush
         ```
 
         The command output contains the task ID of the flush task.

--- a/content/rs/databases/import-export/flush-db-crdb.md
+++ b/content/rs/databases/import-export/flush-db-crdb.md
@@ -101,13 +101,13 @@ To flush data from an Active-Active database:
     1. To find the ID of the Active-Active database, run:
 
         ```sh
-        curl -v -u <user>:<password> -X GET https://<cluster-fqdn>:9443/v1/crdbs
+        GET https://[host][:port]/v1/crdbs
         ```
 
     1. To flush the Active-Active database, run:
 
         ```sh
-        curl -v -u <username>:<password> -X PUT https://<cluster-fqdn>:9443/v1/crdbs/<guid>/flush
+        PUT https://[host][:port]/v1/crdbs/<guid>/flush
         ```
 
         The command output contains the task ID of the flush task.
@@ -115,5 +115,5 @@ To flush data from an Active-Active database:
     1. To check the status of the flush task, run:
 
         ```sh
-        curl -v -u <username>:<password> https://<cluster-fqdn>:9443/v1/crdb_tasks/<task-id>
+        GET https://[host][:port]/v1/crdb_tasks/<task-id>
         ```

--- a/content/rs/databases/import-export/flush-db-crdb.md
+++ b/content/rs/databases/import-export/flush-db-crdb.md
@@ -98,22 +98,22 @@ To flush data from an Active-Active database:
 
 - REST API
 
-    1. To find the ID of the Active-Active database, run:
+    1. To find the ID of the Active-Active database, use [`GET /v1/crdbs`]({{< relref "/rs/references/rest-api/requests/crdbs#get-all-crdbs" >}}):
 
         ```sh
         GET https://[host][:port]/v1/crdbs
         ```
 
-    1. To flush the Active-Active database, run:
+    1. To flush the Active-Active database, use [`PUT /v1/crdbs/{guid}/flush`]({{< relref "/rs/references/rest-api/requests/crdbs/flush#put-crdbs-flush" >}}):
 
         ```sh
-        PUT https://[host][:port]/v1/crdbs/<guid>/flush
+        PUT https://[host][:port]/v1/crdbs/guid/flush
         ```
 
         The command output contains the task ID of the flush task.
 
-    1. To check the status of the flush task, run:
+    1. To check the status of the flush task, use [`GET /v1/crdb_tasks`]({{< relref "/rs/references/rest-api/requests/crdb_tasks#get-crdb_task" >}}):
 
         ```sh
-        GET https://[host][:port]/v1/crdb_tasks/<task-id>
+        GET https://[host][:port]/v1/crdb_tasks/task-id
         ```

--- a/content/rs/security/certificates/updating-certificates.md
+++ b/content/rs/security/certificates/updating-certificates.md
@@ -49,7 +49,7 @@ rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
 
 ### Use the REST API
 
-To replace a certificate using the REST API, run:
+To replace a certificate using the REST API, use [`PUT v1/cluster/update_cert`]({{< relref "/rs/references/rest-api/requests/cluster/update-cert#put-cluster-update_cert" >}}):
 
 ```sh
 PUT https://[host][:port]/v1/cluster/update_cert

--- a/content/rs/security/certificates/updating-certificates.md
+++ b/content/rs/security/certificates/updating-certificates.md
@@ -52,7 +52,8 @@ rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
 To replace a certificate using the REST API, run:
 
 ```sh
-curl -k -X PUT -u "<username>:<password>" -H "Content-Type: application/json" -d '{ "name": "<cert_name>", "key": "<key>", "certificate": "<cert>" }' https://<cluster_address>:9443/v1/cluster/update_cert
+PUT https://[host][:port]/v1/cluster/update_cert
+    '{ "name": "<cert_name>", "key": "<key>", "certificate": "<cert>" }'
 ```
 
 Replace the following variables with your own values:


### PR DESCRIPTION
Staging Link: https://docs.redis.com/staging/jira-doc-1415/rs/

Part of the RS REST API Cleanup. Changed any REST API examples in /rs/ from cURL examples to "VERB https://[host][:port]/v1/[endpoint]".

Did not touch any calls in the user security page, per Lance. 