### PR TITLE
K8s product name cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -112,7 +112,7 @@ To learn more, review the [merged pull requests](https://github.com/RedisLabs/re
 
 - Kubernetes doc updates:
 
-    - A new article shows how to [create Active-Active databases](https://docs.redis.com/latest/kubernetes/re-clusters/create-aa-database/) on Kubernetes ([PR #1555](https://github.com/RedisLabs/redislabs-docs/pull/1555))
+    - A new article shows how to [create Active-Active databases](https://docs.redis.com/latest/kubernetes/re-clusters/create-aa-database/) for Kubernetes ([PR #1555](https://github.com/RedisLabs/redislabs-docs/pull/1555))
 
     - Docs have been updated to support Redis Enterprise for [Kubernetes v6.2.8-2](https://docs.redis.com/latest/kubernetes/release-notes/k8s-6-2-8-2-2021-11/) ([PR #1648](https://github.com/RedisLabs/redislabs-docs/pull/1648))
 
@@ -198,7 +198,7 @@ To learn more, review the [merged pull requests](https://github.com/RedisLabs/re
 
     - Updated docs to support the K8s [6.2.4-1 release](https://docs.redis.com/latest/platforms/release-notes/k8s-6-2-4-1-2021-09/). ([PR #1527](https://github.com/RedisLabs/redislabs-docs/pull/1527)) 
 
-    - [Manage Redis Enterprise databases on Kubernetes](https://docs.redis.com/latest/platforms/kubernetes/redb/db-controller/) has been updated. ([PR #1524](https://github.com/RedisLabs/redislabs-docs/pull/1524)) 
+    - [Manage Redis Enterprise databases for Kubernetes](https://docs.redis.com/latest/platforms/kubernetes/redb/db-controller/) has been updated. ([PR #1524](https://github.com/RedisLabs/redislabs-docs/pull/1524)) 
 
     - A new article shows how to [connect to the admin console](https://docs.redis.com/latest/platforms/kubernetes/rec/connect-to-admin-console/) to manage the Redis Enterprise cluster in your Kubernetes deployment.  ([PR #1529](https://github.com/RedisLabs/redislabs-docs/pull/1529))
 

--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -19,7 +19,7 @@ Make sure your system meets these requirements:
 | <nobr>Rocky Linux 8</nobr> | Based on RHEL 8 |
 | Amazon Linux |Version 1 |
 | Docker | [Docker images]({{< relref "/rs/installing-upgrading/get-started-docker.md" >}}) of Redis Enterprise Software are certified for development and testing only. |
-| Kubernetes | See the [Redis Enterprise Software on Kubernetes documentation]({{< relref "/kubernetes/_index.md" >}}) |
+| Kubernetes | See the [Redis Enterprise for Kubernetes documentation]({{< relref "/kubernetes/_index.md" >}}) |
 
 Be aware that Redis Enterprise Software relies on certain components that require support from the operating system.  You cannot enable support for components, services, protocols, or versions that aren't supported by the operating system running Redis Enterprise Software.  In addition, updates to the operating system or to Redis Enterprise Software can impact component support.
 

--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -176,7 +176,7 @@ More info: [Redis Enterprise durability and high availability]({{<relref "/rs/da
 {{%definition "ingress"%}}
 An API object that manages external access to the services in a Kubernetes cluster, typically HTTP.
 
-More info: [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), [Ingress routing for Redis Enterprise Software on Kubernetes]({{<relref "/kubernetes/re-databases/set-up-ingress-controller.md">}})
+More info: [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), [Ingress routing for Redis Enterprise for Kubernetes]({{<relref "/kubernetes/re-databases/set-up-ingress-controller.md">}})
 {{%/definition%}}
 
 ## K, L {#letter-k}

--- a/content/kubernetes/_index.md
+++ b/content/kubernetes/_index.md
@@ -22,6 +22,6 @@ aliases: [
 ]
 ---
 
-Kubernetes provides enterprise orchestration of containers and has been widely adopted. Redis Enterprise for Kubernetesprovides a simple way to get a Redis Enterprise cluster on Kubernetes and enables more complex deployment scenarios.
+Kubernetes provides enterprise orchestration of containers and has been widely adopted. Redis Enterprise for Kubernetes provides a simple way to get a Redis Enterprise cluster on Kubernetes and enables more complex deployment scenarios.
 
 {{< allchildren style="h2" description="true" />}}

--- a/content/kubernetes/_index.md
+++ b/content/kubernetes/_index.md
@@ -1,6 +1,6 @@
 ---
 Title: Redis Enterprise for Kubernetes
-linkTitle: Redis Enterprise on Kubernetes
+linkTitle: Redis Enterprise for Kubernetes
 description: The Redis Enterprise operators allows you to use Redis Enterprise for Kubernetes. 
 weight: 50
 alwaysopen: false

--- a/content/kubernetes/_index.md
+++ b/content/kubernetes/_index.md
@@ -1,7 +1,7 @@
 ---
-Title: Redis Enterprise Software on Kubernetes
+Title: Redis Enterprise for Kubernetes
 linkTitle: Redis Enterprise on Kubernetes
-description: The Redis Enterprise operators allows you to use Redis Enterprise Software on Kubernetes. 
+description: The Redis Enterprise operators allows you to use Redis Enterprise for Kubernetes. 
 weight: 50
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/_index.md
+++ b/content/kubernetes/_index.md
@@ -22,6 +22,6 @@ aliases: [
 ]
 ---
 
-Kubernetes provides enterprise orchestration of containers and has been widely adopted. The Redis Enterprise operator for Kubernetes provides a simple way to get a Redis Enterprise cluster on Kubernetes and enables more complex deployment scenarios.
+Kubernetes provides enterprise orchestration of containers and has been widely adopted. Redis Enterprise for Kubernetesprovides a simple way to get a Redis Enterprise cluster on Kubernetes and enables more complex deployment scenarios.
 
 {{< allchildren style="h2" description="true" />}}

--- a/content/kubernetes/architecture/_index.md
+++ b/content/kubernetes/architecture/_index.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Enterprise Software on Kubernetes architecture
+Title: Redis Enterprise for Kubernetes architecture
 linkTitle: Architecture
 description: This section provides an overview of the architecture and considerations for Redis Enterprise on Kubernetes.
 weight: 11

--- a/content/kubernetes/architecture/_index.md
+++ b/content/kubernetes/architecture/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes architecture
 linkTitle: Architecture
-description: This section provides an overview of the architecture and considerations for Redis Enterprise on Kubernetes.
+description: This section provides an overview of the architecture and considerations for Redis Enterprise for Kubernetes.
 weight: 11
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/architecture/operator.md
+++ b/content/kubernetes/architecture/operator.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Enterprise Software on Kubernetes operator-based architecture
+Title: Redis Enterprise for Kubernetes operator-based architecture
 linkTitle: What is an operator?
 description: This section provides a description of the design of the Redis Enterprise operator for Kubernetes.
 weight: 30

--- a/content/kubernetes/architecture/operator.md
+++ b/content/kubernetes/architecture/operator.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise for Kubernetes operator-based architecture
 linkTitle: What is an operator?
-description: This section provides a description of the design of the Redis Enterprise operator for Kubernetes.
+description: This section provides a description of the design of Redis Enterprise for Kubernetes.
 weight: 30
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/architecture/operator.md
+++ b/content/kubernetes/architecture/operator.md
@@ -14,7 +14,7 @@ aliases: {
     /kubernetes/architecture/operator/,
 }
 ---
-The Redis Enterprise operator is the fastest, most efficient way to
+Redis Enterprise is the fastest, most efficient way to
 deploy and maintain a Redis Enterprise cluster in Kubernetes.
 
 ## What is an operator?

--- a/content/kubernetes/deployment/_index.md
+++ b/content/kubernetes/deployment/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: Deployment
 linkTitle: Deployment
-description: This section lists the different ways to set up and run Redis Enterprise on Kubernetes. You can deploy on variety of Kubernetes   
+description: This section lists the different ways to set up and run Redis Enterprise for Kubernetes. You can deploy on variety of Kubernetes   
   distributions both on-prem and in the cloud via our Redis Enterprise operator for Kubernetes.
 weight: 11
 alwaysopen: false
@@ -18,7 +18,7 @@ aliases: [
 ]
 ---
 
-This section lists the different ways to set up and run Redis Enterprise on Kubernetes. You can deploy on variety of Kubernetes distributions both on-prem and in the cloud via our Redis Enterprise operator for Kubernetes.
+This section lists the different ways to set up and run Redis Enterprise for Kubernetes. You can deploy on variety of Kubernetes distributions both on-prem and in the cloud via our Redis Enterprise operator for Kubernetes.
 
 ## Operator overview {#overview}
 

--- a/content/kubernetes/deployment/_index.md
+++ b/content/kubernetes/deployment/_index.md
@@ -22,7 +22,7 @@ This section lists the different ways to set up and run Redis Enterprise for Kub
 
 ## Operator overview {#overview}
 
-The Redis Enterprise operator uses [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) (CRDs) to create and manage Redis Enterprise clusters (REC) and Redis Enterprise databases (REDB).
+Redis Enterprise for Kubernetes uses [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) (CRDs) to create and manage Redis Enterprise clusters (REC) and Redis Enterprise databases (REDB).
 
 The operator is a deployment that runs within a given namespace. These operator pods must run with sufficient privileges to create the Redis Enterprise cluster resources within that namespace.
 

--- a/content/kubernetes/deployment/deployment-options.md
+++ b/content/kubernetes/deployment/deployment-options.md
@@ -20,7 +20,7 @@ Multiple Redis Enterprise database resources (REDB) can be associated with singl
 
 ## Single REC and single namespace (one-to-one)
 
-The standard and simplest deployment deploys your Redis Enterprise databases (REDB) in the same namespace as the Redis Enterprise cluster (REC). No additional configuration is required for this, since there is no communication required to cross namespaces. See [Deploy Redis Enterprise Software on Kubernetes]({{<relref "/kubernetes/deployment/quick-start.md">}}).
+The standard and simplest deployment deploys your Redis Enterprise databases (REDB) in the same namespace as the Redis Enterprise cluster (REC). No additional configuration is required for this, since there is no communication required to cross namespaces. See [Deploy Redis Enterprise for Kubernetes]({{<relref "/kubernetes/deployment/quick-start.md">}}).
 
 ![One-to-one deployment option](/images/platforms/k8s-deploy-one-to-one.png)
 

--- a/content/kubernetes/deployment/openshift/_index.md
+++ b/content/kubernetes/deployment/openshift/_index.md
@@ -1,5 +1,5 @@
 ---
-Title: Deploy Redis Enterprise Software on Kubernetes with OpenShift
+Title: Deploy Redis Enterprise for Kubernetes with OpenShift
 linkTitle: OpenShift
 description: A quick introduction to the steps necessary to get a Redis Enterprise
   cluster installed in your OpenShift Kubernetes cluster

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -1,5 +1,5 @@
 ---
-Title: Deployment with OpenShift CLI for Redis Enterprise Software on Kubernetes
+Title: Deployment with OpenShift CLI for Redis Enterprise for Kubernetes
 linkTitle: OpenShift CLI
 description: The Redis Enterprise operator and cluster can be installed via CLI tools
   OpenShift

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -1,7 +1,7 @@
 ---
 Title: Deployment with OpenShift CLI for Redis Enterprise for Kubernetes
 linkTitle: OpenShift CLI
-description: The Redis Enterprise operator and cluster can be installed via CLI tools
+description: Redis Enterprise for Kubernetes and cluster can be installed via CLI tools
   OpenShift
 weight: 60
 alwaysopen: false

--- a/content/kubernetes/deployment/openshift/openshift-operatorhub.md
+++ b/content/kubernetes/deployment/openshift/openshift-operatorhub.md
@@ -163,7 +163,7 @@ After the approval, the status of the resources installed is updated.
 
 ### Next steps
 
-After you install the Redis Enterprise operator into a project you can:
+After you install Redis Enterprise for Kubernetes into a project you can:
 
 - Navigate to the installed version and use the **Create New** button to create a
   new cluster in your namespace.

--- a/content/kubernetes/deployment/openshift/openshift-operatorhub.md
+++ b/content/kubernetes/deployment/openshift/openshift-operatorhub.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Enterprise Software on Kubernetes deployment with the OpenShift OperatorHub
+Title: Redis Enterprise for Kubernetes deployment with the OpenShift OperatorHub
 linkTitle: OpenShift OperatorHub
 description: OpenShift provides the OperatorHub where you can install the
  Redis Enterprise operator from the administrator user interface. Alternatively,

--- a/content/kubernetes/deployment/openshift/openshift-operatorhub.md
+++ b/content/kubernetes/deployment/openshift/openshift-operatorhub.md
@@ -163,7 +163,7 @@ After the approval, the status of the resources installed is updated.
 
 ### Next steps
 
-After you install Redis Enterprise for Kubernetes into a project you can:
+After you install Redis Enterprise for Kubernetes into a project, you can:
 
 - Navigate to the installed version and use the **Create New** button to create a
   new cluster in your namespace.

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -64,7 +64,7 @@ You can use an existing namespace as long as it does not contain any existing Re
 
 ## Install the operator
 
-The Redis Enterprise operator bundle is published as a container image. A list of required images is available in the [release notes]({{<relref "/kubernetes/release-notes/_index.md">}}) for each version.
+Redis Enterprise for Kubernetes bundle is published as a container image. A list of required images is available in the [release notes]({{<relref "/kubernetes/release-notes/_index.md">}}) for each version.
 
 The operator [definition and reference materials](https://github.com/RedisLabs/redis-enterprise-k8s-docs) are available on GitHub. The operator definitions are [packaged as a single generic YAML file](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/bundle.yaml).
 

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -34,7 +34,7 @@ This guide works with most supported Kubernetes distributions. If you're using O
 
 ## Prerequisites
 
-To deploy the Redis Enterprise operator, you'll need:
+To deploy Redis Enterprise for Kubernetes, you'll need:
 
 * a Kubernetes cluster in a [supported distribution]({{<relref "/kubernetes/reference/supported_k8s_distributions.md">}})
 * a minimum of three worker nodes

--- a/content/kubernetes/deployment/using-kustomize.md
+++ b/content/kubernetes/deployment/using-kustomize.md
@@ -1,7 +1,7 @@
 ---
 Title: Deploy with kustomize
 linkTitle: Deploy with kustomize
-description: How to use the kustomize tool with the Redis Enterprise operator on Kubernetes
+description: How to use the kustomize tool with Redis Enterprise for Kubernetes
 weight: 90
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/faqs/_index.md
+++ b/content/kubernetes/faqs/_index.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Enterprise on Kubernetes FAQs
+Title: Redis Enterprise for Kubernetes FAQs
 linkTitle: FAQs
 description:
 weight: 100

--- a/content/kubernetes/faqs/_index.md
+++ b/content/kubernetes/faqs/_index.md
@@ -18,7 +18,7 @@ An operator is a [Kubernetes custom controller](https://kubernetes.io/docs/conce
 
 ## Does Redis Enterprise operator support multiple RECs per namespace?
 
-The Redis Enterprise operator may only deploy a single Redis Enterprise cluster (REC) per [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). Each REC can run multiple databases while maintaining high capacity and performance.
+Redis Enterprise for Kubernetes may only deploy a single Redis Enterprise cluster (REC) per [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). Each REC can run multiple databases while maintaining high capacity and performance.
 
 ## Do I need to deploy a Redis Enterprise operator per namespace?
 

--- a/content/kubernetes/memory/node-selection.md
+++ b/content/kubernetes/memory/node-selection.md
@@ -21,7 +21,7 @@ aliases: [
 
 Many Kubernetes cluster deployments have different kinds of nodes that have
 different CPU and memory resources available for scheduling cluster workloads.
-The Redis Enterprise operator has various abilities to control the scheduling
+Redis Enterprise for Kubernetes has various abilities to control the scheduling
 Redis Enterprise cluster node pods through properties specified in the
 Redis Enterprise cluster custom resource definition (CRD).
 

--- a/content/kubernetes/old-index.md
+++ b/content/kubernetes/old-index.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Enterprise Software on Kubernetes
+Title: Redis Enterprise for Kubernetes
 description:
 weight: 10
 alwaysopen: false

--- a/content/kubernetes/old-index.md
+++ b/content/kubernetes/old-index.md
@@ -7,7 +7,7 @@ categories: ["Platforms"]
 hidden: true
 draft: true
 ---
-Kubernetes provides enterprise orchestration of containers and has been widely adopted. The Redis Enterprise operator for Kubernetes provides a
+Kubernetes provides enterprise orchestration of containers and has been widely adopted. Redis Enterprise for Kubernetesprovides a
 simple way to get a Redis Enterprise cluster on Kubernetes as well as enables more complex deployment scenarios.
 
 {{< allchildren style="h2" description="true" />}}

--- a/content/kubernetes/old-index.md
+++ b/content/kubernetes/old-index.md
@@ -7,7 +7,7 @@ categories: ["Platforms"]
 hidden: true
 draft: true
 ---
-Kubernetes provides enterprise orchestration of containers and has been widely adopted. Redis Enterprise for Kubernetesprovides a
+Kubernetes provides enterprise orchestration of containers and has been widely adopted. Redis Enterprise for Kubernetes provides a
 simple way to get a Redis Enterprise cluster on Kubernetes as well as enables more complex deployment scenarios.
 
 {{< allchildren style="h2" description="true" />}}

--- a/content/kubernetes/re-clusters/connect-prometheus-operator.md
+++ b/content/kubernetes/re-clusters/connect-prometheus-operator.md
@@ -11,7 +11,7 @@ aliases: [
 ]  
 ---
 
-To collect  metrics data from your databases and Redis Enterprise cluster (REC), you can connect your [Prometheus](https://prometheus.io/) server to an endpoint exposed on your REC. The Redis Enterprise operator creates a dedicated service to expose the `prometheus` port (8070) for data collection. A custom resource called `ServiceMonitor` allows the [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/tree/main/Documentation) to connect to this port and collect data from Redis Enterprise.
+To collect  metrics data from your databases and Redis Enterprise cluster (REC), you can connect your [Prometheus](https://prometheus.io/) server to an endpoint exposed on your REC. Redis Enterprise for Kubernetes creates a dedicated service to expose the `prometheus` port (8070) for data collection. A custom resource called `ServiceMonitor` allows the [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/tree/main/Documentation) to connect to this port and collect data from Redis Enterprise.
 
 ## Prerequisites
 

--- a/content/kubernetes/re-clusters/connect-prometheus-operator.md
+++ b/content/kubernetes/re-clusters/connect-prometheus-operator.md
@@ -17,7 +17,7 @@ To collect  metrics data from your databases and Redis Enterprise cluster (REC),
 
 Before connecting Redis Enterprise to Prometheus on your Kubernetes cluster, make sure you've done the following:
 
-- [Deploy the Redis Enterprise operator]({{<relref "/kubernetes/deployment/quick-start.md">}}) (version 6.2.10-4 or newer)
+- [Deploy Redis Enterprise for Kubernetes]({{<relref "/kubernetes/deployment/quick-start.md">}}) (version 6.2.10-4 or newer)
 - [Deploy the Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) (version 0.19.0 or newer)
 - [Create a Redis Enterprise cluster]({{<relref "/kubernetes/deployment/quick-start#create-a-redis-enterprise-cluster-rec">}})
 

--- a/content/kubernetes/re-clusters/connect-prometheus-operator.md
+++ b/content/kubernetes/re-clusters/connect-prometheus-operator.md
@@ -1,7 +1,7 @@
 ---
-Title: Connect the Prometheus operator to Redis Enterprise Software on Kubernetes
+Title: Connect the Prometheus operator to Redis Enterprise for Kubernetes
 linkTitle: Export metrics to Prometheus
-description: This article describes how to configure a Prometheus operator custom resource to allow it to export metrics from Redis Enterprise Software on Kubernetes.
+description: This article describes how to configure a Prometheus operator custom resource to allow it to export metrics from Redis Enterprise for Kubernetes.
 weight: 92
 alwaysopen: false
 categories: ["Platforms"]

--- a/content/kubernetes/re-databases/db-controller.md
+++ b/content/kubernetes/re-databases/db-controller.md
@@ -20,7 +20,7 @@ aliases: [
 
 A Redis Enterprise database (REDB) is created with a custom resource file. The custom resource defines the size, name, and other specifications for the REDB. The database is created when you apply the custom resource file.
 
-The database controller in the Redis Enterprise operator:
+The database controller in Redis Enterprise for Kubernetes:
 
 - Discovers the custom resource
 - Makes sure the REDB is created in the same namespace as the Redis Enterprise cluster (REC)

--- a/content/kubernetes/re-databases/set-up-ingress-controller.md
+++ b/content/kubernetes/re-databases/set-up-ingress-controller.md
@@ -19,7 +19,7 @@ Every time a Redis Enterprise database (REDB) is created with the Redis Enterpri
 
 By default, REDB creates a `ClusterIP` type service, which exposes a cluster-internal IP and can only be accessed from within the K8s cluster. For requests to be routed to the REDB from outside the K8s cluster, you need an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) controller.
 
-Redis Enterprise Software on Kubernetes supports two ingress controllers, [HAProxy](https://haproxy-ingress.github.io/) and [NGINX](https://kubernetes.github.io/ingress-nginx/).
+Redis Enterprise for Kubernetes supports two ingress controllers, [HAProxy](https://haproxy-ingress.github.io/) and [NGINX](https://kubernetes.github.io/ingress-nginx/).
 
 ## Prerequisites
 

--- a/content/kubernetes/reference/_index.md
+++ b/content/kubernetes/reference/_index.md
@@ -14,7 +14,7 @@ aliases: [
 ---
 
 This section contains the references to the operator, cluster, database deployment
-options on Kubernetes.
+options for Kubernetes.
 
 
 {{< allchildren style="h2" description="true" />}}

--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -29,7 +29,7 @@ aliases: [
 ]
 ---
 
-Each release of the Redis Enterprise operator is thoroughly tested against a set of Kubernetes distributions. The table below lists the current release's support status for each distribution.
+Each release of Redis Enterprise for Kubernetes is thoroughly tested against a set of Kubernetes distributions. The table below lists the current release's support status for each distribution.
 
 - "supported" indicates this distribution is supported for this release.
 - "deprecated" indicates this distribution is supported for this release, but will be dropped in a future release.

--- a/content/kubernetes/release-notes/k8s-5-4-10-8-january-2020.md
+++ b/content/kubernetes/release-notes/k8s-5-4-10-8-january-2020.md
@@ -31,7 +31,7 @@ Follow these [instructions]({{< relref "/kubernetes/re-clusters/upgrade-redis-cl
 
 - Rack Awareness - Support for the [Redis Software Rack Awareness][{{< relref "/rs/clusters/configure/rack-zone-awareness.md" >}}] feature was introduced to the Kubernetes deployment. It enables deploying nodes to different zones, in a multi-zone Kubernetes cluster. Databases that are rack-aware will have the cluster populate their master shard and replica shards in different nodes, across different zones or failure domains. This enables maintaining data persistence in case of zone failure.
 
-- OLM Support - The Redis Enterprise operator is now RedHat OpenShift certified and can be effortlessly configured and deployed in Kubernetes clusters supporting OLM, including OpenShift 4.x clusters, with just a few clicks. OLM based deployments do not require Kubernetes cluster administrator rights to deploy the operator.
+- OLM Support - Redis Enterprise for Kubernetes is now RedHat OpenShift certified and can be effortlessly configured and deployed in Kubernetes clusters supporting OLM, including OpenShift 4.x clusters, with just a few clicks. OLM based deployments do not require Kubernetes cluster administrator rights to deploy the operator.
 
 - Improve cluster nodes' pod scheduling resiliency - Redis Enterprise Cluster pod scheduling is hardened by implementing Kubernetes best practices and providing configuration recommendations to cluster operators. Scheduling resiliency minimizes the chance of cluster node pods eviction or failure to schedule.
 See the top 4 articles in the new [Additonal Topics](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/92a2eff4b8c4ccafac459138f12e5f38acde825c/docs/topics.md#additional-topics) documentation section.

--- a/content/kubernetes/release-notes/k8s-6-0-6-6-2020-06.md
+++ b/content/kubernetes/release-notes/k8s-6-0-6-6-2020-06.md
@@ -99,7 +99,7 @@ being reported as an error (RED32805).
 - Missing permission for role - The redis-enterprise-operator role is missing permission on replicasets (RED39002).
 
 - Openshift 3.11 doesn't support DockerHub private registry - Openshift 3.11 doesn't support DockerHub private registry. This is a known OpenShift
-issue and not addressable by the Redis Enterprise operator (RED38579).
+issue and not addressable by Redis Enterprise for Kubernetes (RED38579).
 
 - Possible DNS conflicts within cluster nodes - DNS conflicts are possible between the cluster mdns_server and the K8s DNS.
 This only impacts DNS resolution from within cluster node and while using the full fqdn *.cluster.local (RED37462).

--- a/content/kubernetes/security/_index.md
+++ b/content/kubernetes/security/_index.md
@@ -1,7 +1,7 @@
 ---
 Title: Security
 linkTitle: Security
-description: Security settings and configuration for Redis Enterprise Software on Kubernetes
+description: Security settings and configuration for Redis Enterprise for Kubernetes
 weight: 50
 alwaysopen: false
 categories: ["Platforms"]
@@ -19,6 +19,6 @@ aliases: [
 ]
 ---
 
-This section contains security settings and configuration for Redis Enterprise Software on Kubernetes.
+This section contains security settings and configuration for Redis Enterprise for Kubernetes.
 
 {{< allchildren style="h2" description="true" />}}

--- a/content/kubernetes/security/manage-rec-credentials.md
+++ b/content/kubernetes/security/manage-rec-credentials.md
@@ -13,7 +13,7 @@ aliases:
   /kubernetes/security/manage_REC_credentials/
  
 ---
-The Redis Enterprise for Kubernetes uses a custom resource called [`RedisEnterpriseCluster`]({{<relref "/kubernetes/reference/cluster-options.md">}}) to create a Redis Enterprise cluster (REC). During creation it generates random credentials for the operator to use. The credentials are saved in a Kubernetes (K8s) [secret](https://kubernetes.io/docs/concepts/configuration/secret/). The secret name defaults to the name of the cluster.
+Redis Enterprise for Kubernetes uses a custom resource called [`RedisEnterpriseCluster`]({{<relref "/kubernetes/reference/cluster-options.md">}}) to create a Redis Enterprise cluster (REC). During creation it generates random credentials for the operator to use. The credentials are saved in a Kubernetes (K8s) [secret](https://kubernetes.io/docs/concepts/configuration/secret/). The secret name defaults to the name of the cluster.
 
 {{<note>}}
 This procedure is only supported for operator versions 6.0.20-12 and above.

--- a/content/kubernetes/security/manage-rec-credentials.md
+++ b/content/kubernetes/security/manage-rec-credentials.md
@@ -159,4 +159,4 @@ If you store your secrets with Hashicorp Vault, update the secret for the REC cr
 username:<desired_username>, password:<desired_password>
 ```
 
-For more information about Vault integration with the Redis Enterprise Cluster see [Integrating the Redis Enterprise operator with Hashicorp Vault](https://github.com/RedisLabs/redis-enterprise-k8s-docs/tree/65eba63a6aac69455a691652218e28b0873e4de3/vault#integrating-the-redis-enterprise-operator-with-hashicorp-vault).
+For more information about Vault integration with the Redis Enterprise Cluster see [Integrating Redis Enterprise for Kubernetes with Hashicorp Vault](https://github.com/RedisLabs/redis-enterprise-k8s-docs/tree/65eba63a6aac69455a691652218e28b0873e4de3/vault#integrating-the-redis-enterprise-operator-with-hashicorp-vault).

--- a/content/kubernetes/security/manage-rec-credentials.md
+++ b/content/kubernetes/security/manage-rec-credentials.md
@@ -13,7 +13,7 @@ aliases:
   /kubernetes/security/manage_REC_credentials/
  
 ---
-The Redis Enterprise Software on Kubernetes uses a custom resource called [`RedisEnterpriseCluster`]({{<relref "/kubernetes/reference/cluster-options.md">}}) to create a Redis Enterprise cluster (REC). During creation it generates random credentials for the operator to use. The credentials are saved in a Kubernetes (K8s) [secret](https://kubernetes.io/docs/concepts/configuration/secret/). The secret name defaults to the name of the cluster.
+The Redis Enterprise for Kubernetes uses a custom resource called [`RedisEnterpriseCluster`]({{<relref "/kubernetes/reference/cluster-options.md">}}) to create a Redis Enterprise cluster (REC). During creation it generates random credentials for the operator to use. The credentials are saved in a Kubernetes (K8s) [secret](https://kubernetes.io/docs/concepts/configuration/secret/). The secret name defaults to the name of the cluster.
 
 {{<note>}}
 This procedure is only supported for operator versions 6.0.20-12 and above.

--- a/content/rs/security/access-control/ldap/cluster-based-ldap-authentication.md
+++ b/content/rs/security/access-control/ldap/cluster-based-ldap-authentication.md
@@ -28,7 +28,7 @@ Redis Enterprise Software supports Lightweight Directory Access Protocol (LDAP).
 Known Limitations:
 
 - LDAP access for database access is available only when using the role-based [LDAP authentication]({{<relref "/rs/security/access-control/ldap/">}}).
-- This process does not apply when running Redis Enterprise on Kubernetes.
+- This process does not apply when running Redis Enterprise for Kubernetes.
 - Support for this integration was removed from Redis Enterprise Software v6.2.12.
 {{< /note >}}
 


### PR DESCRIPTION
Corrected product name to "Redis Enterprise for Kubernetes" as well as removed the word operator when it was actually referring to the whole product. 

Staged Preview: https://docs.redis.com/staging/jira-doc-1772/latest/kubernetes/
Jira: DOC-1772