### PR TITLE
DOC-1835 and DOC-1836: Metrics Reference: Redis on Flash and Active-Active metrics

### DIFF
--- a/content/rs/references/metrics/active-active.md
+++ b/content/rs/references/metrics/active-active.md
@@ -1,9 +1,0 @@
----
-Title: Active-Active Metrics
-linkTitle: Active-Active
-description: 
-weight: $weight
-alwaysopen: false
-categories: ["RS"]
-aliases:
----

--- a/content/rs/references/metrics/database-operations.md
+++ b/content/rs/references/metrics/database-operations.md
@@ -106,11 +106,11 @@ ACL CAT write
 
 #### Pending writes min
 
-Minimum number of write operations queued in an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+Minimum number of write operations queued per [Active-Active]({{<relref "/rs/databases/active-active">}}) replica database. 
 
 #### Pending writes max
 
-Maximum number of write operations queued in an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+Maximum number of write operations queued per [Active-Active]({{<relref "/rs/databases/active-active">}}) replica database. 
 
 ### Other commands/sec 
 

--- a/content/rs/references/metrics/database-operations.md
+++ b/content/rs/references/metrics/database-operations.md
@@ -104,6 +104,14 @@ ACL CAT write
 
 **Components measured**: Database
 
+#### Pending writes min
+
+Minimum number of write operations queued in an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+
+#### Pending writes max
+
+Maximum number of write operations queued in an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+
 ### Other commands/sec 
 
 Number of operations per second that are not [read operations](#readssec) or [write operations](#writessec).

--- a/content/rs/references/metrics/redis-on-flash.md
+++ b/content/rs/references/metrics/redis-on-flash.md
@@ -7,3 +7,111 @@ alwaysopen: false
 categories: ["RS"]
 aliases:
 ---
+
+These metrics are additional metrics for [Redis on Flash (RoF)]({{< relref "/rs/databases/redis-on-flash" >}}) databases.
+
+## % Values in RAM
+
+Percent of keys whose values are stored in RAM.
+
+**Components measured**: Database and Shard
+
+### Values in flash
+
+Number of keys with values stored in flash, not including [replication]({{< relref "/rs/databases/durability-ha/replication" >}}).
+
+**Components measured**: Database and Shard
+
+### Values in RAM
+
+Number of keys with values stored in RAM, not including [replication]({{< relref "/rs/databases/durability-ha/replication" >}}).
+
+**Components measured**: Database and Shard 
+
+## Flash Key-Value operations
+
+Number of operations on flash key values (read + write + del) per second.
+
+**Components measured**: Node
+
+### Flash bytes/sec
+
+Number of total bytes read and written per second on flash memory.
+
+**Components measured**: Cluster, Node, Database, and Shard
+
+### Flash I/O operations/sec
+
+Number of input/output operations per second on the flash storage device.
+
+**Components measured**: Cluster and Node
+
+## RAM:Flash access ratio
+
+Ratio between logical Redis key value operations and actual flash key value operations.
+
+**Components measured**: Database and Shard
+
+### RAM hit ratio
+
+Ratio of requests processed directly from RAM to total number of requests processed.
+
+**Components measured**: Database and Shard
+
+## Used flash
+
+Total amount of memory used to store values in flash.
+
+**Components measured**: Database and Shard
+### Free flash
+
+Amount of free space on flash storage. 
+
+**Components measured**: Cluster and Node
+
+### Flash fragmentation
+
+Ratio between the used logical flash memory and the physical flash memory that is used.
+
+**Components measured**: Database and Shard
+
+## Used RAM
+
+Total size of data stored in RAM, including keys, values, overheads, and [replication]({{< relref "/rs/databases/durability-ha/replication" >}}) (if enabled).
+
+**Components measured**: Database and Shard
+
+### RAM dataset overhead
+
+Percentage of the [RAM limit](#ram-limit) that is used for anything other than values, such as key names, dictionaries, and other overheads.
+
+**Components measured**: Database and Shard
+
+### RAM limit
+
+Maximum amount of RAM that can be used in bytes.
+
+**Components measured**: Database
+
+### RAM usage
+
+Percentage of the [RAM limit](#ram-limit) used.
+
+**Components measured**: Database
+
+## Calculated metrics
+
+These Redis on Flash statistics can be calculated from other metrics.
+
+- RoF average key size with overhead
+
+    ([ram_dataset_overhead](#ram-dataset-overhead) * [used_ram](#used-ram))
+                    / ([total_keys]({{< relref "/rs/references/metrics/database-operations#total-keys" >}}) * 2)
+
+- RoF average value size in RAM
+
+    ((1 - [ram_dataset_overhead](#ram-dataset-overhead)) * [used_ram](#used-ram)) / ([values_in_ram](#values-in-ram) * 2)
+
+- RoF average value size in flash
+
+    [used_flash](#used-flash) / [values_in_flash](#values-in-flash)    

--- a/content/rs/references/metrics/redis-on-flash.md
+++ b/content/rs/references/metrics/redis-on-flash.md
@@ -28,7 +28,7 @@ Number of keys with values stored in RAM, not including [replication]({{< relref
 
 **Components measured**: Database and Shard 
 
-## Flash Key-Value operations
+## Flash key-value operations
 
 Number of operations on flash key values (read + write + del) per second.
 
@@ -63,6 +63,7 @@ Ratio of requests processed directly from RAM to total number of requests proces
 Total amount of memory used to store values in flash.
 
 **Components measured**: Database and Shard
+
 ### Free flash
 
 Amount of free space on flash storage. 
@@ -101,7 +102,7 @@ Percentage of the [RAM limit](#ram-limit) used.
 
 ## Calculated metrics
 
-These Redis on Flash statistics can be calculated from other metrics.
+These RoF statistics can be calculated from other metrics.
 
 - RoF average key size with overhead
 

--- a/content/rs/references/metrics/resource-usage.md
+++ b/content/rs/references/metrics/resource-usage.md
@@ -92,11 +92,11 @@ All incoming traffic is not measured during [shard migration]({{< relref "/rs/da
 
 #### Incoming traffic compressed
 
-Total incoming compressed traffic (in bytes/sec) to an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+Total incoming compressed traffic (in bytes/sec) per [Active-Active]({{<relref "/rs/databases/active-active">}}) replica database. 
 
 #### Incoming traffic uncompressed
 
-Total incoming uncompressed traffic (in bytes/sec) to an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+Total incoming uncompressed traffic (in bytes/sec) per [Active-Active]({{<relref "/rs/databases/active-active">}}) replica database. 
 
 ### Outgoing traffic 
 

--- a/content/rs/references/metrics/resource-usage.md
+++ b/content/rs/references/metrics/resource-usage.md
@@ -86,9 +86,17 @@ Percent of memory used by Redis out of the [memory limit](#memory-limit).
 
 Total incoming traffic to the database in bytes per second.
 
-Incoming traffic is not measured during [shard migration]({{< relref "/rs/databases/configure/replica-ha" >}}).
+All incoming traffic is not measured during [shard migration]({{< relref "/rs/databases/configure/replica-ha" >}}).
 
 **Components measured**: Cluster, Node and Database
+
+#### Incoming traffic compressed
+
+Total incoming compressed traffic (in bytes/sec) to an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
+
+#### Incoming traffic uncompressed
+
+Total incoming uncompressed traffic (in bytes/sec) to an [Active-Active]({{<relref "/rs/databases/active-active">}}) database. 
 
 ### Outgoing traffic 
 


### PR DESCRIPTION
Staging links: 

https://docs.redis.com/staging/jira-doc-1835/rs/references/metrics/redis-on-flash/
https://docs.redis.com/staging/jira-doc-1835/rs/references/metrics/database-operations/
https://docs.redis.com/staging/jira-doc-1835/rs/references/metrics/resource-usage/
