### PR TITLE
Release notes for K8s RoF preview

### DIFF
--- a/content/kubernetes/release-notes/k8s-rof-preview.md
+++ b/content/kubernetes/release-notes/k8s-rof-preview.md
@@ -1,0 +1,17 @@
+---
+Title: Redis on Flash for Kubernetes public preview
+linktitle: Redis on Flash preview
+description: This is the public preview for Redis on Flash support on Kubernetes. 
+weight: 60
+alwaysopen: false
+categories: ["Platforms"]
+aliases: [
+    /kubernetes/release-notes/k8s-rof-preview.md,
+    /kubernetes/release-notes/k8s-rof-preview/,   ]
+---
+
+Redis on Flash (RoF) support for Redis Enterprise on Kubernetes is currently in public preview.
+
+Documentation for using flash storage with your [Redis Enterprise clusters (REC)]({{<relref "/kubernetes/reference/cluster-options.md">}}) and [Redis Enterprise databases (REDB)]({{<relref "/kubernetes/reference/db-options.md">}}) on Kubernetes is available on a [preview release page](https://docs.redis.com/staging/release-k8s-redis-on-flash/kubernetes/re-clusters/redis-on-flash/).
+
+For more information about Redis on Flash, see [Redis on Flash]({{<relref "/rs/databases/redis-on-flash/">}}) and [Get started with Redis on Flash]({{<relref "/rs/databases/redis-on-flash/getting-started-redis-flash.md">}}).


### PR DESCRIPTION
***waiting to publish until public preview begins***

This is a short release note for the public preview of Redis on Flash for K8s. It links to a preview site for detailed documentation: https://docs.redis.com/staging/release-k8s-rof-preview/kubernetes/re-clusters/redis-on-flash/

This page will be removed/replaced when RoF reaches GA. 