### PR TITLE
DOC-1827 Remove ServiceAccount for admission

### DIFF
--- a/content/kubernetes/re-clusters/multi-namespace.md
+++ b/content/kubernetes/re-clusters/multi-namespace.md
@@ -71,9 +71,6 @@ subjects:
   name: redis-enterprise-operator
   namespace: <rec-namespace>
 - kind: ServiceAccount
-  name: redis-enterprise-admission
-  namespace: <rec-namespace>
-- kind: ServiceAccount
   name: <service-account-name>
   namespace: <rec-namespace>
 roleRef:


### PR DESCRIPTION
Jira: DOC-1827
Staged preview: https://docs.redis.com/staging/jira-doc-1827/kubernetes/re-clusters/multi-namespace/
SME: @zcahana 

I removed the ServiceAccount entry for the admission controller in the RoleBinding yaml example. 