### PR TITLE
K8s: update supported distros

### DIFF
--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -35,16 +35,16 @@ Each release of the Redis Enterprise operator is thoroughly tested against a set
 - "deprecated" indicates this distribution is supported for this release, but will be dropped in a future release.
 - Any distribution not listed below is not supported for production workloads.
 
-| **Kubernetes version**  | 1.19       | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
-|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|:----------:|
-| Community Kubernetes    |            | deprecated | deprecated | supported  | supported  | supported* |
-| Amazon EKS              | deprecated | deprecated | supported  | supported* |            |
-| Azure AKS               |            |            | deprecated | supported  | supported  |
-| Google GKE              | deprecated | deprecated | supported  | supported  |supported*  |
-| Rancher 2.6             | deprecated | deprecated | supported  | supported  |            |
-| **OpenShift version**   | **4.6**    | **4.7**    | **4.8**    | **4.9**    | **4.10**   |
-|                         |            | deprecated | deprecated | supported  | supported  |
-| **VMware TKGI version** | **1.10**   | **1.11**   | **1.12**   | **1.13**   |            |
+| **Kubernetes version**  | 1.20       | 1.21       | 1.22       | 1.23       | 1.24       |
+|:------------------------|:----------:|:----------:|:----------:|:----------:|:----------:|
+ | Community Kubernetes   |            |            | supported  | supported  | supported |
+| Amazon EKS              |            | deprecated | supported  | supported* |
+| Azure AKS               |            |            | supported  | supported  | supported* |
+| Google GKE              |            | deprecated | supported  | supported  | supported* |
+| Rancher 2.6             |            | supported  | supported  | supported* |            |
+| **OpenShift version**   | **4.7**    | **4.8**    | **4.9**    | **4.10**   | **4.11**   |
+|                         | deprecated | deprecated | supported  | supported  | supported* |
+| **VMware TKGI version** | **1.11**   | **1.12**   | **1.13**   | **1.14**   | **1.15**   |
 |                         | deprecated | deprecated | supported* | supported* |            |
 
-\* Support added in most recent release  
+\* Support added in this release  


### PR DESCRIPTION
Update supported distros to current 6.2.12-1 release values. 
