### PR TITLE
Pub/sub command compatibility

### DIFF
--- a/content/rs/references/compatibility/commands/pub-sub.md
+++ b/content/rs/references/compatibility/commands/pub-sub.md
@@ -1,0 +1,27 @@
+---
+Title: Pub/sub commands compatibility
+linkTitle: Pub/sub
+description: Pub/sub commands compatibility.
+weight: 10
+alwaysopen: false
+categories: ["RS"]
+aliases: 
+---
+
+The following table shows which open source Redis [pub/sub commands](https://redis.io/commands/?group=pubsub) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Enterprise Cloud.
+
+| Command | Redis<br />Enterprise | Redis<br />Cloud | Notes |
+|:--------|:----------------------|:-----------------|:------|
+| [PSUBSCRIBE](https://redis.io/commands/psubscribe) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUBLISH](https://redis.io/commands/publish) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUBSUB CHANNELS](https://redis.io/commands/pubsub-channels) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUBSUB NUMPAT](https://redis.io/commands/pubsub-numpat) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUBSUB NUMSUB](https://redis.io/commands/pubsub-numsub) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUBSUB SHARDCHANNELS](https://redis.io/commands/pubsub-shardchannels) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUBSUB SHARDNUMSUB](https://redis.io/commands/pubsub-shardnumsub) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [PUNSUBSCRIBE](https://redis.io/commands/punsubscribe) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [SPUBLISH](https://redis.io/commands/spublish) | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+| [SSUBSCRIBE](https://redis.io/commands/ssubscribe) | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+| [SUBSCRIBE](https://redis.io/commands/subscribe) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |
+| [SUNSUBSCRIBE](https://redis.io/commands/sunsubscribe) | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+| [UNSUBSCRIBE](https://redis.io/commands/unsubscribe) | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> | <span title="Supported">&#x2705; Standard</span><br /><span title="Supported"><nobr>&#x2705; Active-Active</nobr></span> |  |


### PR DESCRIPTION
Initial compatibility table for OSS Redis pub/sub commands and Redis Enterprise Software/Cloud.

[Staged preview](https://docs.redis.com/staging/jira-doc-1675/rs/references/compatibility/commands/pub-sub/)