### PR TITLE
Fix k8s v6.x redirect

### DIFF
--- a/website.json
+++ b/website.json
@@ -53,7 +53,7 @@
             "Redirect": {
                 "HostName": "docs.redis.com",
                 "Protocol": "https",
-                "ReplaceKeyPrefixWith": "latest/kubernetes/"
+                "ReplaceKeyPrefixWith": "latest/platforms/"
             }
         },
         {


### PR DESCRIPTION
Other existing redirects interfered with the last attempt to fix the k8s v6.x redirect.