### PR TITLE
DOC-1415: Identify existing REST API Examples in RS docs and simplify the presentation

### DIFF
--- a/content/rs/clusters/maintenance-mode.md
+++ b/content/rs/clusters/maintenance-mode.md
@@ -26,7 +26,7 @@ Maintenance mode does not protect against quorum loss. If you turn on maintenanc
     {{</warning>}}
 
 1. Takes a snapshot of the node configuration to record which shards and endpoints are on the node.
-1. Marks the node as a quorum node to prevent shards and endpoints from migrating to it. 
+1. Marks the node as a quorum node to prevent shards and endpoints from migrating to it.
     {{<note>}}
 If you run [`rladmin status`]({{<relref "/rs/references/cli-utilities/rladmin/status">}}), the node's shards field is now yellow to show that shards cannot migrate to it.
     {{</note>}}
@@ -156,7 +156,7 @@ After turning on maintenance mode for node 2, Redis Enterprise saves a snapshot 
 
 Now node 2 has `0/0` shards because shards cannot migrate to it while it is in maintenance mode.
 
-## Toggle maintenance mode via API 
+## Toggle maintenance mode via API
 
 You can also turn maintenance mode on or off via [REST API requests]({{<relref "/rs/references/rest-api">}}) to [<nobr>POST `/nodes/{node_uid}/actions/{action}`</nobr>]({{<relref "/rs/references/rest-api/requests/nodes/actions#post-node-action">}}).
 
@@ -165,10 +165,8 @@ You can also turn maintenance mode on or off via [REST API requests]({{<relref "
 Send a <nobr>`POST /nodes/{node_uid}/actions/maintenance_on`</nobr> request to turn on maintenance mode:
 
 ```
-curl -X POST https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_on 
--k -u <user>:<password> 
---data '{"keep_slave_shards":true}' 
--H "Content-Type: application/json"
+POST https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_on
+     '{"keep_slave_shards":true}'
 ```
 
 The `keep_slave_shards` boolean flag [prevents replica shard migration](#prevent-replica-shard-migration) when set to `true`.
@@ -187,10 +185,8 @@ The `maintenance_on` request returns a JSON response body:
 Send a <nobr>`POST /nodes/{node_uid}/actions/maintenance_off`</nobr> request to turn off maintenance mode:
 
 ```
-curl -X POST https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_off 
--k -u <user>:<password> 
---data '{"skip_shards_restore":false}' 
--H "-Type: application/json"
+POST https://[host][:port]/v1/nodes/<node_id>/actions/maintenance_off
+     '{"skip_shards_restore":false}'
 ```
 
 The `skip_shards_restore` boolean flag allows the `maintenance_off` action to [skip shard restoration](#skip-shard-restoration) when set to `true`.
@@ -211,8 +207,7 @@ You can send a request to [<nobr>GET `/nodes/{node_uid}/actions/{action}`</nobr>
 This request returns the status of the `maintenance_on` action:
 
 ```
-curl https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_on 
--k -u <user>:<password>
+GET https://<hostname>:9443/v1/nodes/<node_id>/actions/maintenance_on
 ```
 
 The response body:

--- a/content/rs/clusters/optimize/turn-off-services.md
+++ b/content/rs/clusters/optimize/turn-off-services.md
@@ -1,7 +1,7 @@
 ---
 Title: Turn off services to free system memory
 linktitle: Free system memory
-description: Turn off services to free memory and improve performance. 
+description: Turn off services to free memory and improve performance.
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
@@ -31,34 +31,30 @@ The services that you can turn off are:
 
 To turn off a service with the `rladmin cluster config` command, use the `services` parameter and the name of the service, followed by `disabled`.
 ```text
- rladmin cluster config 
+ rladmin cluster config
         [ services <service_name> <enabled | disabled> ]
 ```
 
-To turn off a service with the API, use the `/v1/cluster/services/configuration` endpoint
+To turn off a service with the API, use the [`PUT /v1/services_configuration`]({{<relref "/rs/references/rest-api/requests/cluster/services_configuration#put-cluster-services_config">}}) endpoint
 with the name of the service and the operating mode (enabled/disabled) in JSON format.
 
 For example:
-- To turn off the Redis Enterprise admin console, issue this PUT request:
+- To turn off the Redis Enterprise admin console, use this PUT request:
 
     ```sh
-    curl --request PUT \
-    --url https://localhost:9443/v1/cluster/services_configuration \
-    --header 'content-type: application/json' \
-    --data '{
+    PUT https://[host][:9443]/v1/cluster/services_configuration
+    '{
         "cm_server":{
             "operating_mode":"disabled"
         }
     }'
     ```
 
-- To turn off the CRDB services and enable the `stats_archiver` for cluster component statistics, issue this PUT request:
+- To turn off the CRDB services and enable the `stats_archiver` for cluster component statistics, use this PUT request:
 
     ```sh
-    curl --request PUT \
-    --url https://localhost:9443/v1/cluster/services_configuration \
-    --header 'content-type: application/json' \
-    --data '{
+    PUT https://[host][:9443]/v1/cluster/services_configuration
+    '{
         "crdb_coordinator":{
             "operating_mode":"disabled"
         },

--- a/content/rs/clusters/remove-node.md
+++ b/content/rs/clusters/remove-node.md
@@ -1,7 +1,7 @@
 ---
 Title: Remove a cluster node
 linkTitle: Remove node
-description: Remove a node from your Redis Enterprise cluster. 
+description: Remove a node from your Redis Enterprise cluster.
 weight: $weight
 alwaysopen: false
 categories: ["RS"]
@@ -89,12 +89,13 @@ To remove a node using the admin console:
 1. Once the process finishes, the node is no longer shown in
     the UI.
 
-To remove a node using the REST API, use the `/v1/nodes/3/actions/remove` endpoint with the JSON data and the "Content-Type: application/json" header.
+To remove a node using the REST API, use `POST /v1/nodes/<node_id>/actions/remove` endpoint with the following JSON data and the "Content-Type: application/json" header.
 
 For example:
 
 ```sh
-curl -X POST -H "Content-Type: application/json" -i -k -u user@redislabs.com:password https://localhost:9443/v1/nodes/3/actions/remove --data "{}"
+POST https://[host][:port]/v1/nodes/<node_id>/actions/remove
+     "{}"
 ```
 
 {{< note >}}

--- a/content/rs/clusters/remove-node.md
+++ b/content/rs/clusters/remove-node.md
@@ -89,7 +89,7 @@ To remove a node using the admin console:
 1. Once the process finishes, the node is no longer shown in
     the UI.
 
-To remove a node using the REST API, use `POST /v1/nodes/<node_id>/actions/remove` endpoint with the following JSON data and the "Content-Type: application/json" header.
+To remove a node using the REST API, use [`POST /v1/nodes/<node_id>/actions/remove`]({{< relref "/rs/references/rest-api/requests/nodes/actions#post-node-action" >}}) with the following JSON data and the "Content-Type: application/json" header.
 
 For example:
 

--- a/content/rs/databases/import-export/flush-db-crdb.md
+++ b/content/rs/databases/import-export/flush-db-crdb.md
@@ -98,22 +98,22 @@ To flush data from an Active-Active database:
 
 - REST API
 
-    1. To find the ID of the Active-Active database, run:
+    1. To find the ID of the Active-Active database, use [`GET /v1/crdbs`]({{< relref "/rs/references/rest-api/requests/crdbs#get-all-crdbs" >}}):
 
         ```sh
-        curl -v -u <user>:<password> -X GET https://<cluster-fqdn>:9443/v1/crdbs
+        GET https://[host][:port]/v1/crdbs
         ```
 
-    1. To flush the Active-Active database, run:
+    1. To flush the Active-Active database, use [`PUT /v1/crdbs/{guid}/flush`]({{< relref "/rs/references/rest-api/requests/crdbs/flush#put-crdbs-flush" >}}):
 
         ```sh
-        curl -v -u <username>:<password> -X PUT https://<cluster-fqdn>:9443/v1/crdbs/<guid>/flush
+        PUT https://[host][:port]/v1/crdbs/<guid>/flush
         ```
 
         The command output contains the task ID of the flush task.
 
-    1. To check the status of the flush task, run:
+    1. To check the status of the flush task, use [`GET /v1/crdb_tasks`]({{< relref "/rs/references/rest-api/requests/crdb_tasks#get-crdb_task" >}}):
 
         ```sh
-        curl -v -u <username>:<password> https://<cluster-fqdn>:9443/v1/crdb_tasks/<task-id>
+        GET https://[host][:port]/v1/crdb_tasks/<task-id>
         ```

--- a/content/rs/security/access-control/manage-users/login-lockout.md
+++ b/content/rs/security/access-control/manage-users/login-lockout.md
@@ -79,14 +79,11 @@ To unlock a user account or reset a user password with `rladmin`, run:
 rladmin cluster reset_password <user email>
 ```
 
-To unlock a user account or reset a user password with the REST API, run:
+To unlock a user account or reset a user password with the REST API, use [`PUT /v1/users`]({{< relref "/rs/references/rest-api/requests/users#put-user" >}}):
 
 ```sh
-curl -k -X PUT -v -H "cache-control: no-cache" 
-                  -H "content-type: application/json" 
-                  -u "<administrator_user>:<password>" 
-                  -d '{"password": "<new_password>"}' 
-                  https://<RS_server_address>:9443/v1/users/<uid>
+PUT https://[host][:port]/v1/users
+    '{"password": "<new_password>"}'
 ```
 
 ## Session timeout

--- a/content/rs/security/access-control/manage-users/manage-passwords.md
+++ b/content/rs/security/access-control/manage-users/manage-passwords.md
@@ -31,14 +31,11 @@ In addition, the password:
 The password complexity profile applies when a new user is added or an existing user changes their password. This profile does not apply to users authenticated through an external identity provider.
 {{< /note >}}
 
-To enable the password complexity profile, run the following `curl` command against the REST API:
+To enable the password complexity profile, use [`PUT /v1/cluster`]({{< relref "/rs/references/rest-api/requests/cluster#put-cluster" >}}):
 
 ```sh
-curl -k -X PUT -v -H "cache-control: no-cache" 
-                  -H "content-type: application/json" 
-                  -u "<administrator-user-email>:<password>" 
-                  -d '{"password_complexity":true}' 
-                  https://<RS_server_address>:9443/v1/cluster
+PUT https://[host][:port]/v1/cluster
+    '{"password_complexity":true}'
 ```
 
 To turn off the password complexity requirement, run the same command but set `"password_complexity"` to `false`.
@@ -48,11 +45,8 @@ To turn off the password complexity requirement, run the same command but set `"
 To enforce an expiration of a user's password after a specified number of days, use the following REST API request:
 
 ```sh
-curl -k -X PUT -v -H "cache-control: no-cache" 
-                  -H "content-type: application/json" 
-                  -u "<administrator_user>:<password>" 
-                  -d '{"password_expiration_duration":<number_of_days>}' 
-                  https://<RS_server_address>:9443/v1/cluster
+PUT https://[host][:port]/v1/cluster
+    '{"password_expiration_duration":<number_of_days>}'
 ```
 
 To turn off password expiration, set the number of days to `0`.
@@ -88,19 +82,21 @@ The new password cannot already exist as a password for the user and must meet t
 
 To rotate the password of a user account:
 
-1. Add an additional password to a user account with this `POST` request:
+1. Add an additional password to a user account with [`POST /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#add-password" >}}):
 
     ```sh
-    curl -k -v -X POST -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}' https://<RS_server_address>:9443/v1/users/password
+    POST https://[host][:port]/v1/users/password
+         '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}'
     ```
 
     After you send this request, you can authenticate with both the old and the new password.
 
 1. Update the password in all database connections that connect with the user account.
-1. Delete the original password with this `DELETE` request:
+1. Delete the original password with [`DELETE /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#update-password" >}}):
 
 ```sh
-curl -k -v -X DELETE -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>"}' https://<RS_server_address>:9443/v1/users/password
+DELETE https://[host][:port]/v1/users/password
+       '{"username":"<username>", "old_password":"<an_existing_password>"}'
 ```
 
 If there is only one valid password for a user account, you cannot delete that password.
@@ -110,14 +106,15 @@ If there is only one valid password for a user account, you cannot delete that p
 You can also replace all existing passwords for a user account with a single password that does not match any existing passwords.
 This can be helpful if you suspect that your passwords are compromised and you want to quickly resecure the account.
 
-To replace all existing passwords for a user account with a single new password, use this `PUT` request:
+To replace all existing passwords for a user account with a single new password, use [`PUT /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#delete-password" >}}):
 
 ```sh
-curl -k -v -X PUT -H "content-type: application/json" -u "<administrator_user>:<password>" -d '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}' https://<RS_server_address>:9443/v1/users/password
+PUT https://[host][:port]/v1/users/password
+    '{"username":"<username>", "old_password":"<an_existing_password>", "new_password":"<a_new_password>"}'
 ```
 
 All of the existing passwords are deleted and only the new password is valid.
 
 {{<note>}}
-If you run the above command without `-X PUT`, the new password is added to the list of existing passwords.
+If you send the above request without specifying it is a `PUT` request, the new password is added to the list of existing passwords.
 {{</note>}}

--- a/content/rs/security/access-control/manage-users/manage-passwords.md
+++ b/content/rs/security/access-control/manage-users/manage-passwords.md
@@ -42,7 +42,7 @@ To turn off the password complexity requirement, run the same command but set `"
 
 ## Enable password expiration
 
-To enforce an expiration of a user's password after a specified number of days, use the following REST API request:
+To enforce an expiration of a user's password after a specified number of days, use [`PUT /v1/cluster`]({{< relref "/rs/references/rest-api/requests/cluster#put-cluster" >}}):
 
 ```sh
 PUT https://[host][:port]/v1/cluster
@@ -94,12 +94,12 @@ To rotate the password of a user account:
 1. Update the password in all database connections that connect with the user account.
 1. Delete the original password with [`DELETE /v1/users/password`]({{< relref "/rs/references/rest-api/requests/users/password#update-password" >}}):
 
-```sh
-DELETE https://[host][:port]/v1/users/password
-       '{"username":"<username>", "old_password":"<an_existing_password>"}'
-```
+    ```sh
+    DELETE https://[host][:port]/v1/users/password
+           '{"username":"<username>", "old_password":"<an_existing_password>"}'
+    ```
 
-If there is only one valid password for a user account, you cannot delete that password.
+    If there is only one valid password for a user account, you cannot delete that password.
 
 ### Replace all passwords
 

--- a/content/rs/security/certificates/updating-certificates.md
+++ b/content/rs/security/certificates/updating-certificates.md
@@ -49,10 +49,11 @@ rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem
 
 ### Use the REST API
 
-To replace a certificate using the REST API, run:
+To replace a certificate using the REST API, use [`PUT /v1/cluster/update_cert`]({{< relref "/rs/references/rest-api/requests/cluster/update-cert#put-cluster-update_cert" >}}):
 
 ```sh
-curl -k -X PUT -u "<username>:<password>" -H "Content-Type: application/json" -d '{ "name": "<cert_name>", "key": "<key>", "certificate": "<cert>" }' https://<cluster_address>:9443/v1/cluster/update_cert
+PUT https://[host][:port]/v1/cluster/update_cert
+    '{ "name": "<cert_name>", "key": "<key>", "certificate": "<cert>" }'
 ```
 
 Replace the following variables with your own values:


### PR DESCRIPTION
Duplicate of #1938. Opening a new PR here because of the RS Reorg stuff that has been merged to master - there were too many merge conflicts and too much of a possibility for merge mistakes that it would be easier to start fresh.

Staging Links:
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/clusters/maintenance-mode/
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/clusters/optimize/turn-off-services/
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/clusters/remove-node/
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/databases/import-export/flush-db-crdb/
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/security/access-control/manage-users/login-lockout/
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/security/access-control/manage-users/manage-passwords/
https://docs.redis.com/staging/jira-doc-1415-with-reorg/rs/security/certificates/updating-certificates/