### PR TITLE
Changed ioredis to node-redis for supported connection clients

### DIFF
--- a/content/rs/connections/supported-clients-browsers.md
+++ b/content/rs/connections/supported-clients-browsers.md
@@ -14,19 +14,25 @@ You can connect to Redis Enterprise Software databases programmatically using cl
 
 To connect an application to a Redis database hosted by Redis Enterprise Software, use a [client library](https://redis.io/clients) appropriate for your programming language.
 
-You can also use the `redis-cli` utility to connect to a database from the command-line.
+You can also use the `redis-cli` utility to connect to a database from the command line.
 
-For examples of each approach, see Get started using [Redis Enterprise Software]({{< relref "/" >}})
+For examples of each approach, see [Get started with Redis Enterprise Software]({{<relref "/rs/installing-upgrading/get-started-redis-enterprise-software">}}).
 
 Note: You cannot use client libraries to configure Redis Enterprise Software.  Instead, use:
 
 - The Redis Software [admin console]({{< relref "/rs/installing-upgrading/get-started-redis-enterprise-software.md" >}})
-- The [REST API]({{< relref "/rs/administering/" >}})
-- Appropriate command-line utilities, such as [`rladmin`]({{< relref "/rs/references/rladmin.md" >}})
+- The [REST API]({{<relref "/rs/references/rest-api">}})
+- Command-line utilities, such as [`rladmin`]({{< relref "/rs/references/rladmin.md" >}})
 
 ### Discovery service
 
 We recommend the following clients when using a [discovery service]({{< relref "/rs/concepts/data-access/discovery-service.md" >}}) based on the Redis Sentinel API:
 
-{{< embed-md "discovery-clients.md" >}}
+- [redis-py](https://github.com/redis/redis-py) (Python Redis client)
+- [Hiredis](https://github.com/redis/hiredis) (C Redis client)
+- [Jedis](https://github.com/redis/jedis) (Java Redis client)
+- [node-redis](https://github.com/redis/node-redis) (Node.js Redis client)
+
+If you need to use another client, you can use [Sentinel Tunnel](https://github.com/RedisLabs/sentinel_tunnel)
+to discover the current Redis master with Sentinel and create a TCP tunnel between a local port on the client and the master.
 


### PR DESCRIPTION
Changed ioredis to node-redis for supported connection clients and replaced the embed.

[Staged preview](https://docs.redis.com/staging/jira-doc-1434/rs/connections/supported-clients-browsers/)