### PR TITLE
Added release notes for RedisAI, RedisTimeSeries, RedisGraph, RediSearch

### DIFF
--- a/content/modules/redisai/release-notes/redisai-1.2-release-notes.md
+++ b/content/modules/redisai/release-notes/redisai-1.2-release-notes.md
@@ -6,15 +6,40 @@ min-version-db: 6.0.0
 min-version-rs: 6.2.2
 weight: 99
 alwaysopen: false
+toc: "true"
 categories: ["Modules"]
 ---
 
 ## Requirements
 
-RedisAI v1.2.5 requires:
+RedisAI v1.2.7 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.2.2
+
+## 1.2.7 (June 2022)
+
+This is a maintenance release for RedisAI 1.2.
+
+Update urgency: `MODERATE`.
+
+Headlines:
+
+- This release improves overall stability and provides fixes for issues found after the previous release.
+
+Details:
+
+- Minor enhancements:
+
+    - [#918](https://github.com/RedisAI/RedisAI/pull/918), [#924](https://github.com/RedisAI/RedisAI/pull/924) Add `AI.CONFIG GET` sub-command
+    - [#914](https://github.com/RedisAI/RedisAI/pull/914), [#915](https://github.com/RedisAI/RedisAI/pull/915), [#917](https://github.com/RedisAI/RedisAI/pull/917) Backends update - TF 2.8, PyTorch 1.11, ONNXRuntime 1.11
+    - [#904](https://github.com/RedisAI/RedisAI/pull/904) Enable saving model/script run statistics when run by a low-level API (by using RedisGears integration in particular) and retrieving the statistics with the `AI.INFO` command
+    - [#897](https://github.com/RedisAI/RedisAI/pull/897) Restore support for MacOS build scripts
+    - [#893](https://github.com/RedisAI/RedisAI/pull/893) Removed support for Linux Xenial
+
+- Bug fixes:
+
+    - [#923](https://github.com/RedisAI/RedisAI/pull/923) Fix a synchronization issue, regarding updates to the number of background threads, that rarely caused a crash upon executing models in ONNX
 
 ## 1.2.5 (November 2021)
 

--- a/content/modules/redisearch/release-notes/redisearch-2.4-release-notes.md
+++ b/content/modules/redisearch/release-notes/redisearch-2.4-release-notes.md
@@ -10,10 +10,35 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RediSearch v2.4.8 requires:
+RediSearch v2.4.9 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
+
+## v2.4.9 (June 2022)
+
+This is a maintenance release for RediSearch 2.4.
+
+Update urgency: `MODERATE`: Program an upgrade of the server, but it's not urgent.
+
+Details:
+
+- Bug fixes:
+
+  - [#2837](https://github.com/RediSearch/RediSearch/pull/2837), [#2836](https://github.com/RediSearch/RediSearch/issues/2836) Crash on `FT.AGGREGATE` "... APPLY '-INF % -1'..."
+  - [#2814](https://github.com/RediSearch/RediSearch/pull/2814) `FT.EXPLAIN` without parameters causes a crash
+  - [#2790](https://github.com/RediSearch/RediSearch/pull/2790) Incorrect `num_terms` value in `FT.INFO` after a term is deleted from all the docs (garbage collection)
+  - [#2804](https://github.com/RediSearch/RediSearch/pull/2804) Freeze when `OFFSET`+`LIMIT` was greater than `maxSearchResults` (config)
+  - [#2791](https://github.com/RediSearch/RediSearch/pull/2791) Add `BlockedClientMeasureTime` to coordinator for more accurate performance stats
+  - [#2802](https://github.com/RediSearch/RediSearch/pull/2802) Tagged parts of keys (curly brackets `{}`) are now returned by `FT.SEARCH`
+
+- Improvements:
+
+  - [#2806](https://github.com/RediSearch/RediSearch/pull/2806) Do not load the JSON API when RediSearch is initialized as a library
+
+- Minor breaking change:
+
+  - As pointed out above, [#2802](https://github.com/RediSearch/RediSearch/pull/2802) is a bug fix. However, if your application relies on RediSearch incorrectly trimming the tagged part of a key (using `{}`), this could break your application. This only applies to users who are using RediSearch in clustered databases.
 
 ## v2.4.8 (May 2022)
 

--- a/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
+++ b/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
@@ -10,10 +10,23 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisGraph v2.8.13 requires:
+RedisGraph v2.8.15 requires:
 
 - Minimum Redis compatibility version (database): 6.2.0
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v2.8.15 (June 2022)
+
+This is a maintenance release for RedisGraph 2.8.
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
+
+Details:
+
+- Bug fixes:
+
+    - [#2241](https://github.com/RedisGraph/RedisGraph/issues/2241) Possible crash on queries with `MERGE` operation in a Cartesian product (MOD-3500)
+    - [#2394](https://github.com/RedisGraph/RedisGraph/issues/2394) Possible crash when freeing an index immediately after its creation
 
 ## v2.8.13 (May 2022)
 

--- a/content/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes.md
+++ b/content/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes.md
@@ -10,10 +10,32 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisTimeSeries v1.6.13 requires:
+RedisTimeSeries v1.6.16 requires:
 
 - Minimum Redis compatibility version (database): 6.0.16
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v1.6.16 (June 2022)
+
+This is a maintenance release for RedisTimeSeries 1.6.
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
+
+Details:
+
+- Features:
+
+    - [#1193](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1193) Commands that don’t execute on the main thread now appear in [SLOWLOG](https://redis.io/commands/slowlog/)
+
+- Bug fixes:
+
+    - [#1203](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1203) Compaction rules are not replicated (Replica Of) on Redis Enterprise
+    - [#1204](https://github.com/RedisTimeSeries/RedisTimeSeries/issues/1204) When the last sample is deleted with [`TS.DEL`](https://redis.io/commands/ts.del/), it may still be accessible with [`TS.GET`](https://redis.io/commands/ts.get/)
+    - [#1226](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/1226) [`TS.MRANGE`](https://redis.io/commands/ts.mrange/), [`TS.MREVRANGE`](https://redis.io/commands/ts.mrevrange/): on a multi-shard environment, some chunks may be skipped
+
+{{<note>}}
+New RDB version (v5). RDB files created with 1.6.16 are not backward compatible.
+{{</note>}}
 
 ## v1.6.13 (June 2022)
 


### PR DESCRIPTION
Added release notes for RedisAI v1.2.7, RedisTimeSeries v1.6.16, RedisGraph v2.8.15, and RediSearch v2.4.9.

Staged previews:
[RedisAI](https://docs.redis.com/staging/module-release-notes/modules/redisai/release-notes/redisai-1.2-release-notes/)
[RedisGraph](https://docs.redis.com/staging/module-release-notes/modules/redisgraph/release-notes/redisgraph-2.8-release-notes/)
[RediSearch](https://docs.redis.com/staging/module-release-notes/modules/redisearch/release-notes/redisearch-2.4-release-notes/)
[RedisTimeSeries](https://docs.redis.com/staging/module-release-notes/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes/)
