### PR TITLE
Updated RedisJSON quick start

### DIFF
--- a/content/modules/redisjson/redisjson-quickstart.md
+++ b/content/modules/redisjson/redisjson-quickstart.md
@@ -36,42 +36,69 @@ The `--raw` option forces the command to return raw output.
 
 ### Create JSON documents
 
-You can use the [`JSON.SET`](https://redis.io/commands/json.set) command to create a JSON document.
+You can use the [`JSON.SET`](https://redis.io/commands/json.set) command to create a [JSON](https://www.json.org) document.
 
-Create a JSON document that represents a `shopping_list`:
+Here's an example JSON document that represents a shopping list:
+
+```json
+{
+  "list_date": "05/05/2022",
+  "stores": {
+    "grocery_store": {
+      "items": [
+        {
+          "name": "apples",
+          "count": 5
+        }
+      ]
+    }
+  }
+}
+```
+
+To create this JSON document in your database, run [`JSON.SET`](https://redis.io/commands/json.set):
 
 ```sh
-127.0.0.1:12543> JSON.SET shopping_list $ '{"list_date" : "05/05/2022", "stores": {}'
+127.0.0.1:12543> JSON.SET shopping_list $ '{"list_date": "05/05/2022", "stores": {"grocery_store": {"items": [{"name": "apples", "count": 5}]}}}'
 OK
 ```
 
-The second argument in `JSON.SET` is the [JSON path](https://redis.io/docs/stack/json/path/). The `$` or `.` character represents the root of the JSON document. All elements with a JSON document are relative to the root.
+[`JSON.SET`](https://redis.io/commands/json.set) accepts a [JSON path](https://redis.io/docs/stack/json/path) as a parameter. Paths must start with a `$` ([JSONPath syntax](https://redis.io/docs/stack/json/path/#jsonpath-syntax)) or `.` ([legacy path syntax](https://redis.io/docs/stack/json/path/#legacy-path-syntax)) character, which represents the root of the JSON document. All elements within a JSON document are relative to the root.
 
 ### Modify JSON documents
 
-You can also use [`JSON.SET`](https://redis.io/commands/json.set) to modify existing JSON documents and elements.
+You can also use [`JSON.SET`](https://redis.io/commands/json.set) to modify existing JSON documents and elements. To modify specific JSON elements, you need to provide the [path](https://redis.io/docs/stack/json/path) to the target JSON element as a parameter.
 
-Add each store with an array of `items` that you need to buy:
+Add a new store to the shopping list and provide an array of `items` that you need to buy from there:
 
 ``` sh
-127.0.0.1:12543> JSON.SET shopping_list $.stores.grocery_store '{ "items": [ { "name": "apples", "count": 5 } ] }'
-OK
 127.0.0.1:12543> JSON.SET shopping_list $.stores.clothing_store '{ "items": [ { "name": "socks", "count": 2 } ] }'
 OK
 ```
 
-Use [`JSON.ARRAPPEND`](https://redis.io/commands/json.arrappend) to add more items to the `items` arrays. `JSON.ARRAPPEND` returns the number of objects in the array.
+You can use [`JSON.ARRAPPEND`](https://redis.io/commands/json.arrappend) to add a new element to an array.
+
+For example, add `pears` to the `grocery_store` list:
 
 ``` sh
 127.0.0.1:12543> JSON.ARRAPPEND shopping_list $.stores.grocery_store.items '{ "name" : "pears", "count" : 3 }'    
 2
 ```
 
-Use [`JSON.NUMINCRBY`](https://redis.io/commands/json.numincrby) to change the number of a specific item that you need. This returns the new value of the item.
+The output number indicates how many items are currently in the array.
+
+[`JSON.NUMINCRBY`](https://redis.io/commands/json.numincrby) lets you change an item's `count` by a specific number and display the updated value.
+
+Increase an item count by 2:
 
 ```sh
 127.0.0.1:12543> JSON.NUMINCRBY shopping_list $.stores.clothing_store.items[0].count 2    
 4
+```
+
+Decrease an item count by 1:
+
+```sh
 127.0.0.1:12543> JSON.NUMINCRBY shopping_list $.stores.grocery_store.items[1].count -1
 2
 ```

--- a/content/modules/redisjson/redisjson-quickstart.md
+++ b/content/modules/redisjson/redisjson-quickstart.md
@@ -69,12 +69,16 @@ OK
 
 You can also use [`JSON.SET`](https://redis.io/commands/json.set) to modify existing JSON documents and elements. To modify a specific JSON element, you need to provide the [path](https://redis.io/docs/stack/json/path) to the element as a parameter.
 
+#### Add a new JSON object
+
 Add a new store named `clothing_store` to the shopping list and provide an array of `items` that you need to buy from there:
 
 ``` sh
 127.0.0.1:12543> JSON.SET shopping_list $.stores.clothing_store '{ "items": [ { "name": "socks", "count": 2 } ] }'
 OK
 ```
+
+#### Append to an array
 
 You can use [`JSON.ARRAPPEND`](https://redis.io/commands/json.arrappend) to add a new element to an existing array.
 
@@ -87,6 +91,8 @@ For example, add a new item named `pears` to the `grocery_store` list:
 
 The output number indicates how many items are currently in the array.
 
+#### Increase or decrease a number
+
 [`JSON.NUMINCRBY`](https://redis.io/commands/json.numincrby) lets you increase (or decrease) a number by a specified value.
 
 Increase the `count` of the first item on the `clothing_store` list by 2:
@@ -95,6 +101,8 @@ Increase the `count` of the first item on the `clothing_store` list by 2:
 127.0.0.1:12543> JSON.NUMINCRBY shopping_list $.stores.clothing_store.items[0].count 2    
 [4]
 ```
+
+#### Conditional update
 
 You can also use filter expressions `?()` in the JSONPath to modify JSON elements that match some condition.
 
@@ -107,9 +115,11 @@ The following example filters on `grocery_store` item names to decrease the `cou
 
 To use double quotes in a filter expression, you must enclose the path within single quotes.
 
-### Read JSON elements
+### Read JSON
 
 The [`JSON.GET`](https://redis.io/commands/json.get) command lets you retrieve JSON documents stored in the database. If you run `redis-cli` with the `--raw` option, you can format the response with the `INDENT`, `NEWLINE`, and `SPACE` options.
+
+#### Read entire document
 
 To retrieve the entire JSON document, run [`JSON.GET`](https://redis.io/commands/json.get) with root `$` as the path:
 
@@ -143,6 +153,8 @@ To retrieve the entire JSON document, run [`JSON.GET`](https://redis.io/commands
   }
 ]
 ```
+
+#### Read specific elements
 
 You can also use [`JSON.GET`](https://redis.io/commands/json.get) to retrieve specific elements within a JSON document.
 
@@ -203,42 +215,44 @@ integer
 
 ### Delete JSON elements
 
-Use [`JSON.DEL`](https://redis.io/commands/json.del) to delete parts of the JSON document.
+Use [`JSON.DEL`](https://redis.io/commands/json.del) to delete parts of the JSON document:
 
-Remove the `clothing_store` JSON object:
+1. Remove the `clothing_store` JSON object:
 
-```sh
-127.0.0.1:12543> JSON.DEL shopping_list $.stores.clothing_store
-1
-```
+    ```sh
+    127.0.0.1:12543> JSON.DEL shopping_list $.stores.clothing_store
+    1
+    ```
 
-Then remove the second item from the `grocery_store` list:
+1. Then remove the second item from the `grocery_store` list:
 
-```sh
-127.0.0.1:12543> JSON.DEL shopping_list $.stores.grocery_store.items[1]
-1
-```
+    ```sh
+    127.0.0.1:12543> JSON.DEL shopping_list $.stores.grocery_store.items[1]
+    1
+    ```
 
-If you run [`JSON.GET`](https://redis.io/commands/json.get), you can verify the removal of the expected JSON elements:
+1. If you run [`JSON.GET`](https://redis.io/commands/json.get), you can verify the removal of the expected JSON elements:
 
-```sh
-127.0.0.1:12543> JSON.GET shopping_list $ INDENT "\t" NEWLINE "\n"
-[
-  {
-    "list_date": "05/05/2022",
-    "stores": {
-      "grocery_store": {
-        "items": [
-          {
-            "name": "apples",
-            "count": 5
+    ```sh
+    127.0.0.1:12543> JSON.GET shopping_list $ INDENT "\t" NEWLINE "\n"
+    [
+      {
+        "list_date": "05/05/2022",
+        "stores": {
+          "grocery_store": {
+            "items": [
+              {
+                "name": "apples",
+                "count": 5
+              }
+            ]
           }
-        ]
+        }
       }
-    }
-  }
-]
-```
+    ]
+    ```
+
+### Delete JSON document
 
 If you run [`JSON.DEL`](https://redis.io/commands/json.del) but don't specify a path, it will delete the entire JSON document:
 

--- a/content/modules/redisjson/redisjson-quickstart.md
+++ b/content/modules/redisjson/redisjson-quickstart.md
@@ -17,13 +17,13 @@ For this quick start tutorial, you need:
 
     - A [Redis Enterprise Software]({{<relref "/modules/install/add-module-to-database">}}) database
 
-- [`redis-cli`](https://redis.io/docs/manual/cli/) command-line tool
+- [`redis-cli`]({{<relref "/rs/references/cli-utilities/redis-cli">}}) command-line tool
 
 - [`redis-py`](https://github.com/redis/redis-py) client library v4.0.0 or greater
 
 ## RedisJSON with `redis-cli`
 
-The [`redis-cli`](https://redis.io/docs/manual/cli/) command-line tool comes packaged with Redis. You can use it to connect to your Redis database and test RedisJSON commands.
+The [`redis-cli`]({{<relref "/rs/references/cli-utilities/redis-cli">}}) command-line tool comes packaged with Redis. You can use it to connect to your Redis database and test RedisJSON commands.
 
 ### Connect to a database
 

--- a/content/modules/redisjson/redisjson-quickstart.md
+++ b/content/modules/redisjson/redisjson-quickstart.md
@@ -17,86 +17,77 @@ For this quick start tutorial, you need:
 
     - A [Redis Enterprise Software]({{<relref "/modules/install/add-module-to-database">}}) database
 
-- redis-cli command line tool
+- `redis-cli` command-line tool
 
-- [redis-py](https://github.com/redis/redis-py) client library v4.0.0 or greater
+- [`redis-py`](https://github.com/redis/redis-py) client library v4.0.0 or greater
 
 ## RedisJSON with redis-cli
 
-The [`redis-cli`](https://redis.io/docs/manual/cli/) command-line tool is part of the Redis installation. You can use it to connect to your Redis database and test RedisJSON commands.
-
-In these examples, you will create a shopping list using a JSON document in Redis.
+The [`redis-cli`](https://redis.io/docs/manual/cli/) command-line tool comes packaged with Redis. You can use it to connect to your Redis database and test RedisJSON commands.
 
 ### Connect to a database
 
 ```sh
-$ redis-cli -h <endpoint> -p <port> -a <password> --raw
+$ redis-cli --raw -h <endpoint> -p <port> -a <password>
 127.0.0.1:12543>
 ```
 
-The `--raw` option maintains the format of the database response.
+The `--raw` option forces the command to return raw output.
 
-### Create a JSON document
+### Create JSON documents
 
-Use the `JSON.SET` command to set a Redis key with a JSON value. A key can contain any valid JSON value, including scalars, objects, and arrays.
+You can use the [`JSON.SET`](https://redis.io/commands/json.set) command to create a JSON document.
 
-Set the key `shopping-list` to a simple JSON object containing the date the list was created.
-
-```sh
-127.0.0.1:12543> JSON.SET shopping-list $ '{"list-date" : "05/05/2022"}'
-OK
-```
-
-The second argument in `JSON.SET` is the path in the JSON object. The `$` or `.` character is the "root" of the JSON object. All new keys must have either `$` or `.` as the path.
-
-### Add info to a JSON document
-
-Now that you have a JSON object, use `JSON.SET` to add an entity to it. You can add any JSON entity type to a JSON object with `JSON.SET`.
-
-In the `shopping-list` JSON key, use `JSON.SET` to add an object with the path `.stores`. Use `JSON.SET` to add other objects to the `.stores` path to represent the stores you need to visit.
+Create a JSON document that represents a `shopping_list`:
 
 ```sh
-127.0.0.1:12543> JSON.SET shopping-list .stores '{}'
+127.0.0.1:12543> JSON.SET shopping_list $ '{"list_date" : "05/05/2022", "stores": {}'
 OK
 ```
 
-In each store, add an array of `items` that will represent the number of specific items you need to buy from those stores.
+The second argument in `JSON.SET` is the [JSON path](https://redis.io/docs/stack/json/path/). The `$` or `.` character represents the root of the JSON document. All elements with a JSON document are relative to the root.
+
+### Modify JSON documents
+
+You can also use [`JSON.SET`](https://redis.io/commands/json.set) to modify existing JSON documents and elements.
+
+Add each store with an array of `items` that you need to buy:
 
 ``` sh
-127.0.0.1:12543> JSON.SET shopping-list .stores.grocery-store '{ "items": [ { "name": "apples", "count": 5 } ] }'
+127.0.0.1:12543> JSON.SET shopping_list $.stores.grocery_store '{ "items": [ { "name": "apples", "count": 5 } ] }'
 OK
-127.0.0.1:12543> JSON.SET shopping-list .stores.hardware-store '{ "items": [ { "name": "hammers", "count": 1 } ] }'
-OK
-127.0.0.1:12543> JSON.SET shopping-list .stores.clothing-store '{ "items": [ { "name": "socks", "count": 2 } ] }'
+127.0.0.1:12543> JSON.SET shopping_list $.stores.clothing_store '{ "items": [ { "name": "socks", "count": 2 } ] }'
 OK
 ```
 
-Use `JSON.ARRAPPEND` to add more items to the `items` arrays. `JSON.ARRAPPEND` returns the number of objects in the array.
+Use [`JSON.ARRAPPEND`](https://redis.io/commands/json.arrappend) to add more items to the `items` arrays. `JSON.ARRAPPEND` returns the number of objects in the array.
 
 ``` sh
-127.0.0.1:12543> JSON.ARRAPPEND shopping-list .stores.grocery-store.items '{ "name" : "pears", "count" : 3 }'    
+127.0.0.1:12543> JSON.ARRAPPEND shopping_list $.stores.grocery_store.items '{ "name" : "pears", "count" : 3 }'    
 2
 ```
 
-Use `JSON.NUMINCRBY` to change the number of a specific item that you need. This returns the new value of the item.
+Use [`JSON.NUMINCRBY`](https://redis.io/commands/json.numincrby) to change the number of a specific item that you need. This returns the new value of the item.
 
 ```sh
-127.0.0.1:12543> JSON.NUMINCRBY shopping-list .stores.clothing-store.items[0].count 2    
+127.0.0.1:12543> JSON.NUMINCRBY shopping_list $.stores.clothing_store.items[0].count 2    
 4
-127.0.0.1:12543> JSON.NUMINCRBY shopping-list .stores.grocery-store.items[1] count -1
+127.0.0.1:12543> JSON.NUMINCRBY shopping_list $.stores.grocery_store.items[1].count -1
 2
 ```
 
-### Read a JSON document
+### Read JSON elements
 
-Use `JSON.GET` to read the JSON object from the database. If you connected to `redis-cli` with the `--raw` option, you can format the response to `JSON.GET` with the `INDENT`, `NEWLINE`, and `SPACE` options.
+Use [`JSON.GET`](https://redis.io/commands/json.get) to read the JSON object from the database. If you connected to `redis-cli` with the `--raw` option, you can format the response to `JSON.GET` with the `INDENT`, `NEWLINE`, and `SPACE` options.
+
+Run `JSON.GET` and pass the JSON root `$` as the path to retrieve the contents of the entire JSON document:
 
 ```sh
-127.0.0.1:12543> JSON.GET shopping-list . INDENT "\t" NEWLINE "\n" SPACE " "     
+127.0.0.1:12543> JSON.GET shopping_list $ INDENT "\t" NEWLINE "\n" SPACE " "     
 {
-    "list-date": "05/05/2022",
+    "list_date": "05/05/2022",
     "stores": {
-        "grocery-store": {
+        "grocery_store": {
             "items": [
                 {
                     "name": "apples",
@@ -108,15 +99,7 @@ Use `JSON.GET` to read the JSON object from the database. If you connected to `r
                 }
             ]
         },
-        "hardware-store": {
-            "items": [
-                {
-                    "name": "hammers",
-                    "count": 1
-                }
-            ]
-        },
-        "clothing-store": {
+        "clothing_store": {
             "items": [
                 {
                     "name": "socks",
@@ -130,8 +113,10 @@ Use `JSON.GET` to read the JSON object from the database. If you connected to `r
 
 You can also use `JSON.GET` to read a single entity or multiple entities with the same name from the JSON object.
 
+To only return the items from the `grocery_store` list, run:
+
 ```sh
-127.0.0.1:12543> JSON.GET shopping-list .grocery-store INDENT "\t" NEWLINE "\n"    
+127.0.0.1:12543> JSON.GET shopping_list $.stores.grocery_store INDENT "\t" NEWLINE "\n"    
 {
     "items":[
         {
@@ -144,70 +129,63 @@ You can also use `JSON.GET` to read a single entity or multiple entities with th
         }
     ]
 }
-127.0.0.1:12543> JSON.GET shopping-list $..items INDENT "\t" NEWLINE "\n"
+```
+
+To return all items from all stores on the shopping list, run:
+
+```sh
+127.0.0.1:12543> JSON.GET shopping_list $..items[*] INDENT "\t" NEWLINE "\n"
 [
-    [
-        {
-            "name":"apples",
-            "count":5
-        },
-        {
-            "name":"pears",
-            "count":2
-        }
-    ],
-    [
-        {
-            "name":"hammers",
-            "count":1
-        }
-    ],
-    [
-        {
-            "name":"socks",
-            "count":4
-        }
-    ]
+	{
+		"name":"apples",
+		"count":5
+	},
+	{
+		"name":"pears",
+		"count":2
+	},
+	{
+		"name":"hammers",
+		"count":1
+	},
+	{
+		"name":"socks",
+		"count":4
+	}
 ]
 ```
 
-Use `JSON.TYPE` to check the JSON type of the key or an entity inside the key.
+### Verify JSON type
+
+Use [`JSON.TYPE`](https://redis.io/commands/json.type) to check the JSON type of the key or an entity inside the key.
 
 ```sh
-127.0.0.1:12543> JSON.TYPE shopping-list
+127.0.0.1:12543> JSON.TYPE shopping_list
 object
-127.0.0.1:12543> JSON.TYPE shopping-list .stores.grocery-store.items
+127.0.0.1:12543> JSON.TYPE shopping_list $.stores.grocery_store.items
 array
-127.0.0.1:12543> JSON.TYPE shopping-list .stores.grocery-store.items[0].name
+127.0.0.1:12543> JSON.TYPE shopping_list $.stores.grocery_store.items[0].name
 string
 ```
 
-### Delete info from a JSON document
+### Delete JSON elements
 
-Use `JSON.DEL` to delete parts of the JSON document.
+Use [`JSON.DEL`](https://redis.io/commands/json.del) to delete parts of the JSON document.
 
 ```sh
-127.0.0.1:12543> JSON.DEL shopping-list .stores.clothing-store
+127.0.0.1:12543> JSON.DEL shopping_list $.stores.clothing_store
 1
-127.0.0.1:12543> JSON.DEL shopping-list .stores.grocery-store.items[1]
+127.0.0.1:12543> JSON.DEL shopping_list $.stores.grocery_store.items[1]
 1
-127.0.0.1:12543> JSON.GET shopping-list INDENT "\t" NEWLINE "\n"
+127.0.0.1:12543> JSON.GET shopping_list INDENT "\t" NEWLINE "\n"
 {
-    "list-date":"05/05/2022",
+    "list_date":"05/05/2022",
     "stores":{
-        "grocery-store":{
+        "grocery_store":{
             "items":[
                 {
                     "name":"apples",
                     "count":5
-                }
-            ]
-        },
-        "hardware-store":{
-            "items":[
-                {
-                    "name":"hammers",
-                    "count":1
                 }
             ]
         }
@@ -215,12 +193,12 @@ Use `JSON.DEL` to delete parts of the JSON document.
 }
 ```
 
-Use `JSON.DEL` with no specified path to delete the key.
+If you run `JSON.DEL` and don't specify a path, it will delete the entire JSON document.
 
 ```sh
-127.0.0.1:12543> JSON.DEL shopping-list
+127.0.0.1:12543> JSON.DEL shopping_list
 1
-127.0.0.1:12543> EXISTS shopping-list
+127.0.0.1:12543> EXISTS shopping_list
 0
 ```
 
@@ -243,29 +221,26 @@ r = redis.Redis(host="<endpoint>", port="<port>",
 # Create a JSON document
 print("Creating shopping list...")
 list_obj = {
-    'list-date': '05/05/2022'
+    'list_date': '05/05/2022'
 }
 
-r.json().set('shopping-list:py', '.', list_obj)
-reply = r.json().get('shopping-list:py', '.')
+r.json().set('shopping_list:py', '.', list_obj)
+reply = r.json().get('shopping_list:py', '.')
 print(json.dumps(reply, indent=4) + "\n")
 
 # Add info to the JSON document
 print("Adding stores and starting items...")
 stores_obj = {
-    "grocery-store" : {
+    "grocery_store" : {
         "items" : [ { "name": "apples", "count": 5 } ]
     },
-    "hardware-store" : {
-        "items": [ { "name": "hammers", "count": 1 } ]
-    },
-    "clothing-store" : {
+    "clothing_store" : {
         "items": [ { "name": "socks", "count": 2 } ]
     }
 }
 
-r.json().set('shopping-list:py', '.stores', stores_obj)
-reply = r.json().get('shopping-list:py', '.')
+r.json().set('shopping_list:py', '.stores', stores_obj)
+reply = r.json().get('shopping_list:py', '.')
 print(json.dumps(reply, indent=4) + "\n")
 
 # Add new items to the list
@@ -275,35 +250,35 @@ pears_obj = {
     "count" : 3
 }
 
-r.json().arrappend('shopping-list:py', '.stores.grocery-store.items',
+r.json().arrappend('shopping_list:py', '.stores.grocery_store.items',
                     pears_obj)
-reply = r.json().get('shopping-list:py', '.')
+reply = r.json().get('shopping_list:py', '.')
 print(json.dumps(reply, indent=4) + "\n")
 
 # Increment item counts
 print("Changing item counts...")
-r.json().numincrby('shopping-list:py',
-                    '.stores.clothing-store.items[0].count', 2)
-r.json().numincrby('shopping-list:py',
-                    '.stores.grocery-store.items[1].count', -1)
-reply = r.json().get('shopping-list:py', '.')
+r.json().numincrby('shopping_list:py',
+                    '.stores.clothing_store.items[0].count', 2)
+r.json().numincrby('shopping_list:py',
+                    '.stores.grocery_store.items[1].count', -1)
+reply = r.json().get('shopping_list:py', '.')
 print(json.dumps(reply, indent=4) + "\n")
 
 # Get all items no matter which heading they're under
 print("Getting all items...")
-reply = r.json().get('shopping-list:py', '$..items')
+reply = r.json().get('shopping_list:py', '$..items')
 print(json.dumps(reply, indent=4) + "\n")
 
 # Delete specific parts of the document
 print("Deleting clothing store and pears...")
-r.json().delete('shopping-list:py', '.stores.clothing-store')
-r.json().delete('shopping-list:py', '.stores.grocery-store.items[1]')
-reply = r.json().get('shopping-list:py', '.')
+r.json().delete('shopping_list:py', '.stores.clothing_store')
+r.json().delete('shopping_list:py', '.stores.grocery_store.items[1]')
+reply = r.json().get('shopping_list:py', '.')
 print(json.dumps(reply, indent=4) + "\n")
 
 # Delete the JSON document key
-print("Deleting shopping-list:py key...")
-r.json().delete('shopping-list:py')
+print("Deleting shopping_list:py key...")
+r.json().delete('shopping_list:py')
 print("Done!")
 ```
 
@@ -312,14 +287,14 @@ Example output:
 $ python3 quick_start.py
 Creating shopping list...
 {
-    "list-date": "05/05/2022"
+    "list_date": "05/05/2022"
 }
 
 Adding stores and starting items...
 {
-    "list-date": "05/05/2022",
+    "list_date": "05/05/2022",
     "stores": {
-        "grocery-store": {
+        "grocery_store": {
             "items": [
                 {
                     "name": "apples",
@@ -327,15 +302,7 @@ Adding stores and starting items...
                 }
             ]
         },
-        "hardware-store": {
-            "items": [
-                {
-                    "name": "hammers",
-                    "count": 1
-                }
-            ]
-        },
-        "clothing-store": {
+        "clothing_store": {
             "items": [
                 {
                     "name": "socks",
@@ -348,9 +315,9 @@ Adding stores and starting items...
 
 Adding pears...
 {
-    "list-date": "05/05/2022",
+    "list_date": "05/05/2022",
     "stores": {
-        "grocery-store": {
+        "grocery_store": {
             "items": [
                 {
                     "name": "apples",
@@ -362,15 +329,7 @@ Adding pears...
                 }
             ]
         },
-        "hardware-store": {
-            "items": [
-                {
-                    "name": "hammers",
-                    "count": 1
-                }
-            ]
-        },
-        "clothing-store": {
+        "clothing_store": {
             "items": [
                 {
                     "name": "socks",
@@ -383,9 +342,9 @@ Adding pears...
 
 Changing item counts...
 {
-    "list-date": "05/05/2022",
+    "list_date": "05/05/2022",
     "stores": {
-        "grocery-store": {
+        "grocery_store": {
             "items": [
                 {
                     "name": "apples",
@@ -397,15 +356,7 @@ Changing item counts...
                 }
             ]
         },
-        "hardware-store": {
-            "items": [
-                {
-                    "name": "hammers",
-                    "count": 1
-                }
-            ]
-        },
-        "clothing-store": {
+        "clothing_store": {
             "items": [
                 {
                     "name": "socks",
@@ -444,28 +395,20 @@ Getting all items...
 
 Deleting clothing store and pears...
 {
-    "list-date": "05/05/2022",
+    "list_date": "05/05/2022",
     "stores": {
-        "grocery-store": {
+        "grocery_store": {
             "items": [
                 {
                     "name": "apples",
                     "count": 5
                 }
             ]
-        },
-        "hardware-store": {
-            "items": [
-                {
-                    "name": "hammers",
-                    "count": 1
-                }
-            ]
         }
     }
 }
 
-Deleting shopping-list:py key...
+Deleting shopping_list:py key...
 Done!
 ```
 


### PR DESCRIPTION
Updated RedisJSON quick start:
- Updated examples to use JSONPath instead of legacy path
- Streamlined/clarified examples
- Fixed reported bugs (DOC-1515)
- Copy edits
- Added links for commands and JSON path syntax

[Staged preview](https://docs.redis.com/staging/jira-doc-1540/modules/redisjson/redisjson-quickstart/)