### PR TITLE
Added release notes for RedisJSON v2.0.9, RedisTimeSeries v1.6.13

### DIFF
--- a/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
+++ b/content/modules/redisjson/release-notes/redisjson-2.0-release-notes.md
@@ -10,10 +10,26 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisJSON v2.0.8 requires:
+RedisJSON v2.0.9 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
+
+## v2.0.9 (June 2022)
+
+This is a maintenance release for RedisJSON 2.0.
+
+Update urgency: `LOW`: No need to upgrade unless there are new features you want to use.
+
+Details:
+
+- Bug fixes:
+
+  - [#721](https://github.com/RedisJSON/RedisJSON/pull/721) Skip String and Boolean scalars in `JSON.CLEAR` (MOD-3136)
+
+- Improvements:
+
+  - [#709](https://github.com/RedisJSON/RedisJSON/pull/709) Allow internal JSON API's `getdouble` to succeed with integer values
 
 ## v2.0.8 (April 2022)
 

--- a/content/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes.md
+++ b/content/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes.md
@@ -10,10 +10,23 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisTimeSeries v1.6.11 requires:
+RedisTimeSeries v1.6.13 requires:
 
 - Minimum Redis compatibility version (database): 6.0.16
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v1.6.13 (June 2022)
+
+This is a maintenance release for RedisTimeSeries 1.6.
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
+
+Details:
+
+- Bug fixes:
+
+    - [#1176](https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1176), [#1187](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1187) When executing [`DEL`](https://redis.io/commands/ts.del/), chunk index could be set to a wrong value and cause some data to be inaccessible
+    - [#1180](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1180) When executing [`MADD`](https://redis.io/commands/ts.madd/), make sure that only successful insertions are replicated
 
 ## v1.6.11 (May 2022)
 


### PR DESCRIPTION
[RedisJSON release notes](https://docs.redis.com/staging/module-release-notes/modules/redisjson/release-notes/redisjson-2.0-release-notes/)
[RedisTimeSeries release notes](https://docs.redis.com/staging/module-release-notes/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes/)