### PR TITLE
Update create.md to fix database naming criteria

### DIFF
--- a/content/rs/databases/create.md
+++ b/content/rs/databases/create.md
@@ -56,7 +56,7 @@ To create a new database:
 
         - Maximum of 63 characters
         - Only letter, number or hyphen (-) characters
-        - Starts with a letter; ends with a letter or digit.
+        - Starts with a letter or digit; ends with a letter or digit.
 
         {{< note >}}
 The database name is not case-sensitive


### PR DESCRIPTION
The UI enforces that the following for the database name: "Database name must be up to 63 characters long, include only letters, digits, or hyphen ('-'), start with a letter or digit, and end with a letter or digit."

This edit makes the docs consistent with the create criteria