### PR TITLE
DOC-1703: Fixed 404s in Monitoring entry page

### DIFF
--- a/content/rs/clusters/monitoring/_index.md
+++ b/content/rs/clusters/monitoring/_index.md
@@ -78,4 +78,4 @@ To send cluster or database alerts by email:
 
 1. In **settings** > **alerts**, select **Receive email alerts** at the bottom of the page.
 1. Configure the [email server settings]({{< relref "/rs/clusters/configure/cluster-settings#configuring-email-server-settings" >}}).
-1. In **access control**, select for each user [the database and cluster alerts]({{< relref "/rs/security/access-control/manage-users" >}}) that you want the user to receive.
+1. In **access control**, select the [database and cluster alerts]({{< relref "/rs/security/access-control/manage-users" >}}) that you want each user to receive.

--- a/content/rs/clusters/monitoring/_index.md
+++ b/content/rs/clusters/monitoring/_index.md
@@ -77,5 +77,5 @@ To enable alerts for a database:
 To send cluster or database alerts by email:
 
 1. In **settings** > **alerts**, select **Receive email alerts** at the bottom of the page.
-1. Configure the [email server settings]({{< relref "/rs/administering/cluster-operations/settings/_index.md" >}}).
-1. In **access control**, select for each user [the database and cluster alerts]({{< relref "/rs/administering/designing-production/access-control/_index.md" >}}) that you want the user to receive.
+1. Configure the [email server settings]({{< relref "/rs/clusters/configure/cluster-settings#configuring-email-server-settings" >}}).
+1. In **access control**, select for each user [the database and cluster alerts]({{< relref "/rs/security/access-control/manage-users" >}}) that you want the user to receive.


### PR DESCRIPTION
Staging link: https://docs.redis.com/staging/jira-doc-1703/rs/clusters/monitoring/#sending-alerts-by-email

The last two links in the article were pointing to pages that are no longer there.