### PR TITLE
Archived self-managed AWS account docs

### DIFF
--- a/content/rc/cloud-integrations/_index.md
+++ b/content/rc/cloud-integrations/_index.md
@@ -18,8 +18,6 @@ By default, Redis Enterprise Cloud subscriptions are hosted in cloud vendor acco
 
 To integrate Redis Enterprise Cloud into an existing cloud vendor account, you can:
 
-- Designate an existing AWS subscription as an [AWS cloud account]({{<relref "/rc/cloud-integrations/aws-cloud-accounts/">}}) for your Redis Cloud subscription.
-
 - Subscribe to Redis Enterprise Cloud through [AWS Marketplace]({{<relref "/rc/cloud-integrations/aws-marketplace/">}}).
 
 - Subscribe to Redis Enterprise Cloud through [GCP Marketplace]({{<relref "/rc/cloud-integrations/gcp-marketplace/">}}).

--- a/content/rc/cloud-integrations/aws-cloud-accounts/_index.md
+++ b/content/rc/cloud-integrations/aws-cloud-accounts/_index.md
@@ -4,6 +4,9 @@ LinkTitle: AWS cloud accounts
 description: Describes how to provision your Redis Enterprise Cloud subscription to use existing cloud provider accounts.
 weight: 40
 alwaysopen: false
+hidden: true
+bannerText: Self-managed AWS accounts are deprecated, so this article has been archived.
+bannerChildren: true
 categories: ["RC"]
 aliases: /rv/how-to/view-edit-cloud-account/
          /rv/how-to/creating-cloud-account/


### PR DESCRIPTION
Staged previews:
- [Cloud integrations](https://docs.redis.com/staging/jira-doc-1876/rc/cloud-integrations/) - hid archived docs so they no longer appear in the main ToC
- Archived content:
  - [AWS cloud accounts](https://docs.redis.com/staging/jira-doc-1876/rc/cloud-integrations/aws-cloud-accounts/)
    - [Create IAM resources](https://docs.redis.com/staging/jira-doc-1876/rc/cloud-integrations/aws-cloud-accounts/iam-resources/)
      - [AWS console](https://docs.redis.com/staging/jira-doc-1876/rc/cloud-integrations/aws-cloud-accounts/iam-resources/aws-console/)
      - [CloudFormation](https://docs.redis.com/staging/jira-doc-1876/rc/cloud-integrations/aws-cloud-accounts/iam-resources/cloudformation/)
      - [Terraform](https://docs.redis.com/staging/jira-doc-1876/rc/cloud-integrations/aws-cloud-accounts/iam-resources/terraform/)