### PR TITLE
Fixed format of Terraform VPC peering note

### DIFF
--- a/content/rc/security/vpc-peering.md
+++ b/content/rc/security/vpc-peering.md
@@ -52,7 +52,7 @@ To set up VPC peering:
 1. You can provide up to five VPC CIDRs.
     
     {{< note >}}
-    The [Redis Cloud Terraform provider](https://registry.terraform.io/providers/RedisLabs/rediscloud/latest/docs) currently supports one VPC CIDR.  Additional CIDRs defined by the console will be removed by Terraform.
+The [Redis Cloud Terraform provider](https://registry.terraform.io/providers/RedisLabs/rediscloud/latest/docs) currently supports one VPC CIDR.  Additional CIDRs defined by the console will be removed by Terraform.
     {{< /note >}}
     
     To add multiple VPC CIDRs:


### PR DESCRIPTION
I noticed an issue with the formatting of a note in the VPC peering doc. This change should fix the formatting bug.

[Staged preview](https://docs.redis.com/staging/vpc-peering-format-patch/rc/security/vpc-peering/)