### PR TITLE
K8s: 6.2.18-41 Jan 2023 release notes

### DIFF
--- a/content/kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md
@@ -27,12 +27,11 @@ DockerHub images are available at `docker.io/`.
 
 **OLM operator version**: `v6.2.18-41b`
 
-Red Hat images are available at `registry.connect.redhat.com/`.
 
-* **Redis Enterprise**: `redislabs/redis-enterprise:6.2.18-72.rhel8-openshift`
-    (or `redislabs/redis-enterprise:6.2.18-72.rhel7-openshift` if upgrading from RHEL 7)
-* **Operator**: `/redislabs/redis-enterprise-operator:6.2.18-41`
-* **Services Rigger**: `redislabs/services-manager:6.2.18-41`
+* **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:6.2.18-72.rhel8-openshift`
+    (or `registry.connect.redhat.com/redislabs/redis-enterprise:6.2.18-72.rhel7-openshift` if upgrading from RHEL 7)
+* **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:6.2.18-41`
+* **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:6.2.18-41`
 
 ## Feature enhancements
 

--- a/content/kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md
@@ -17,18 +17,24 @@ New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref 
 
 ## Images
 
+DockerHub images are available at `docker.io/`.
+
 * **Redis Enterprise**: `redislabs/redis:6.2.18-72`
 * **Operator**: `redislabs/operator:6.2.18-41`
 * **Services Rigger**: `redislabs/k8s-controller:6.2.18-41`
 
 ### OpenShift images
 
-* **Redis Enterprise**: `redislabs/redis:6.2.18-72.rhel8-openshift` (or `redislabs/redis:6.2.18-72.rhel7-openshift` if upgrading from RHEL 7)
-* **Operator**: `redislabs/operator:6.2.18-41`
-* **Services Rigger**: `redislabs/services-manager:6.2.18-41`
-* **OLM Bundle**: `v6.2.18-41b`
+**OLM operator version**: `v6.2.18-41b`
 
-## Bug fixes
+Red Hat images are available at `registry.connect.redhat.com/`.
+
+* **Redis Enterprise**: `redislabs/redis-enterprise:6.2.18-72.rhel8-openshift`
+    (or `redislabs/redis-enterprise:6.2.18-72.rhel7-openshift` if upgrading from RHEL 7)
+* **Operator**: `/redislabs/redis-enterprise-operator:6.2.18-41`
+* **Services Rigger**: `redislabs/services-manager:6.2.18-41`
+
+## Feature enhancements
 
 * Upgraded to support Redis Enterprise 6.2.18-72
 

--- a/content/kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md
@@ -1,0 +1,41 @@
+---
+Title: Redis Enterprise for Kubernetes release notes 6.2.18-41 (Jan 2023)
+linktitle: 6.2.18-41 (Jan 2023)
+description: This is a maintenance release for 6.2.18 and includes support for Redis Enterprise 6.2.18-72.
+weight: 59
+alwaysopen: false
+categories: ["Platforms"]
+aliases: [ 
+    /kubernetes/release-notes/k8s-6-2-18-41-jan-2023.md,
+    /kubernetes/release-notes/k8s-6-2-18-41-jan-2023/,   ]
+---
+## Overview
+
+This is a maintenance release of Redis Enterprise for Kubernetes 6.2.18-41 that adds supports for Redis Enterprise 6.2.18-72.
+
+New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref "/kubernetes/release-notes/k8s-6-2-18-41.md">}}) for compatibility notes and known limitations.
+
+## Images
+
+* **Redis Enterprise**: `redislabs/redis:6.2.18-72`
+* **Operator**: `redislabs/operator:6.2.18-41`
+* **Services Rigger**: `redislabs/k8s-controller:6.2.18-41`
+
+### OpenShift images
+
+* **Redis Enterprise**: `redislabs/redis:6.2.18-72.rhel8-openshift` (or `redislabs/redis:6.2.18-72.rhel7-openshift` if upgrading from RHEL 7)
+* **Operator**: `redislabs/operator:6.2.18-41`
+* **Services Rigger**: `redislabs/services-manager:6.2.18-41`
+* **OLM Bundle**: `v6.2.18-41b`
+
+## Bug fixes
+
+* Upgraded to support Redis Enterprise 6.2.18-72
+
+## Compatibility notes
+
+See [Redis Enterprise for Kubernetes release notes 6.2.18-41 (Dec 2022)]({{<relref "/kubernetes/release-notes/k8s-6-2-18-41.md">}}).
+
+## Known limitations
+
+See [Redis Enterprise for Kubernetes release notes 6.2.18-41 (Dec 2022)]({{<relref "/kubernetes/release-notes/k8s-6-2-18-41.md">}}).

--- a/content/kubernetes/release-notes/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/k8s-6-2-18-41.md
@@ -19,9 +19,16 @@ The key bug fixes and known limitations are described below.
 
 This release includes the following container images:
 
-* **Redis Enterprise**: `redislabs/redis:6.2.18-65` or  `redislabs/redis:6.2.18-65.rhel8-openshift` (or `redislabs/redis:6.2.18-65.rhel7-openshift` if upgrading from RHEL 7)
+* **Redis Enterprise**: `redislabs/redis:6.2.18-65`
 * **Operator**: `redislabs/operator:6.2.18-41`
-* **Services Rigger**: `redislabs/k8s-controller:6.2.18-41` or `redislabs/services-manager:6.2.18-41` (on the Red Hat registry)
+* **Services Rigger**: `redislabs/k8s-controller:6.2.18-41`
+
+### OpenShift images
+
+* **Redis Enterprise**: `redislabs/redis:6.2.18-65.rhel8-openshift` (or `redislabs/redis:6.2.18-65.rhel7-openshift` if upgrading from RHEL 7)
+* **Operator**: `redislabs/operator:6.2.18-41`
+* **Services Rigger**: `redislabs/services-manager:6.2.18-41`
+* **OLM Bundle**: `v6.2.18-41a`
 
 ## Bug fixes
 

--- a/content/kubernetes/release-notes/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/k8s-6-2-18-41.md
@@ -17,7 +17,7 @@ The key bug fixes and known limitations are described below.
 
 ## Images
 
-This release includes the following container images:
+DockerHub images are available at `docker.io/`.
 
 * **Redis Enterprise**: `redislabs/redis:6.2.18-65`
 * **Operator**: `redislabs/operator:6.2.18-41`
@@ -25,10 +25,14 @@ This release includes the following container images:
 
 ### OpenShift images
 
-* **Redis Enterprise**: `redislabs/redis:6.2.18-65.rhel8-openshift` (or `redislabs/redis:6.2.18-65.rhel7-openshift` if upgrading from RHEL 7)
-* **Operator**: `redislabs/operator:6.2.18-41`
+**OLM operator version**: `v6.2.18-41a`
+
+Red Hat images are available at `registry.connect.redhat.com/`.
+
+* **Redis Enterprise**: `redislabs/redis-enterprise:6.2.18-65.rhel8-openshift`
+    (or `redislabs/redis-enterprise:6.2.18-65.rhel7-openshift` if upgrading from RHEL 7)
+* **Operator**: `/redislabs/redis-enterprise-operator:6.2.18-41`
 * **Services Rigger**: `redislabs/services-manager:6.2.18-41`
-* **OLM Bundle**: `v6.2.18-41a`
 
 ## Bug fixes
 

--- a/content/kubernetes/release-notes/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/k8s-6-2-18-41.md
@@ -17,7 +17,6 @@ The key bug fixes and known limitations are described below.
 
 ## Images
 
-DockerHub images are available at `docker.io/`.
 
 * **Redis Enterprise**: `redislabs/redis:6.2.18-65`
 * **Operator**: `redislabs/operator:6.2.18-41`
@@ -27,12 +26,11 @@ DockerHub images are available at `docker.io/`.
 
 **OLM operator version**: `v6.2.18-41a`
 
-Red Hat images are available at `registry.connect.redhat.com/`.
 
-* **Redis Enterprise**: `redislabs/redis-enterprise:6.2.18-65.rhel8-openshift`
+* **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:6.2.18-65.rhel8-openshift`
     (or `redislabs/redis-enterprise:6.2.18-65.rhel7-openshift` if upgrading from RHEL 7)
-* **Operator**: `/redislabs/redis-enterprise-operator:6.2.18-41`
-* **Services Rigger**: `redislabs/services-manager:6.2.18-41`
+* **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:6.2.18-41`
+* **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:6.2.18-41`
 
 ## Bug fixes
 


### PR DESCRIPTION
- Added support for 6.2.18-72 images
- Separated the OpenShift specific images from the other images 
- Added the name of the OLM bundle

Staged preview: 
[6.2.18-41 Jan 2023](https://docs.redis.com/staging/jira-doc-1859/kubernetes/release-notes/k8s-6-2-18-41-jan-2023/)
[6.2.18-41 Dec 2022]((https://docs.redis.com/staging/jira-doc-1859/kubernetes/release-notes/k8s-6-2-18-41/))
