### PR TITLE
New in-page banner shortcode & partial

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,26 @@
     {{if not .IsHome}}
       <div class="main-content">
           <div class="main-content-left">
+            <!-- In-page banner -->
+            {{ if .Params.bannerText }}
+              <!-- Banner params are in the current page's front matter -->
+              {{ partial "banner-article.html" . }}
+            {{ else }}
+              <!-- Iterate through the page's ancestors to determine if a 
+                section-wide banner is enabled by a parent page's front matter -->
+              {{ $ancestorDirs := slice }}
+              {{ with .File }}
+                {{ $ancestorDirs = split .File.Dir "/" }}
+              {{ end }}
+              {{ $currPage := .Page }}
+              {{ range $i, $page := $ancestorDirs }}
+                {{ if and $currPage.Params.bannerText $currPage.Params.bannerChildren }}
+                  {{ partial "banner-article.html" $currPage }}
+                {{ end }}
+                {{ $currPage = $currPage.Parent }}
+              {{ end }}
+            {{ end }}
+
             {{ block "main" . }}
             {{ end }}
           </div>

--- a/layouts/partials/banner-article.html
+++ b/layouts/partials/banner-article.html
@@ -1,0 +1,17 @@
+<div class="banner-article">
+    {{ if .Params.bannerLink }}
+        {{ if in .Params.bannerText "[" }}
+            {{ $splitText := slice }}
+            {{ $splitText1 := split .Params.bannerText "[" }}
+            {{ range $i, $elem := $splitText1 }}
+                {{ $splitText2 := split $elem "]" }}
+                {{ $splitText = $splitText | append $splitText2 }}
+            {{ end }}
+            <p>{{ index $splitText 0 }}<a href="{{ .Params.bannerLink }}">{{ index $splitText 1 }}</a>{{ index $splitText 2}}</p>
+        {{ else }}
+            <p><a href="{{ .Params.bannerLink }}">{{ .Params.bannerText }}</a></p>
+        {{ end }}
+    {{ else }}
+        <p>{{ .Params.bannerText }}</p>
+    {{ end }}
+</div>

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -115,12 +115,6 @@
       </div>
       {{end}}
 
-      <!-- <div class="article-banner">
-        {{ if .Site.Params.bannerText  }}
-          {{ partial "banner.html" . }}
-        {{ end }}
-      </div> -->
-
       <div class="nav-select">
           <center>
           <select onchange="javascript:location.href = this.value;">

--- a/layouts/shortcodes/banner-article.html
+++ b/layouts/shortcodes/banner-article.html
@@ -1,0 +1,7 @@
+{{ $bannerText :=  .Get "bannerText" }}
+{{ $bannerLink :=  .Get "bannerLink" }}
+{{ $bannerColor :=  .Get "bannerColor" }}
+
+<div class="banner-article" style="background-color: {{$bannerColor}}">
+    <p>{{ .Inner | markdownify }}</p>
+</div>

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -1170,8 +1170,24 @@ article {
   text-decoration: underline;
 }
 
-.article-banner {
-  margin-top: 2rem;
+.banner-article {
+  /*background-color: #f7f7f7;*/
+  background-color: #fff8dc;
+  padding: 1px;
+  margin-left: -3px;
+  z-index: 998;
+}
+
+.banner-article p {
+  text-align: left;
+  font-size: 16px !important;
+  padding-top: 1rem;
+  padding-left: 3px;
+  padding-right: 3px;
+}
+
+.banner-article a {
+  text-decoration: underline;
 }
 
 .cbp-spmenu a.menu__link__title {


### PR DESCRIPTION
There are now 2 methods to add an in-page banner to articles (appears beneath the article title).

Shortcode method (single page only):
- Add the `banner-article` shortcode directly after the front matter of a Markdown file
- The banner only appears on the page where you added the `banner-article` shortcode
- You can adjust the banner's color with the optional shortcode param `bannerColor`

```Markdown
---
Title: The article's title
<other front matter>
---

{{<banner-article bannerColor="#fff8dc">}}
This is preview content. See the [latest version](https://docs.redis.com/latest/) of the site.
{{</banner-article>}}

The main text of your article starts here...
```

Front matter method (single or multi page):
- Add `bannerText` and optionally `bannerLink` and/or `bannerChildren` to a Markdown file's front matter
- If you add `bannerChildren: true` to a parent page's front matter, its banner will also appear for all of its descendent/child pages
- You can't adjust the banner's color without editing `style.css` or partials

```Markdown
---
Title: The article's title
<other front matter>
bannerText: The message that appears in the banner. Use brackets to signify [linkable text].
bannerLink: https://docs.redis.com/latest/
bannerChildren: true
---
```