### PR TITLE
clarifying getting 'getting started' for prometheus integration

### DIFF
--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -29,8 +29,8 @@ To get started with custom monitoring:
 
 1. Create a directory called 'prometheus' on your local machine:
 
-    - Within that directory, create a file called `prometheus.yml`.
-    - Add the following contents to the yml file and replace `<cluster_name>` with your Redis cluster's FQDN:
+1. Within that directory, create a file called `prometheus.yml`.
+1. Add the following contents to the yml file and replace `<cluster_name>` with your Redis cluster's FQDN:
 
     {{< note >}}
 

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -29,7 +29,7 @@ To get started with custom monitoring:
 
 1. Create a directory called 'prometheus' on your local machine:
 
-    - Within that folder, create a file called 'prometheus.yml'
+    - Within that directory, create a file called `prometheus.yml`.
     - Copy and paste the following contents into the yml file, replacing `<cluster_name>` with your redis cluster FQDN:
 
     {{< note >}}

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -27,10 +27,16 @@ In each cluster, the metrics_exporter component listens on port 8070 and serves 
 
 To get started with custom monitoring:
 
-1. Copy this Prometheus configuration into `./prometheus/prometheus.yml` in your current folder:
+1. Create a folder called 'prometheus' on your local machine:
 
-    - If you already have Prometheus installed, just copy the 'redis-enterprise' job into your existing Prometheus configuration and skip the next step.
-    - Replace `<cluster_name>` with your actual cluster FQDN.
+    - Within that folder, create a file called 'prometheus.yml'
+    - Copy and paste the following contents into the yml file, replacing `<cluster_name>` with your redis cluster FQDN:
+
+    {{< note >}}
+
+This is for deveopment testing only (running in docker)
+
+    {{< /note >}}
 
     ```yml
     global:

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -34,7 +34,7 @@ To get started with custom monitoring:
 
     {{< note >}}
 
-This is for deveopment testing only (running in docker)
+This is for development testing only (running in docker).
 
     {{< /note >}}
 

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -27,7 +27,7 @@ In each cluster, the metrics_exporter component listens on port 8070 and serves 
 
 To get started with custom monitoring:
 
-1. Create a directory called 'prometheus' on your local machine:
+1. Create a directory called 'prometheus' on your local machine.
 
 1. Within that directory, create a file called `prometheus.yml`.
 1. Add the following contents to the yml file and replace `<cluster_name>` with your Redis cluster's FQDN:

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -27,7 +27,7 @@ In each cluster, the metrics_exporter component listens on port 8070 and serves 
 
 To get started with custom monitoring:
 
-1. Create a folder called 'prometheus' on your local machine:
+1. Create a directory called 'prometheus' on your local machine:
 
     - Within that folder, create a file called 'prometheus.yml'
     - Copy and paste the following contents into the yml file, replacing `<cluster_name>` with your redis cluster FQDN:

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -34,7 +34,7 @@ To get started with custom monitoring:
 
     {{< note >}}
 
-This is for development testing only (running in docker).
+This is for development testing only (running in Docker).
 
     {{< /note >}}
 

--- a/content/rs/monitoring-metrics/prometheus-integration.md
+++ b/content/rs/monitoring-metrics/prometheus-integration.md
@@ -30,7 +30,7 @@ To get started with custom monitoring:
 1. Create a directory called 'prometheus' on your local machine:
 
     - Within that directory, create a file called `prometheus.yml`.
-    - Copy and paste the following contents into the yml file, replacing `<cluster_name>` with your redis cluster FQDN:
+    - Add the following contents to the yml file and replace `<cluster_name>` with your Redis cluster's FQDN:
 
     {{< note >}}
 


### PR DESCRIPTION
https://redislabs.atlassian.net/browse/DOC-607

Updated the language for 'Getting started' on the [Prometheus integration](https://docs.redis.com/latest/rs/monitoring-metrics/prometheus-integration/) page to be less confusing for users.

These changes are only helpful for docker, and since this is RS specific this only works for users not on windows or m1.