### PR TITLE
RS /nodes/status REST API requests

### DIFF
--- a/content/rs/installing-upgrading/upgrading.md
+++ b/content/rs/installing-upgrading/upgrading.md
@@ -82,9 +82,9 @@ Before upgrading a cluster:
 
 - Identify the cluster master node and upgrade that node first.
 
-    Use the [`rladmin status nodes`]({{<relref "/rs/references/cli-utilities/rladmin/status#status-nodes">}}) command to identify the master node.
+    Use the [`rladmin status nodes`]({{<relref "/rs/references/cli-utilities/rladmin/status#status-nodes">}}) command or send a [`GET /nodes/status`]({{<relref "/rs/references/rest-api/requests/nodes/status#get-all-nodes-status">}}) request to the [REST API]({{<relref "/rs/references/rest-api">}}) to identify the master node.
 
-## Cluster upgrade process
+### Cluster upgrade process
 
 Starting with the master node, follow these steps for every node in the cluster.  (We recommend upgrading each node separately to ensure cluster availability.)
 

--- a/content/rs/references/rest-api/objects/node.md
+++ b/content/rs/references/rest-api/objects/node.md
@@ -32,6 +32,7 @@ An API object that represents a node in the cluster.
 | public_addr | string | Public IP address of node |
 | rack_id | string | Rack ID where node is installed |
 | recovery_path | string | Recovery files path |
+| role | 'master'<br/>'slave' | The node's current role in the cluster<br />**master:** a primary node<br />**slave:** a replica node |
 | shard_count | integer | Number of shards on the node (read-only) |
 | shard_list | array of integers | Cluster unique IDs of all node shards |
 | software_version | string | Installed Redis Enterprise cluster software version (read-only) |

--- a/content/rs/references/rest-api/objects/node.md
+++ b/content/rs/references/rest-api/objects/node.md
@@ -32,7 +32,6 @@ An API object that represents a node in the cluster.
 | public_addr | string | Public IP address of node |
 | rack_id | string | Rack ID where node is installed |
 | recovery_path | string | Recovery files path |
-| role | 'master'<br/>'slave' | The node's current role in the cluster<br />**master:** a primary node<br />**slave:** a replica node |
 | shard_count | integer | Number of shards on the node (read-only) |
 | shard_list | array of integers | Cluster unique IDs of all node shards |
 | software_version | string | Installed Redis Enterprise cluster software version (read-only) |

--- a/content/rs/references/rest-api/requests/nodes/status.md
+++ b/content/rs/references/rest-api/requests/nodes/status.md
@@ -1,0 +1,106 @@
+---
+Title: Node status requests
+linkTitle: status
+description: Node status requests
+weight: $weight
+alwaysopen: false
+headerRange: "[1-2]"
+categories: ["RS"]
+aliases: /rs/references/rest-api/nodes/status
+         /rs/references/rest-api/nodes/status.md
+         /rs/references/restapi/nodes/status
+         /rs/references/restapi/nodes/status.md
+         /rs/references/rest_api/nodes/status
+         /rs/references/rest_api/nodes/status.md
+---
+
+| Method | Path | Description |
+|--------|------|-------------|
+| [GET](#get-all-nodes-status) | `/v1/nodes/status` | Get the status of all nodes |
+| [GET](#get-node-status) | `/v1/nodes/{uid}/status` | Get a node's status |
+
+## Get all node statuses {#get-all-nodes-status}
+
+	GET /v1/nodes/status
+
+Get the status of all nodes in the cluster.
+
+#### Required permissions
+
+| Permission name |
+|-----------------|
+| [view_all_nodes_alerts]({{<relref "/rs/references/rest-api/permissions#view_all_nodes_alerts">}}) |
+
+### Request {#get-all-request} 
+
+#### Example HTTP request
+
+	GET /nodes/status
+
+#### Request headers
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| Host | cnm.cluster.fqdn | Domain name |
+| Accept | application/json | Accepted media type |
+
+### Response {#get-all-response} 
+
+Returns an array of [node objects]({{<relref "/rs/references/rest-api/objects/node">}}).
+
+#### Example JSON body
+
+```json
+
+```
+
+### Status codes {#get-all-status-codes} 
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | No error |
+
+
+## Get node status {#get-node-status}
+
+	GET /v1/nodes/{int: uid}/status
+
+Get the status of a specific node.
+
+#### Required permissions
+
+| Permission name |
+|-----------------|
+| [view_node_alerts]({{<relref "/rs/references/rest-api/permissions#view_node_alerts">}}) |
+
+### Request {#get-request} 
+
+#### Example HTTP request
+
+	GET /nodes/1/status
+
+
+#### Request headers
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| Host | cnm.cluster.fqdn | Domain name |
+| Accept | application/json | Accepted media type |
+
+
+### Response {#get-response} 
+
+Returns a [node object]({{<relref "/rs/references/rest-api/objects/node">}}).
+
+#### Example JSON body
+
+```json
+
+```
+
+### Status codes {#get-status-codes} 
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | No error |
+| [404 Not Found](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) | Specified alert or node does not exist |

--- a/content/rs/references/rest-api/requests/nodes/status.md
+++ b/content/rs/references/rest-api/requests/nodes/status.md
@@ -1,9 +1,10 @@
 ---
 Title: Node status requests
 linkTitle: status
-description: Node status requests
+description: Requests that return a node's hostname and role.
 weight: $weight
 alwaysopen: false
+toc: "true"
 headerRange: "[1-2]"
 categories: ["RS"]
 aliases: /rs/references/rest-api/nodes/status
@@ -23,13 +24,17 @@ aliases: /rs/references/rest-api/nodes/status
 
 	GET /v1/nodes/status
 
-Get the status of all nodes in the cluster.
+Gets the status of all nodes. Includes each node's hostname and role in the cluster:
+
+- Primary nodes return `"role": "master"`
+
+- Replica nodes return `"role": "slave"`
 
 #### Required permissions
 
 | Permission name |
 |-----------------|
-| [view_all_nodes_alerts]({{<relref "/rs/references/rest-api/permissions#view_all_nodes_alerts">}}) |
+| [view_node_info]({{<relref "/rs/references/rest-api/permissions#view_node_info">}}) |
 
 ### Request {#get-all-request} 
 
@@ -46,12 +51,25 @@ Get the status of all nodes in the cluster.
 
 ### Response {#get-all-response} 
 
-Returns an array of [node objects]({{<relref "/rs/references/rest-api/objects/node">}}).
+For each node in the cluster, returns a JSON object that contains the node's hostname and role.
 
 #### Example JSON body
 
 ```json
-
+{
+    "1": {
+        "hostname": "3d99db1fdf4b",
+        "role": "master"
+    },
+    "2": {
+        "hostname": "fc7a3d332458",
+        "role": "slave"
+    },
+    "3": {
+        "hostname": "b87cc06c830f",
+        "role": "slave"
+    }
+}
 ```
 
 ### Status codes {#get-all-status-codes} 
@@ -65,13 +83,17 @@ Returns an array of [node objects]({{<relref "/rs/references/rest-api/objects/no
 
 	GET /v1/nodes/{int: uid}/status
 
-Get the status of a specific node.
+Gets the status of a node. Includes the node's hostname and role in the cluster:
+
+- Primary nodes return `"role": "master"`
+
+- Replica nodes return `"role": "slave"`
 
 #### Required permissions
 
 | Permission name |
 |-----------------|
-| [view_node_alerts]({{<relref "/rs/references/rest-api/permissions#view_node_alerts">}}) |
+| [view_node_info]({{<relref "/rs/references/rest-api/permissions#view_node_info">}}) |
 
 ### Request {#get-request} 
 
@@ -88,14 +110,24 @@ Get the status of a specific node.
 | Accept | application/json | Accepted media type |
 
 
+#### URL parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| uid | integer | The node's unique ID. |
+
+
 ### Response {#get-response} 
 
-Returns a [node object]({{<relref "/rs/references/rest-api/objects/node">}}).
+Returns a JSON object that contains the node's hostname and role.
 
 #### Example JSON body
 
 ```json
-
+{
+    "hostname": "3d99db1fdf4b",
+    "role": "master"
+}
 ```
 
 ### Status codes {#get-status-codes} 
@@ -103,4 +135,4 @@ Returns a [node object]({{<relref "/rs/references/rest-api/objects/node">}}).
 | Code | Description |
 |------|-------------|
 | [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | No error |
-| [404 Not Found](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) | Specified alert or node does not exist |
+| [404 Not Found](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) | Node UID does not exist |

--- a/content/rs/release-notes/rs-6-2-18.md
+++ b/content/rs/release-notes/rs-6-2-18.md
@@ -162,7 +162,7 @@ For help upgrading a module, see [Add a module to a cluster](https://docs.redis.
 
 ## Enhancements added in 6.2.18-49 (October release)
 
-- The `nodes/status` REST API endpoint indicates whether a node is the primary.  (RS82566)
+- The [`/nodes/status`]({{<relref "/rs/references/rest-api/requests/nodes/status">}}) REST API endpoint indicates whether a node is the primary.  (RS82566)
 - Added metrics to track certificates expiration time (RS56040)
 
 ## Enhancements added in 6.2.18-58 (November release)


### PR DESCRIPTION
Staged previews:
- New [`/nodes/status` reference](https://docs.redis.com/staging/jira-doc-1704/rs/references/rest-api/requests/nodes/status/)
- Mentioned `/nodes/status` in [upgrade cluster prerequisites](https://docs.redis.com/staging/jira-doc-1704/rs/installing-upgrading/upgrading/#upgrade-prerequisites)
- Linked to `/nodes/status` reference in [v6.2.18 release notes](https://docs.redis.com/staging/jira-doc-1704/rs/release-notes/rs-6-2-18/#enhancements-added-in-6218-49-october-release)