### PR TITLE
RS certificates table

### DIFF
--- a/content/kubernetes/security/manage-rec-certificates.md
+++ b/content/kubernetes/security/manage-rec-certificates.md
@@ -11,15 +11,7 @@ aliases: [
 ]
 ---
 
-By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster.
-
-Below are the names of certificates used by Redis Enterprise Software and the traffic they encrypt:
-
-- `proxy` - for connections between clients and database endpoints
-- `api` - for REST API calls
-- `cm` - for connections to the management admin console
-- `syncer` - for Active-Active and Replica Of synchronization between Redis Enterprise clusters
-- `metrics_exporter` - for exporting metrics to Prometheus
+By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{<relref "/rs/security/certificates">}}).
 
 To install and use your own certificates with Kubernetes on your Redis Enterprise cluster, they need to be stored in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). The REC custom resource also needs to be configured with those secret names to read and use the certificates.
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/certificate.md
@@ -20,13 +20,7 @@ rladmin cluster certificate
         [ key_file <key filepath> ]
 ```
 
-To set a certificate for a specific service, use the corresponding certificate name:
-
-- `cm` for the admin console
-- `api` for the REST API
-- `proxy` for the proxy, which manages connections between clients and database endpoints
-- `syncer` for the syncer, which synchronizes data between clusters (using either Active-Active or Active-Passive replication)
-- `metrics_exporter` for the metrics exporter, which sends metrics to Prometheus
+To set a certificate for a specific service, use the corresponding certificate name. See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of cluster certificates and their descriptions.
 
 ### Parameters
 

--- a/content/rs/references/rest-api/requests/cluster/certificates/_index.md
+++ b/content/rs/references/rest-api/requests/cluster/certificates/_index.md
@@ -71,7 +71,7 @@ Returns a JSON object that contains the cluster's certificates and keys.
 
 Removes the specified cluster certificate from both CCS and disk
 across all nodes. Only optional certificates can be deleted through
-this endpoint.
+this endpoint. See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of cluster certificates and their descriptions.
 
 ### Request {#delete-request} 
 

--- a/content/rs/references/rest-api/requests/cluster/update-cert.md
+++ b/content/rs/references/rest-api/requests/cluster/update-cert.md
@@ -26,6 +26,8 @@ PUT /v1/cluster/update_cert
 
 Replaces an existing certificate on all nodes within the cluster with a new certificate. The new certificate must pass validation before it can replace the old certificate.
 
+See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of cluster certificates and their descriptions.
+
 ### Request {#put-request}
 
 #### Example HTTP request

--- a/content/rs/security/certificates/_index.md
+++ b/content/rs/security/certificates/_index.md
@@ -14,11 +14,11 @@ Here's the list of self-signed certificates that create secure, encrypted connec
 
 | Certificate name | Description |
 |------------------|-------------|
-| api | Encrypts [REST API]({{<relref "/rs/references/rest-api/">}}) requests and responses. |
-| cm | Secures connections to the Redis Enterprise admin console. |
-| metrics_exporter | Sends Redis Enterprise metrics to external [monitoring tools]({{<relref "/rs/clusters/monitoring/">}}) over a secure connection. |
-| proxy | Creates secure, encrypted connections between clients and databases. |
-| syncer | For [Active-Active]({{<relref "/rs/databases/active-active/">}}) or [Replica Of]({{<relref "rs/databases/import-export/replica-of/">}}) databases, encrypts data during the synchronization of participating clusters. |
+| `api` | Encrypts [REST API]({{<relref "/rs/references/rest-api/">}}) requests and responses. |
+| `cm` | Secures connections to the Redis Enterprise admin console. |
+| `metrics_exporter` | Sends Redis Enterprise metrics to external [monitoring tools]({{<relref "/rs/clusters/monitoring/">}}) over a secure connection. |
+| `proxy` | Creates secure, encrypted connections between clients and databases. |
+| `syncer` | For [Active-Active]({{<relref "/rs/databases/active-active/">}}) or [Replica Of]({{<relref "rs/databases/import-export/replica-of/">}}) databases, encrypts data during the synchronization of participating clusters. |
 
 These self-signed certificates are generated on the first node of each Redis Enterprise Software installation and are copied to all other nodes added to the cluster.
 

--- a/content/rs/security/certificates/_index.md
+++ b/content/rs/security/certificates/_index.md
@@ -10,13 +10,15 @@ aliases:
 
 Redis Enterprise Software uses self-signed certificates by default to ensure that the product is secure. If using a self-signed certificate is not the right solution for you, you can import a certificate signed by a certificate authority of your choice.
 
-The self-signed certificates establish encryption-in-transit for the following cluster components:
+Here's the list of self-signed certificates that create secure, encrypted connections to your Redis Enterprise cluster:
 
-- The admin console
-- The REST API
-- The proxy, which manages connections between clients and database endpoints
-- The syncer, which synchronizes data between clusters (using either Active-Active or Active-Passive replication)
-- The metrics exporter, which sends metrics to Prometheus
+| Certificate name | Description |
+|------------------|-------------|
+| api | Encrypts [REST API]({{<relref "/rs/references/rest-api/">}}) requests and responses. |
+| cm | Secures connections to the Redis Enterprise admin console. |
+| metrics_exporter | Sends Redis Enterprise metrics to external [monitoring tools]({{<relref "/rs/clusters/monitoring/">}}) over a secure connection. |
+| proxy | Creates secure, encrypted connections between clients and databases. |
+| syncer | For [Active-Active]({{<relref "/rs/databases/active-active/">}}) or [Replica Of]({{<relref "rs/databases/import-export/replica-of/">}}) databases, encrypts data during the synchronization of participating clusters. |
 
 These self-signed certificates are generated on the first node of each Redis Enterprise Software installation and are copied to all other nodes added to the cluster.
 

--- a/content/rs/security/certificates/create-certificates.md
+++ b/content/rs/security/certificates/create-certificates.md
@@ -44,9 +44,4 @@ You will be prompted for a Country Name, State or Province Name, Locality Name, 
         key_file <key-file-name>.pem
     ```
 
-    The certificate names are as follows: 
-      - For the admin console: `cm`
-      - For the REST API: `api`
-      - For the proxy: `proxy`
-      - For the syncer: `syncer`
-      - For the metrics exporter: `metrics_exporter`
+    See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of valid certificate names.

--- a/content/rs/security/certificates/create-certificates.md
+++ b/content/rs/security/certificates/create-certificates.md
@@ -36,7 +36,8 @@ You will be prompted for a Country Name, State or Province Name, Locality Name, 
 
 4. Upload the certificate to the cluster.
 
-    Use the `rladmin` command-line utility to upload the certificate to the cluster and replace the current certificate. You'll run the `cluster certificate set` command, followed by the name of the certificate to set, the certificate filename, and the key filename.
+    To upload the new certificate and replace the current certificate with the [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin">}}) command-line utility,
+    run the [`cluster certificate set`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/certificate">}}) command:
 
     ```sh
     rladmin cluster certificate set <cert-name> \
@@ -44,4 +45,8 @@ You will be prompted for a Country Name, State or Province Name, Locality Name, 
         key_file <key-file-name>.pem
     ```
 
-    See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of valid certificate names.
+    Replace the following variables with your own values:
+    
+    - `<cert-name>` - The name of the certificate to update. See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of valid certificate names.
+    - `<cert-file-name>` - The certificate filename 
+    - `<key-file-name>` - The key filename

--- a/content/rs/security/certificates/updating-certificates.md
+++ b/content/rs/security/certificates/updating-certificates.md
@@ -16,7 +16,7 @@ When you update the certificates, the new certificate replaces the same certific
 
 ## How to update certificates
 
-You can use either the `rladmin` command-line interface (CLI) or the REST API to update certificates.
+You can use either the [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin">}}) command-line interface (CLI) or the [REST API]({{<relref "/rs/references/rest-api">}}) to update certificates.
 
 The new certificates are used the next time the clients connect to the database.
 
@@ -24,7 +24,7 @@ When you upgrade Redis Enterprise Software, the upgrade process copies the certi
 
 ### Use the CLI
 
-To replace certificates with the `rladmin` CLI, run:
+To replace certificates with the `rladmin` CLI, run the [`cluster certificate set`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/certificate">}}) command:
 
 ```sh
  rladmin cluster certificate set <cert-name> certificate_file <cert-file-name>.pem key_file <key-file-name>.pem
@@ -36,7 +36,7 @@ Replace the following variables with your own values:
 - `<cert-file-name>` - The name of your certificate file
 - `<key-file-name>` - The name of your key file
 
-For example, to replace the cm certificate with the private key "key.pem" and the certificate file "cluster.pem":
+For example, to replace the admin console (`cm`) certificate with the private key `key.pem` and the certificate file `cluster.pem`:
 
 ```sh
 rladmin cluster certificate set cm certificate_file cluster.pem key_file key.pem

--- a/content/rs/security/certificates/updating-certificates.md
+++ b/content/rs/security/certificates/updating-certificates.md
@@ -32,12 +32,7 @@ To replace certificates with the `rladmin` CLI, run:
 
 Replace the following variables with your own values:
 
-- `<cert-name>` - The name of the certificate you want to replace:
-  - For the admin console: `cm`
-  - For the REST API: `api`
-  - For the database endpoint: `proxy`
-  - For the syncer: `syncer`
-  - For the metrics exporter: `metrics_exporter`
+- `<cert-name>` - The name of the certificate you want to replace. See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of valid certificate names.
 - `<cert-file-name>` - The name of your certificate file
 - `<key-file-name>` - The name of your key file
 
@@ -58,12 +53,7 @@ PUT https://[host][:port]/v1/cluster/update_cert
 
 Replace the following variables with your own values:
 
-- `<cert_name>` - The name of the certificate to replace:
-  - For the admin console: `cm`
-  - For the REST API: `api`
-  - For the database endpoint: `proxy`
-  - For the syncer: `syncer`
-  - For the metrics exporter: `metrics_exporter`
+- `<cert_name>` - The name of the certificate to replace. See the [certificates table]({{<relref "/rs/security/certificates">}}) for the list of valid certificate names.
 - `<key>` - The contents of the \*\_key.pem file
 
     {{< tip >}}


### PR DESCRIPTION
Initial RS certificates updates:
- Created a certificates table intended to be the source of truth for self-signed certificate names in RS.
- Added a more detailed description for each certificate.
- Replaced repeated certificate lists scattered throughout the docs with links to the main certificates table.

[Staged preview](https://docs.redis.com/staging/jira-doc-1807/rs/security/certificates/)