### PR TITLE
Redirect k8s v6.x to latest

### DIFF
--- a/website.json
+++ b/website.json
@@ -48,6 +48,16 @@
         },
         {
             "Condition": {
+                "KeyPrefixEquals": "6.0/platforms/"
+            },
+            "Redirect": {
+                "HostName": "docs.redis.com",
+                "Protocol": "https",
+                "ReplaceKeyPrefixWith": "latest/kubernetes/"
+            }
+        },
+        {
+            "Condition": {
                 "KeyPrefixEquals": "5.4/platforms/"
             },
             "Redirect": {


### PR DESCRIPTION
Added a redirect so selecting the latest (v6.x) k8s version from the version dropdown list redirects you to latest (v6.2) instead of the 6.0 snapshot.