### PR TITLE
RS - DOC-1616: v6.2.18 release notes and supporting docs (#2156)

### DIFF
--- a/content/rs/release-notes/rs-6-2-18.md
+++ b/content/rs/release-notes/rs-6-2-18.md
@@ -1,0 +1,168 @@
+---
+Title: Redis Enterprise Software release notes 6.2.18 (September 2022)
+linkTitle: 6.2.18 (September 2022)
+description: Database auditing.  Private key encryption.  Active-Active database support for MEMORY USAGE command.  Improvements to crdb-cli
+compatibleOSSVersion: Redis 6.2.6
+weight: 73
+alwaysopen: false
+categories: ["RS"]
+aliases: /rs/release-notes/rs-6-2-18/
+         /rs/release-notes/rs-6-2-18.md
+---
+
+[Redis Enterprise Software version 6.2.18](https://redislabs.com/redis-enterprise-software/download-center/software/) is now available! 
+
+This version of Redis Enterprise Software offers:
+
+- Database connection auditing
+- Private key encryption
+- Active-Active support for `memory usage` command
+- `crdb-cli` improvements
+- Compatibility with open source Redis v6.2.6
+- Additional enhancements and fixes
+
+The following table shows the MD5 checksums for the available packages.
+
+|Package| MD5 Checksum |
+|:------|:-------------|
+| Ubuntu 16 | `055973eb7009073b0c199ec1dfd81018` |
+| Ubuntu 18 | `8c37c6ae10b0ae4956e3c11db80d18ce` |
+| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | `c770a66d9bfdd8734f1208d64aa67784` |
+| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 | `85eb6339f837205d83f215e32c1d028f` |
+
+## Features and enhancements
+
+### Database connection auditing
+
+You can now [audit database connection]({{<relref "/rs/security/audit-events">}}) and authentication events to track and troubleshoot activity.  Administrators can now use third-party systems to track and analyze connection events in realtime.  
+
+### Private key encryption
+
+When enabled, private key encryption encrypts private keys stored in the cluster configuration store (CCS).  Private keys are encrypted using a secure, self-contained internal process.  Databases must be at least version 6.2.2 or later to use this feature.
+
+### Active-Active support for MEMORY USAGE command
+
+Redis Enteprise Active-Active databases now support the [MEMORY USAGE](https://redis.io/commands/memory-usage/) command, which simplifies troubleshooting and lets applications detect anomalous behavior and dangerous trends.
+
+MEMORY USAGE reports the RAM memory use, in bytes, of a key and its value.  The result includes the memory allocated for the data value and the administrative overhead associated with the key.
+
+### `crdb-cli` improvements
+
+The `crdb-cli` utility used to manage Active-Active databases now allows greater visibility into management operations to make it easier to investigate and troubleshoot problems. You can now use:
+
+- `crdb-cli task list` to retrieve details about current and previous tasks for all Active-Active databases on a cluster
+
+- `crdb-cli task --task-id <task-id>` to get detailed information about a specific task.
+
+To learn more, see [`crdb-cli`]({{<relref "/rs/references/cli-utilities/crdb-cli">}})
+
+## Version changes 
+
+### Breaking changes
+
+RS84006 - When using the REST API to create a database, this specific set of conditions can lead to an error:
+
+- sharding is enabled
+- oss_sharding and implicit_shard_key are both deactivated
+- A shard_key_regex is _not_ defined
+
+If this occurs, the database endpoint returns `(error) ERR key "test" does not match any rule`.
+
+To address this issue, do one of the following:
+
+- Explicitly define shard_key_regex
+- Enable oss_sharing or implicit_shard_key (enabling both also works) 
+
+
+### Prerequisites and notes 
+
+-  You can [upgrade to v6.2.18](https://docs.redis.com/latest/rs/installing-upgrading/upgrading/) from Redis Enterprise Software v6.0 and later. 
+
+- Refer to [v6.2.4 release notes](https://docs.redis.com/latest/rs/release-notes/rs-6-2-4-august-2021/) for important notes regarding changes made to the upgrade policy and how those changes might impct your experience. 
+
+- Upgrades from versions earlier than v6.0 are not supported.
+
+- If you plan to upgrade your cluster to RHEL 8, see the [v6.2.8 release notes](https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2021/) for known limitations.
+
+### Future deprecation notice
+
+#### TLS 1.0 and TLS 1.1 
+
+TLS 1.0 and TLS 1.1 connections are considered deprecated in favor of TLS 1.2 or later.  
+
+Please verify that all clients, apps, and connections support TLS 1.2.  Support for the earlier protocols will be removed in a future release.
+
+Certain operating systems, such as RHEL 8, have already removed support for the earlier protocols.  Redis Enterprise Software cannot support connection protocols that are not supported by the underlying operating system.
+
+### Product lifecycle updates 
+
+Redis Enterprise Software v6.0.x reached end-of-life (EOL) on May 31, 2022.
+
+Redis Enterprise Software 6.2.x EOL has been extended by six (6) months.  The new EOL date is August 31, 2023.
+
+To learn more, see the Redis Enterprise Software [product lifecycle](https://docs.redis.com/latest/rs/administering/product-lifecycle/), which details the release number and the end-of-life schedule for Redis Enterprise Software.
+
+For Redis modules information and lifecycle, see [Module lifecycle](https://docs.redis.com/latest/modules/modules-lifecycle/).
+
+## Redis modules 
+
+Redis Enterprise Software v6.2.12 includes the following Redis modules:
+
+- [RediSearch v2.4.11](https://docs.redis.com/latest/modules/redisearch/release-notes/)
+- [RedisJSON v2.2.0](https://docs.redis.com/latest/modules/redisjson/release-notes/)
+- [RedisBloom v2.2.18](https://docs.redis.com/latest/modules/redisbloom/release-notes/)
+- [RedisGraph v2.8.17](https://docs.redis.com/latest/modules/redisgraph/release-notes/)
+- [RedisTimeSeries v1.6.17](https://docs.redis.com/latest/modules/redistimeseries/release-notes/)
+
+For help upgrading a module, see [Add a module to a cluster](https://docs.redis.com/latest/modules/add-module-to-cluster/#upgrading-the-module-for-the-database). 
+
+## Additional enhancements
+
+- Added support for the MODULE LIST command on Active-Active databases
+- Enhanced validity checks of the input parameters of the CRDB-CLI tool
+- The Syncer lag calculation has been improved and fixes multiple miscalculations
+- Support package includes additional information for Active-Active databases
+- Added the ability to retrieve the syncer mode (centralized / distributed) by running   
+
+    `rladmin info db [{db:<id> | <name>}]`  
+
+    To learn more, see [Distributed sychronization]({{<relref "/rs/databases/active-active/synchronization-mode">}})   
+
+## Resolved issues 
+
+- RS64002 - Fixes email alerts for LDAP mappings. 
+- RS79519 - fixes a bug that prevented Administrators from editing an Active-Active database using the API with username instead of email as their identifier.
+- RS78039 - fixes a bug that caused the sync between two shards to pause when resetting a shard's data which can be when performing full sync or importing an RDB.
+- RS73454 - Updates internal timeouts to enable faster resharding.
+- RS75783 - Fixes failover due to false identification of dead nodes when master node goes down.
+- RS75206, RS52686 - Fixes backup_interval_offset in case where the user chose an offset that is higher than backup_interval; Fixes the UI from resetting backup_interval_offset after manual DB configuration.
+- RS75176 - Fixes rare case of stuck state machine during “maintenance off”.
+- RS57200 - Add an IP address to "failed_authentication_attempt" errors.
+- RS56615 - Changed rladmin tune db db_name max_aof_load_time to receive the value in seconds; Added max_aof_load_time option to rladmin help tune.
+- RS54745 - Fixes the Rest API to reject BDB creation using negative integers as a uid.
+- RS46092 - Fixes rlcheck failure when somaxconn policy is a value other than 1024.
+- RS68965, RS80615 - Adds internode encryption ports 3340-3344 to rlcheck connectivity.
+- RS63302 - Adds umask validation for root user when installing.
+- RS46947 - Fixes removal of old installations in install.sh.
+
+## Known limitations
+
+- RS81463 A shard may crash when resharding an Active-Active database with Redis on Flash (RoF). Specifically, the shard will crash when volatile keys or Active-Active tombstone keys reside in Flash memory.
+
+- RS54131 Returning +OK reply from the QUIT command on a TLS enabled database
+
+## Security
+
+### Open Source Redis Security fixes compatibility
+
+As part of Redis commitment to security, Redis Enterprise Software implements the latest [security fixes](https://github.com/redis/redis/releases) available with open source Redis. The following [Open Source Redis](https://github.com/redis/redis) [CVEs](https://github.com/redis/redis/security/advisories) do not affect Redis Enterprise:
+
+- [CVE-2021-32625](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32625) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis since Redis Enterprise does not implement LCS. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.4, Redis 6.0.14)
+
+- [CVE-2021-32672](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32672) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the LUA debugger is unsupported in Redis Enterprise. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)
+
+- [CVE-2021-32675](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32675) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the proxy in Redis Enterprise does not forward unauthenticated requests. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)
+
+- [CVE-2021-32762](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32762) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the memory allocator used in Redis Enterprise is not vulnerable. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16)
+
+- [CVE-2021-41099](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41099) - Redis Enterprise is not impacted by the CVE that was found and fixed in open source Redis because the proto-max-bulk-len CONFIG is blocked in Redis Enterprise. Additional information about the open source Redis fix is on [the Redis GitHub page](https://github.com/redis/redis/releases) (Redis 6.2.6, Redis 6.0.16) security fixes for [recent CVEs](https://github.com/redis/redis/security/advisories). Redis Enterprise has already included the fixes for the relevant CVEs. Some CVEs announced for Open Source Redis do not affect Redis Enterprise due to different and additional functionality available in Redis Enterprise that is not available in Open Source Redis.

--- a/content/rs/security/audit-events.md
+++ b/content/rs/security/audit-events.md
@@ -1,0 +1,227 @@
+---
+title: Audit connection events
+linkTitle: Audit events
+description: Describes how to audit connection events. 
+weight: 15
+alwaysopen: false
+categories: ["RS"]
+aliases: [ "/rs/security/audit-connections/",
+           "/rs/security/audit-connections.md/",
+           "/rs/security/audit-events.md" ]
+---
+
+Starting with version 6.2.18, Redis Enterprise Software lets you audit database connection and authentication events.  This helps you track and troubleshoot connection activity.
+
+The following events are tracked:
+
+- Database connection attempts
+- Authentication requests, including requests for new and existing connections
+- Database disconnects
+
+When tracked events are triggered, notifications are sent via TCP to an address and port defined when auditing is enabled.  Notifications appear in the near real-time and are intended to be consumed by an external listener, such as a TCP listener, third-party service, or related utility.
+
+For development and testing environments, notifications can be saved to a local file; however, this is neither supported nor intended for production environments.
+
+For performance reasons, auditing is disabled by default.  In addition, auditing occurs in the background (asynchronously) and is non-blocking by design.  That is, the action that triggered the notification continues without regard to the status of the notification or the listening tool.  
+
+## Enable audit notifications
+
+### Cluster audits
+
+To audit all databases in your cluster, you can use:
+
+- `rladmin`
+
+    ```
+    rladmin tune cluster config auditing db_conns \
+       audit_protocol <TCP|local> \
+       audit_address <address> \
+       audit_port <port>
+    ```
+
+    where:
+
+    - _audit_protocol_ indicates the protocol used to process notifications.  For production systems, _TCP_ is the only supported value.
+
+    - _audit_address_ defines the TCP/IP address where one can listen for notifications
+
+    - _audit_port_ defines the port where one can listen for notifications
+
+- the REST API
+
+    ```
+    PUT /v1/cluster/auditing/db_conns
+    { 
+        "audit-address":"<address>", 
+        "audit-port":<port>, 
+        "audit_protocol":"TCP" 
+    }
+    ```
+
+    where `<address>` is a string containing the TCP/IP address and `<port`> is a numeric value representing the port.
+
+### Database audits
+
+To audit a single database, you can use:
+
+- `rladmin`
+
+    ```
+    rladmin tune db db:<id|name> db_conns_auditing enabled
+    ```
+
+    where the value of the _db:_ parameter is either the cluster ID of the database or the database name.
+
+    To deactivate auditing, set `db_conns_auditing` to `disabled`.
+
+    Use `rladmin info` to retrieve additional details:
+
+    ```
+    rladmin info db <id|name>
+    rladmin info cluster
+    ```
+
+- the REST API
+
+    ```
+    PUT /v1/bdb/1
+    { "db_conns_auditing":"enabled" }
+    ```
+
+    To disable auditing, set `db_conns_auditing` to `disabled`.
+
+### Policy defaults for new databases
+
+To audit connections for new databases by default, use:
+
+- `rladmin`
+
+    ```
+    rladmin tune cluster db_conns_auditing enabled
+    ```
+
+    To deactivate this policy, set `db_conns_auditing` to `disabled`.
+
+- the REST API
+
+    ```
+    PUT /v1/cluster/policy
+    { "db_conns_auditing":true }
+    ```
+
+    To deactivate this policy, set `db_conns_auditing` to `false`.
+
+## Notification examples
+
+Audit event notifications are reported as JSON objects.
+
+### New connection
+
+This example reports a new connection for a database:
+
+``` json
+{
+    "ts":1655821384,
+    "new_conn":
+    {
+        "id":2285001002 ,
+        "srcip":"127.0.0.1",
+        "srcp":"39338",
+        "trgip":"127.0.0.1",
+        "trgp":"12635",
+        "hname":"",
+        "bdb_name":"DB1",
+        "bdb_uid":"5"
+    }
+}
+```
+
+### Authentication request
+
+Here is a sample authentication request for a database:
+
+``` json
+{
+    "ts":1655821384,
+    "action":"auth",
+    "id":2285001002 ,
+    "srcip":"127.0.0.1",
+    "srcp":"39338",
+    "trgip":"127.0.0.1",
+    "trgp":"12635",
+    "hname":"",
+    "bdb_name":"DB1",
+    "bdb_uid":"5",
+    "status":2,
+    "username":"user_one",
+    "identity":"user:1",
+    "acl-rules":"~* +@all"
+}
+```
+
+State reports success or failure.  Values of `2` or `8` indicate success; other values indicate failure.
+
+### Database disconnect
+
+Here's what's reported when a database connection is closed:
+
+``` json
+{
+    "ts":1655821384,
+    "close_conn":
+    {
+        "id":2285001002,
+        "srcip":"127.0.0.1",
+        "srcp":"39338",
+        "trgip":"127.0.0.1",
+        "trgp":"12635",
+        "hname":"",
+        "bdb_name":"DB1",
+        "bdb_uid":"5"
+    }
+}
+```
+
+## Notification field reference
+
+The field value that appears immediately after the timestamp describes the action that triggered the notification.  The following values may appear:
+
+- `new_conn` indicates a new external connection
+- `new_int_conn` indicates a new internal connection 
+- `close_conn` occurs when a connection is closed
+- `"action":"auth"` indicates an authentication request and can refer to new authentication requests or authorization checks on existing connections
+
+In addition, the following fields may also appear in audit event notifications:
+
+| Field&nbsp;name | Description |
+|:---------:|-------------|
+| `acl-rules` | ACL rule associated with the connection, which includes a rule for the `default` user. |
+| `bdb_name` | Destination database name - the name of the database being accessed | 
+| `bdb_uid` | Destination database ID - The cluster ID of the database being accessed | 
+| `hname` | Client hostname - The hostname of the client.  Currently empty; reserved for future use. |
+| `id` | Connection ID - Unique connection ID assigned by the proxy |
+| `identity` | Identity - A unique ID value assigned by the proxy to the user for the current connection. |
+| `srcip` | Source IP address - Source TCP/IP address of the client accessing the Redis database |
+| `srcp` | Source port - Port associated with the source IP address accessing the Redis database.  Can be combined with the address to uniquely identify the socket. |
+| `status` | Status result code - An integer representing the result of an authentication request. |
+| `trgip` | Target IP address - The IP address of the destination being accessed by the action |
+| `trgp` | Target port - The port of the destination being access by the action.  Can be combined with the destination IP address to uniquely identify the database being accessed. |
+| `ts`  | Timestamp - The date and time of the event, in [Coordinated Universal Time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) (UTC).  Granularity is within one millisecond (ms). |
+| `username` | Authentication username  - Username associated with the connection; can include `default` for databases that allow default access.  (Passwords are _not_ recorded). |
+
+## Status result codes
+
+The `status` field reports the results of an authentication request as an integer.  Here's what different values mean:
+
+| Error&nbsp;value | Error code | Description | 
+|:-------------:|------------|-------------|
+| `0` | AUTHENTICATION_FAILED | Invalid username and/or password |
+| `1` | AUTHENTICATION_FAILED_TOO_LONG | Username or password are too long |
+| `2` | AUTHENTICATION_NOT_REQUIRED | Client tried to authenticate, but authentication isn't necessary. | 
+| `3` | AUTHENTICATION_DIRECTORY_PENDING | Attempt to receive authentication info from Directory in async mode |
+| `4` | AUTHENTICATION_DIRECTORY_ERROR | Authentication attempt failed because there was a directory connection error |
+| `5` | AUTHENTICATION_SYNCER_IN_PROGRESS | Syncer SASL handshake, return SASL response and wait for next request | 
+| `6` | AUTHENTICATION_SYNCER_FAILED | Syncer SASL handshake, return SASL response and close the connection |
+| `7` | AUTHENTICATION_SYNCER_OK | Syncer authenticated. Return SASL response |
+| `8` | AUTHENTICATION_OK | Client successfully authenticated
+

--- a/content/rs/security/internode-encryption.md
+++ b/content/rs/security/internode-encryption.md
@@ -2,7 +2,7 @@
 title: Internode encryption
 linkTitle: Internode encryption
 description: Describes internode which improves the security of data in transit. 
-weight: 10
+weight: 15
 alwaysopen: false
 categories: ["RS"]
 aliases: /rs/security/internode-encryption/


### PR DESCRIPTION
* Initial draft

* Update rs-6-2-18.md

Removed RHEL 8.6 (its from 6.2.12)
Added MD5 values
Changed the audit (we do not track historical events only real time, but the data is kept and allows admin to analyze it later) Changed the "breaking change" notice a bit to reflect that this is not a common or desired situation

* Update rs-6-2-18.md

* Update rs-6-2-18.md

* Update rs-6-2-18.md

* Updating audit events article

* Additional updates/edits

* Moar edits/fixes

Co-authored-by: adisht <36517802+adisht@users.noreply.github.com>