### PR TITLE
Added release notes for RedisGraph v2.8.17, RediSearch v2.4.10

### DIFF
--- a/content/modules/redisearch/release-notes/redisearch-2.4-release-notes.md
+++ b/content/modules/redisearch/release-notes/redisearch-2.4-release-notes.md
@@ -10,10 +10,24 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RediSearch v2.4.9 requires:
+RediSearch v2.4.10 requires:
 
 - Minimum Redis compatibility version (database): 6.0.0
 - Minimum Redis Enterprise Software version (cluster): 6.0.0
+
+## v2.4.10 (July 2022)
+
+This is a maintenance release for RediSearch 2.4.
+
+Update urgency: `MODERATE`: Program an upgrade of the server, but it's not urgent.
+
+Details:
+
+- Bug fixes:
+
+  - [#2863](https://github.com/RediSearch/RediSearch/pull/2863) Crash due to too high (Levenshtein) `DISTANCE` in `FT.SPELLCHECK`. This fix limits the `DISTANCE` to 4. (MOD-3563)
+  - [#2875](https://github.com/RediSearch/RediSearch/pull/2875) Not all documents with vector fields were indexed with Redis on Flash (MOD-3584)
+  - [#2846](https://github.com/RediSearch/RediSearch/pull/2846) Enforce Redis Enterprise memory limit for vector indices
 
 ## v2.4.9 (June 2022)
 

--- a/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
+++ b/content/modules/redisgraph/release-notes/redisgraph-2.8-release-notes.md
@@ -10,10 +10,24 @@ categories: ["Modules"]
 ---
 ## Requirements
 
-RedisGraph v2.8.16 requires:
+RedisGraph v2.8.17 requires:
 
 - Minimum Redis compatibility version (database): 6.2.0
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v2.8.17 (July 2022)
+
+This is a maintenance release for RedisGraph 2.8.
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
+
+Details:
+
+- Bug fixes:
+
+    - [#2499](https://github.com/RedisGraph/RedisGraph/pull/2499) Potential crash with concurrent connections due to missing lock - additional fixes
+    - [#2424](https://github.com/RedisGraph/RedisGraph/issues/2424) Potential crash when using `ORDER BY`
+    - [#2491](https://github.com/RedisGraph/RedisGraph/issues/2491) Whitespaces between `MATCH` terms can render the query invalid
 
 ## v2.8.16 (July 2022)
 


### PR DESCRIPTION
[RedisGraph](https://docs.redis.com/staging/module-release-notes/modules/redisgraph/release-notes/redisgraph-2.8-release-notes/)
[RediSearch](https://docs.redis.com/staging/module-release-notes/modules/redisearch/release-notes/redisearch-2.4-release-notes/)