### PR TITLE
Fix legacy connection params.

### DIFF
--- a/content/rs/references/client_references/client_nodejs.md
+++ b/content/rs/references/client_references/client_nodejs.md
@@ -29,8 +29,10 @@ The following code creates a connection to Redis:
 ```js
 const redis = require('redis');
 const client = redis.createClient({
-    host: '<hostname>',
-    port: <port>,
+    socket: {
+        host: '<hostname>',
+        port: <port>
+    },
     password: '<password>'
 });
 


### PR DESCRIPTION
The npm package redis had changed params of redis.createClient, the params in the article were wrong, and will result in default behavior(connecting to 127.0.0.1:6379).