### PR TITLE
Added release notes for RedisBloom v2.2.18 and RedisGraph v2.8.16

### DIFF
--- a/content/modules/redisbloom/release-notes/redisbloom-2.2-release-notes.md
+++ b/content/modules/redisbloom/release-notes/redisbloom-2.2-release-notes.md
@@ -10,10 +10,23 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisBloom v2.2.17 requires:
+RedisBloom v2.2.18 requires:
 
 - Minimum Redis compatibility version (database): 4.0.0
 - Minimum Redis Enterprise Software version (cluster): 5.0.0
+
+## v2.2.18 (July 2022)
+
+This is a maintenance release for RedisBloom 2.2.
+
+Update urgency: `MODERATE`: Program an upgrade of the server, but it's not urgent.
+
+Details:
+
+- Bug fixes:
+
+    - [#481](https://github.com/RedisBloom/RedisBloom/issues/481) CF crashes on expansion 0
+    - [#478](https://github.com/RedisBloom/RedisBloom/pull/478) [`BF.INFO`](https://redis.io/commands/bf.info/) reports an inaccurate result about the memory footprint
 
 ## v2.2.17 (June 2022)
 

--- a/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
+++ b/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
@@ -10,10 +10,24 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisGraph v2.8.15 requires:
+RedisGraph v2.8.16 requires:
 
 - Minimum Redis compatibility version (database): 6.2.0
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v2.8.16 (July 2022)
+
+This is a maintenance release for RedisGraph 2.8.
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
+
+Details:
+
+- Bug fixes:
+
+    - [#2478](https://github.com/RedisGraph/RedisGraph/pull/2478) Potential crash with concurrent connections due to missing lock
+    - [#2370](https://github.com/RedisGraph/RedisGraph/issues/2370) Wrong results / warning messages when using edge indexes
+    - [#2473](https://github.com/RedisGraph/RedisGraph/issues/2473) Crash on invalid `distance()` query with index
 
 ## v2.8.15 (June 2022)
 


### PR DESCRIPTION
[RedisBloom](https://docs.redis.com/staging/module-release-notes/modules/redisbloom/release-notes/redisbloom-2.2-release-notes/)
[RedisGraph](https://docs.redis.com/staging/module-release-notes/modules/redisgraph/release-notes/redisgraph-2.8-release-notes/)