### PR TITLE
Fix default port for admin console via Kubernetes

### DIFF
--- a/content/kubernetes/re-clusters/connect-to-admin-console.md
+++ b/content/kubernetes/re-clusters/connect-to-admin-console.md
@@ -49,7 +49,7 @@ There are several methods for accessing the admin console. Port forwarding is th
     ```
 
     {{<note>}}
-    The default port is 8843.
+    The default port is 8443.
     {{</note>}}
 
 1. Use `kubectl port-forward` to forward your local port to the service port.


### PR DESCRIPTION
Tiny fix to the default port (8843 --> 8443) used to access the RE admin console via a Kubernetes service port.