### PR TITLE
Change RedisJSON v2.2 release notes to a draft

### DIFF
--- a/content/modules/redisjson/release-notes/redisjson-2.2-release-notes.md
+++ b/content/modules/redisjson/release-notes/redisjson-2.2-release-notes.md
@@ -7,6 +7,7 @@ min-version-rs: "6.0.0"
 weight: 98
 alwaysopen: false
 categories: ["Modules"]
+draft: true
 ---
 ## Requirements
 


### PR DESCRIPTION
Changed RedisJSON v2.2 release notes to a draft to hide them from the ToC for now.

[Staged preview](https://docs.redis.com/staging/json-release-notes/modules/redisjson/release-notes/)