### PR TITLE
Avoid label selector in operator deployment verification

### DIFF
--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -101,7 +101,7 @@ kubectl apply -f https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8
 Check the operator deployment to verify it's running in your namespace:
 
 ```sh
-kubectl get deployment -l name=redis-enterprise-operator
+kubectl get deployment redis-enterprise-operator
 ```
 
 You should see a result similar to this:


### PR DESCRIPTION
The existing documentation includes a command to verify the operator deployment is running, which uses a label selector for a label that isn't set on the operator deployment. This PR fixes the command to address the deployment by its name.