### PR TITLE
Added release notes for RediSearch v2.4.8, RedisGraph v2.4.14

### DIFF
--- a/content/modules/redisearch/release-notes/redisearch-2.4-release-notes.md
+++ b/content/modules/redisearch/release-notes/redisearch-2.4-release-notes.md
@@ -10,10 +10,30 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RediSearch v2.4.6 requires:
+RediSearch v2.4.8 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
+
+## v2.4.8 (May 2022)
+
+This is a maintenance release for RediSearch 2.4.
+
+Update urgency: `MODERATE`: Program an upgrade of the server, but it's not urgent.
+However, if you're using Vector Similarity (introduced in RediSearch 2.4), there are some critical bugs that may affect a subset of users. In this case, you should upgrade.
+
+Details:
+
+- Bug fixes:
+
+  - [#2739](https://github.com/RediSearch/RediSearch/pull/2739) Memory leak in coordinator related to Vector Similarity (MOD-3023)
+  - [#2736](https://github.com/RediSearch/RediSearch/pull/2736), [#2782](https://github.com/RediSearch/RediSearch/pull/2782) Memory allocation restrictions for Vector Similarity indices (causing OOM) (MOD-3195)
+  - [#2755](https://github.com/RediSearch/RediSearch/pull/2755) Compare the entire vector field name instead of a prefix when creating a new vector index
+  - [#2780](https://github.com/RediSearch/RediSearch/pull/2780) Initialize all variables in `EvalContext` (which might have led to crashes in clustered databases)
+
+- Improvements:
+
+  - [#2740](https://github.com/RediSearch/RediSearch/pull/2740) Performance optimization for hybrid vector queries
 
 ## v2.4.6 (May 2022)
 

--- a/content/modules/redisgraph/release-notes/redisgraph-2.4-release-notes.md
+++ b/content/modules/redisgraph/release-notes/redisgraph-2.4-release-notes.md
@@ -10,10 +10,30 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisGraph v2.4.13 requires:
+RedisGraph v2.4.14 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.8
+
+## v2.4.14 (May 2022)
+
+This is a maintenance release for RedisGraph 2.4.
+
+Update urgency: `LOW`: No need to upgrade unless there are new features you want to use.
+
+Details:
+
+- Bug fixes:
+
+    - [#2072](https://github.com/RedisGraph/RedisGraph/issues/2072), [#2081](https://github.com/RedisGraph/RedisGraph/pull/2081) CRLF sequences embedded in strings no longer trigger a protocol error when being emitted
+
+- Improvements:
+
+    - [#2102](https://github.com/RedisGraph/RedisGraph/pull/2102) New load-time configuration option `NODE_CREATION_BUFFER` - see [documentation](https://github.com/RedisGraph/RedisGraph/blob/master/docs/docs/configuration.md#node_creation_buffer) (MOD-2348)
+
+{{<note>}}
+For Redis Enterprise users who want to upgrade to this patch, this version requires being on version 6.2.8 or later.
+{{</note>}}
 
 ## v2.4.13 (December 2021)
 


### PR DESCRIPTION
[RediSearch preview](https://docs.redis.com/staging/module-release-notes/modules/redisearch/release-notes/redisearch-2.4-release-notes/)
[RedisGraph preview](https://docs.redis.com/staging/module-release-notes/modules/redisgraph/release-notes/redisgraph-2.4-release-notes/)