### PR TITLE
K8s 6.2.10-45 Lucy release notes and distro changes 

### DIFF
--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -23,7 +23,7 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
   2. Upgrade the Redis Enterprise cluster (REC)
 
 {{< warning >}}
-  **Do not** upgrade to the 6.2.10-34 release if you are an OpenShift customer and also use modules. Upgrade to the [6.2.10-45]({{< relref "/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md" >}}) release instead.
+  OpenShift customers who also use Redis Modules are advised to skip upgrading to the 6.2.10-34 release, and instead upgrade to the [6.2.10-45]({{< relref "/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md" >}}) release. Either way, when upgrading existing RS clusters running on RHEL7-based images, make sure to select a RHEL7-based image for the new version.
   {{</warning>}}
 
 ## Upgrade the operator

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -23,11 +23,8 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
   2. Upgrade the Redis Enterprise cluster (REC)
 
 {{< warning >}}
-  **Do not** upgrade to the 6.2.10-34 release if you are an **OpenShift** customer and **also use modules**.
-  
-  There was a change in 6.2.10-34 to a new RHEL 8 base image for the Redis Server image. Due to binary differences in modules between the two operating systems, you cannot directly update RHEL 7 clusters to RHEL 8 when those clusters host databases using modules.
-
-  This message will be updated as remediation plans and new steps are available to address this situation. Please contact support if you have further questions. {{</warning>}}
+  **Do not** upgrade to the 6.2.10-34 release if you are an OpenShift customer and also use modules. Upgrade to the [6.2.10-45]({{< relref "/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md" >}}) release instead.
+  {{</warning>}}
 
 ## Upgrade the operator
 

--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -36,16 +36,16 @@ Each release of the Redis Enterprise operator is thoroughly tested against a set
 - Any distribution not listed below is not supported for production workloads.
 
 
-| **Kubernetes version**  | 1.19       | 1.20       | 1.21       | 1.22       | 1.23       |
-|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Community Kubernetes    | deprecated | deprecated | supported  | supported  | supported* |
-| Amazon EKS              | supported  | supported  | supported  |            |            |
-| Azure AKS               |            |            | supported  | supported  | supported* |
-| Google GKE              | supported  | supported  | supported  | supported  |            |
-| Rancher 2.6             | supported  | supported  | supported  | supported  |            |
+| **Kubernetes version**  | 1.19       | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
+|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
+| Community Kubernetes    |            |            | deprecated | supported  | supported  | supported* |
+| Amazon EKS              | deprecated | deprecated | supported  | supported* |            |
+| Azure AKS               |            |            | deprecated | supported  | supported  |
+| Google GKE              | deprecated | deprecated | supported  | supported  |supported*  |
+| Rancher 2.6             | deprecated | deprecated | supported  | supported  |            |
 | **OpenShift version**   | **4.6**    | **4.7**    | **4.8**    | **4.9**    | **4.10**   |
-|                         | deprecated | deprecated | supported  | supported  | supported* |
+|                         |            | deprecated | deprecated | supported  | supported  |
 | **VMware TKGI version** | **1.10**   | **1.11**   | **1.12**   | **1.13**   |            |
-|                         | supported  | supported  | supported* |            |            |
+|                         | deprecated | deprecated | supported* | supported* |            |
 
 \* Support added in most recent release  

--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -35,10 +35,9 @@ Each release of the Redis Enterprise operator is thoroughly tested against a set
 - "deprecated" indicates this distribution is supported for this release, but will be dropped in a future release.
 - Any distribution not listed below is not supported for production workloads.
 
-
 | **Kubernetes version**  | 1.19       | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
 |:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Community Kubernetes    |            |            | deprecated | supported  | supported  | supported* |
+| Community Kubernetes    |            | deprecated | deprecated | supported  | supported  | supported* |
 | Amazon EKS              | deprecated | deprecated | supported  | supported* |            |
 | Azure AKS               |            |            | deprecated | supported  | supported  |
 | Google GKE              | deprecated | deprecated | supported  | supported  |supported*  |

--- a/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
@@ -1,6 +1,6 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.2.10-45 (July 2022)
-linktitle: 6.2.10-45 (May 2022)
+linktitle: 6.2.10-45 (July 2022)
 description: Support for REBD specific upgrade policies, memcached type REDBs, and RHEL8 for OpenShift, as well as feature improvements and bug fixes.
 weight: 62
 alwaysopen: false

--- a/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
@@ -79,14 +79,6 @@ Below is a table showing supported distributions at the time of this release. Se
 
 ## Known limitations
 
-* **Warning** Openshift customers using modules cannot use 6.2.10-45 version
-  {{<warning>}}
-  **Do not** upgrade to this 6.2.10-45 release if you are an **OpenShift** customer and **also use modules**. 
-  
-  There was a change in 6.2.10-45 to a new RHEL 8 base image for the Redis Server image. Due to binary differences in modules between the two operating systems, you cannot directly update RHEL 7 clusters to RHEL 8 when those clusters host databases using modules. 
-  
-  This message will be updated as remediation plans and new steps are available to address this situation. Please contact support if you have further questions. {{</warning>}}
-
 * Long cluster names cause routes to be rejected  (RED-25871)
 
   A cluster name longer than 20 characters will result in a rejected route configuration because the host part of the domain name will exceed 63 characters. The workaround is to limit cluster name to 20 characters or less.

--- a/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
@@ -1,102 +1,89 @@
 ---
-Title: Redis Enterprise for Kubernetes Release Notes 6.2.10-34 (May 2022)
-linktitle: 6.2.10-34 (May 2022)
+Title: Redis Enterprise for Kubernetes Release Notes 6.2.10-45 (July 2022)
+linktitle: 6.2.10-45 (May 2022)
 description: Support for REBD specific upgrade policies, memcached type REDBs, and RHEL8 for OpenShift, as well as feature improvements and bug fixes.
-weight: 63
+weight: 62
 alwaysopen: false
 categories: ["Platforms"]
 aliases: [
-    /kubernetes/release-notes/k8s-6-2-10-34-2022-02.md,
-    /kubernetes/release-notes/k8s-6-2-10-34-2022-02/,   ]
+    /kubernetes/release-notes/k8s-6-2-10-45-2022-02.md,
+    /kubernetes/release-notes/k8s-6-2-10-45-2022-02/,   ]
 ---
 ## Overview
 
-The Redis Enterprise K8s 6.2.10-34 supports the Redis Enterprise Software release 6.2.10 and includes feature improvements and bug fixes.
+The Redis Enterprise K8s 6.2.10-45 supports the Redis Enterprise Software release 6.2.10 and includes feature improvements and bug fixes.
 
-The key new features, bug fixes, and known limitations are described below.
-
-{{<warning>}}
-  **Do not** upgrade to this 6.2.10-34 release if you are an **OpenShift** customer and **also use modules**. Instead, **use the [6.2.10-45]({{< relref "/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md" >}})** release.
-  
-  There was a change in 6.2.10-34 to a new RHEL 8 base image for the Redis Server image. Due to binary differences in modules between the two operating systems, you cannot directly update RHEL 7 clusters to RHEL 8 when those clusters host databases using modules.
-  
-   Please contact support if you have further questions. {{</warning>}}
+The key bug fixes and known limitations are described below.
 
 ## Images
 
 This release includes the following container images:
 
-* **Redis Enterprise**: `redislabs/redis:6.2.10-107` or  `redislabs/redis:6.2.10-107.rhel8-openshift`
-* **Operator**: `redislabs/operator:6.2.10-34`
-* **Services Rigger**: `redislabs/k8s-controller:6.2.10-34` or `redislabs/services-manager:6.2.10-34` (on the Red Hat registry)
-
-## New features
-
-* Support database upgrade policy (major/latest) for REDB resources (RED-71028)
-* Support for memcached type databases for REDB (RED-70284)(RED-75269)
-* Use RHEL8 base images for OpenShift deployments (RED-72374)
+* **Redis Enterprise**: `redislabs/redis:6.2.10-129` or  `redislabs/redis:6.2.10-129.rhel8-openshift`
+* **Operator**: `redislabs/operator:6.2.10-45`
+* **Services Rigger**: `redislabs/k8s-controller:6.2.10-45` or `redislabs/services-manager:6.2.10-45` (on the Red Hat registry)
 
 ## Feature improvements
 
-* OpenShift 4.10 support (RED-73966)
-* Allow setting host time zone on running containers (RED-56810)
-* AKS 1.23 support (RED-73965)
-* EKS 1.22 support (RED-73972)
+* OpenShift OperatorLifecycleManager support on restricted networks (RED-72968)
+* `log_collector` script uses `oc` command with automatic detection of OpenShift (RED-73215)
+* Operator uses `policy/v1` for `PodDistruptionBudget`(RED-78564)
+* Added support for Kubernetes distributions (see Compatibility notes below)
 
 ## Fixed bugs
 
-* Outdated SCC YAML file (RED-72026) (RED-73341)
-* Admission container startup failure (RED-72081)
-* Admission container restarts due to race condition with config map creation (RED-72268)
-* Incorrect REDB status report during cluster recovery (RED-72944)
-* Invalid REDB spec not always rejected by admission controller (RED-73145)
+* Upgrade failures when RHEL7 was used (RED-77890)
+* Log collector failures when Python2 was used (RED-73403)
+
+## API changes
+
+The `digestHash` optional field added to `imageSpec` fields in the REC. This field should be used in disconnected environments using the OperatorLifecycleManager.
 
 ## Compatibility notes
 
 Below is a table showing supported distributions at the time of this release. See [Supported Kubernetes distributions]({{< relref "/kubernetes/reference/supported_k8s_distributions.md" >}}) for the current list of supported distributions.
 
-| **Kubernetes version**  | **1.19**   | **1.20**   | **1.21**   | **1.22**   | **1.23**   |
-|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Community Kubernetes    | deprecated | deprecated | supported  | supported  | supported* |
-| Amazon EKS              | supported  | supported  | supported  |            |            |
-| Azure AKS               |            |            | supported  | supported  | supported* |
-| Google GKE              | supported  | supported  | supported  | supported  |            |
-| Rancher 2.6             | supported  | supported  | supported  | supported  |            |
+| **Kubernetes version**  | 1.19       | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
+|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
+| Community Kubernetes    |            |            | deprecated | supported  | supported  | supported* |
+| Amazon EKS              | deprecated | deprecated | supported  | supported* |            |
+| Azure AKS               |            |            | deprecated | supported  | supported  |
+| Google GKE              | deprecated | deprecated | supported  | supported  |supported*  |
+| Rancher 2.6             | deprecated | deprecated | supported  | supported  |            |
 | **OpenShift version**   | **4.6**    | **4.7**    | **4.8**    | **4.9**    | **4.10**   |
-|                         | deprecated | deprecated | supported  | supported  | supported* |
+|                         |            | deprecated | deprecated | supported  | supported  |
 | **VMware TKGI version** | **1.10**   | **1.11**   | **1.12**   | **1.13**   |            |
-|                         | supported  | supported  | supported* |            |            |
+|                         | deprecated | deprecated | supported* | supported* |            |
 
-\* Support added in most recent release  
+\* Support added in this release  
 
-### Now supported
+### Support added
 
-* OpenShift 4.10 is now supported
-* kOps (Community Kubernetes) 1.23 is now supported
-* AKS 1.23 is now supported
-* EKS 1.22 is now supported
+* K8s community version 1.24
 
 ### Deprecated
 
-* OpenShift 4.6-4.7 is deprecated
-* kOps (Community Kubernetes) 1.18-1.20 are deprecated
-* GKE 1.19 is deprecated
-* Rancher 2.6 - K8s 1.18 is deprecated
-* AKS 1.20-1.21 are deprecated
-* EKS 1.18-1.19 are deprecated
+* OpenShift 4.7-4.8
+* Kubernetes 1.20
+* Rancher 2.6 for K8s 1.19-1.20
+* TKGI 1.10-11
 
 ### No longer supported
 
-* Rancher version 2.5 (previously deprecated) is no longer supported (not supported by SUSE)
-* OpenShift version 3.11 (previously deprecated) is no longer supported.
+* OpenShift 4.6 (previously deprecated)
+* Kubernetes 1.18-1.19 (previously deprecated)
+* Rancher 2.6 for K8s 1.18 (previously deprecated)
+* AKS 1.20-1.21 (previously deprecated)
+* EKS 1.18-1.19 (previously deprecated)
+* GKE 1.19 (previously deprecated)
 
 ## Known limitations
 
-* **Warning** Openshift customers using modules cannot use 6.2.10-34 version
+* **Warning** Openshift customers using modules cannot use 6.2.10-45 version
   {{<warning>}}
-  **Do not** upgrade to this 6.2.10-34 release if you are an **OpenShift** customer and **also use modules**. 
+  **Do not** upgrade to this 6.2.10-45 release if you are an **OpenShift** customer and **also use modules**. 
   
-  There was a change in 6.2.10-34 to a new RHEL 8 base image for the Redis Server image. Due to binary differences in modules between the two operating systems, you cannot directly update RHEL 7 clusters to RHEL 8 when those clusters host databases using modules. 
+  There was a change in 6.2.10-45 to a new RHEL 8 base image for the Redis Server image. Due to binary differences in modules between the two operating systems, you cannot directly update RHEL 7 clusters to RHEL 8 when those clusters host databases using modules. 
   
   This message will be updated as remediation plans and new steps are available to address this situation. Please contact support if you have further questions. {{</warning>}}
 

--- a/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes Release Notes 6.2.10-45 (July 2022)
 linktitle: 6.2.10-45 (July 2022)
-description: Support for REBD specific upgrade policies, memcached type REDBs, and RHEL8 for OpenShift, as well as feature improvements and bug fixes.
+description: Support added for additional distributions as well as some feature improvements. 
 weight: 62
 alwaysopen: false
 categories: ["Platforms"]
@@ -19,7 +19,7 @@ The key bug fixes and known limitations are described below.
 
 This release includes the following container images:
 
-* **Redis Enterprise**: `redislabs/redis:6.2.10-129` or  `redislabs/redis:6.2.10-129.rhel8-openshift`
+* **Redis Enterprise**: `redislabs/redis:6.2.10-129` or  `redislabs/redis:6.2.10-129.rhel8-openshift` (or `redislabs/redis:6.2.10-129.rhel7-openshift` if upgrading from a RHEL7 cluster)
 * **Operator**: `redislabs/operator:6.2.10-45`
 * **Services Rigger**: `redislabs/k8s-controller:6.2.10-45` or `redislabs/services-manager:6.2.10-45` (on the Red Hat registry)
 
@@ -27,7 +27,7 @@ This release includes the following container images:
 
 * OpenShift OperatorLifecycleManager support on restricted networks (RED-72968)
 * `log_collector` script uses `oc` command with automatic detection of OpenShift (RED-73215)
-* Operator uses `policy/v1` for `PodDistruptionBudget`(RED-78564)
+* Operator uses `policy/v1` for `PodDisruptionBudget`(RED-78564)
 * Added support for Kubernetes distributions (see Compatibility notes below)
 
 ## Fixed bugs


### PR DESCRIPTION
Jira: DOC-1498
Staging pages:

-  https://docs.redis.com/staging/jira-doc-1498/kubernetes/release-notes/k8s-6-2-10-45-2022-07/
- https://docs.redis.com/staging/jira-doc-1498/kubernetes/reference/supported_k8s_distributions/