### PR TITLE
K8s 6.2.12-1 release notes

### DIFF
--- a/content/kubernetes/release-notes/k8s-6-2-12-1.md
+++ b/content/kubernetes/release-notes/k8s-6-2-12-1.md
@@ -1,17 +1,17 @@
 ---
-Title: Redis Enterprise for Kubernetes release notes 6.2.10-45 (July 2022)
-linktitle: 6.2.10-45 (July 2022)
-description: Support added for additional distributions as well as some feature improvements. 
-weight: 62
+Title: Redis Enterprise for Kubernetes release notes 6.2.12-1 (Sept 2022)
+linktitle: 6.2.12-1 (Sept 2022)
+description: Support added for additional distributions, as well as feature improvements and bug fixes. 
+weight: 61
 alwaysopen: false
 categories: ["Platforms"]
 aliases: [
-    /kubernetes/release-notes/k8s-6-2-10-45-2022-02.md,
-    /kubernetes/release-notes/k8s-6-2-10-45-2022-02/,   ]
+    /kubernetes/release-notes/k8s-6-2-12-1.md,
+    /kubernetes/release-notes/k8s-6-2-12-1/,   ]
 ---
 ## Overview
 
-The Redis Enterprise K8s 6.2.10-45 supports the Redis Enterprise Software release 6.2.10 and includes feature improvements and bug fixes.
+The Redis Enterprise K8s 6.2.12-1 supports the Redis Enterprise Software release 6.2.12 and includes feature improvements and bug fixes.
 
 The key bug fixes and known limitations are described below.
 
@@ -19,63 +19,71 @@ The key bug fixes and known limitations are described below.
 
 This release includes the following container images:
 
-* **Redis Enterprise**: `redislabs/redis:6.2.10-129` or  `redislabs/redis:6.2.10-129.rhel8-openshift` (or `redislabs/redis:6.2.10-129.rhel7-openshift` if upgrading from a RHEL7 cluster)
-* **Operator**: `redislabs/operator:6.2.10-45`
-* **Services Rigger**: `redislabs/k8s-controller:6.2.10-45` or `redislabs/services-manager:6.2.10-45` (on the Red Hat registry)
+* **Redis Enterprise**: `redislabs/redis:6.2.12-82` or  `redislabs/redis:6.2.12-82.rhel8-openshift`
+* **Operator**: `redislabs/operator:6.2.12-1`
+* **Services Rigger**: `redislabs/k8s-controller:6.2.12-1` or `redislabs/services-manager:6.2.12-1` (on the Red Hat registry)
 
 ## Feature improvements
 
-* OpenShift OperatorLifecycleManager support on restricted networks (RED-72968)
-* `log_collector` script uses `oc` command with automatic detection of OpenShift (RED-73215)
-* Operator uses `policy/v1` for `PodDisruptionBudget`(RED-78564)
-* Added support for Kubernetes distributions (see Compatibility notes below)
+* Redis Enterprise Software 6.2.12 support (RED-83829)
+* Added support for annotations on services created by Redis Enterprise (RED-56245)
+* Support for additional builds of same Redis Software version with same operator version. The list of supported builds will be published. (RED-78757)
 
-## Fixed bugs
 
-* Upgrade failures when RHEL7 was used (RED-77890)
-* Log collector failures when Python2 was used (RED-73403)
+## Bug fixes
+
+* Fixed Golang related vulnerabilities (RED-79205)
+* Log collector creating larger packages (RED-79650)
+* Log collector crashes when Redis Enterprise cluster is not running (RED-79996)
 
 ## API changes
 
-The `digestHash` optional field added to `imageSpec` fields in the REC. This field should be used in disconnected environments using the OperatorLifecycleManager.
+The Redis Enterprise cluster `podSecurityPolicy` is deprecated. This is still supported but will be removed when all K8s versions supporting the feature are removed.
 
 ## Compatibility notes
 
 Below is a table showing supported distributions at the time of this release. See [Supported Kubernetes distributions]({{< relref "/kubernetes/reference/supported_k8s_distributions.md" >}}) for the current list of supported distributions.
 
-| **Kubernetes version**  | 1.19       | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
-|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Community Kubernetes    |            |            | deprecated | supported  | supported  | supported* |
-| Amazon EKS              | deprecated | deprecated | supported  | supported* |            |
-| Azure AKS               |            |            | deprecated | supported  | supported  |
-| Google GKE              | deprecated | deprecated | supported  | supported  |supported*  |
-| Rancher 2.6             | deprecated | deprecated | supported  | supported  |            |
-| **OpenShift version**   | **4.6**    | **4.7**    | **4.8**    | **4.9**    | **4.10**   |
-|                         |            | deprecated | deprecated | supported  | supported  |
-| **VMware TKGI version** | **1.10**   | **1.11**   | **1.12**   | **1.13**   |            |
+| **Kubernetes version**  | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
+|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|
+ | Community Kubernetes   |            |            | supported  | supported  | supported |
+| Amazon EKS              |            | deprecated | supported  | supported* |
+| Azure AKS               |            |            | supported  | supported  | supported* |
+| Google GKE              |            | deprecated | supported  | supported  | supported* |
+| Rancher 2.6             |            | supported  | supported  | supported* |            |
+| **OpenShift version**   | **4.7**    | **4.8**    | **4.9**    | **4.10**   | **4.11**   |
+|                         | deprecated | deprecated | supported  | supported  | supported* |
+| **VMware TKGI version** | **1.11**   | **1.12**   | **1.13**   | **1.14**   | **1.15**   |
 |                         | deprecated | deprecated | supported* | supported* |            |
 
 \* Support added in this release  
 
 ### Support added
 
-* K8s community version 1.24
+* Azure AKS 1.24
+* Amazon EKS 1.23
+* Google GKE 1.24
+* OpenShift 4.11
+* Rancher 1.23
+* VMware TKGI 1.14
 
 ### Deprecated
 
-* OpenShift 4.7-4.8
-* Kubernetes 1.20
-* Rancher 2.6 for K8s 1.19-1.20
-* TKGI 1.10-11
+* Amazon EKS 1.21
+* Google GKE 1.21
+* OpenShift 4.7
+* OpenShift 4.8
+* VMware TKGI 1.11
+* VMware TKGI 1.12
 
 ### No longer supported
 
-* OpenShift 4.6 (previously deprecated)
-* Kubernetes 1.18-1.19 (previously deprecated)
-* Rancher 2.6 for K8s 1.18 (previously deprecated)
-* AKS 1.20-1.21 (previously deprecated)
-* EKS 1.18-1.19 (previously deprecated)
-* GKE 1.19 (previously deprecated)
+* Community Kubernetes 1.21
+* Amazon EKS 1.19, 1.20
+* Azure AKS 1.21
+* Google GKE 1.19, 1.20
+* Rancher 2.6 1.19, 1.20
+* VMware TKGI 1.10
 
 ## Known limitations
 
@@ -145,7 +153,7 @@ Below is a table showing supported distributions at the time of this release. Se
 
 * Following old revision of quick start guide causes issues creating an REDB due to unrecognized memory field name (RED-69515)
 
-The workaround is to use the newer (current) revision of the quick start document available online.
+  The workaround is to use the newer (current) revision of the quick start document available online.
 
 * `autoUpgrade` set to true by operator might cause unexpected bdb upgrades when `redisUpgradePolicy` is set to true (RED-72351)
 
@@ -153,3 +161,9 @@ The workaround is to use the newer (current) revision of the quick start documen
 
 * Procedure to update credentials might be problematic on OpenShift when accessing the cluster externally using routes (RS issue)(RED-73251)(RED-75329)
   To workaround this, access the API from within the K8s cluster.
+
+* On Windows, `log_collector` doesn't recognize the namespace given with the `-n` flag (RED-83532)
+
+  To workaround this, use a different operating system.
+
+* Active-Active database creation will fail if the ingress class annotation is not exactly "nginx" when using Nginx ingress controller (RED-83070)


### PR DESCRIPTION
Jira: DOC-1615
Staged preview: https://docs.redis.com/staging/jira-doc-1615/kubernetes/release-notes/k8s-6-2-12-1/

Version build number might still change. Using 6.2.12-1 until I hear otherwise.