### PR TITLE
Update rs-6-2-18.md

### DIFF
--- a/content/rs/release-notes/rs-6-2-18.md
+++ b/content/rs/release-notes/rs-6-2-18.md
@@ -27,10 +27,10 @@ The following table shows the MD5 checksums for the available packages.
 
 |Package| MD5 Checksum |
 |:------|:-------------|
-| Ubuntu 16 | `055973eb7009073b0c199ec1dfd81018` |
-| Ubuntu 18 | `8c37c6ae10b0ae4956e3c11db80d18ce` |
-| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | `c770a66d9bfdd8734f1208d64aa67784` |
-| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 | `85eb6339f837205d83f215e32c1d028f` |
+| Ubuntu 16 | `89029a28a2b0e3ad379559b94d00ae32` |
+| Ubuntu 18 | `830e8704c0f6902a04df9ff53cc5e41f` |
+| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | `766d2f8448fc28d0ea67cac20387a9e3` |
+| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 | `7e31fb3e3416b404513dad508669f836` |
 
 ## Features and enhancements
 
@@ -129,6 +129,11 @@ For help upgrading a module, see [Add a module to a cluster](https://docs.redis.
     `rladmin info db [{db:<id> | <name>}]`  
 
     To learn more, see [Distributed sychronization]({{<relref "/rs/databases/active-active/synchronization-mode">}})   
+
+## Enhancements added in build 49
+
+- Added Support to getting the primary (master) node indication from the API (RS82566)
+- Added metrics to track certificates expiration time (RS56040)
 
 ## Resolved issues 
 

--- a/content/rs/release-notes/rs-6-2-18.md
+++ b/content/rs/release-notes/rs-6-2-18.md
@@ -132,7 +132,7 @@ For help upgrading a module, see [Add a module to a cluster](https://docs.redis.
 
 ## Enhancements added in build 49
 
-- Added Support to getting the primary (master) node indication from the API (RS82566)
+- The `nodes/status` REST API endpoint indicates whether a node is the primary.  (RS82566)
 - Added metrics to track certificates expiration time (RS56040)
 
 ## Resolved issues 


### PR DESCRIPTION
Build 49 - updated the MD5 and added 2 enhancements:
- Added Support to getting the primary (master) node indication from the API (RS82566)
- Added metrics to track certificates expiration time (RS56040)