### PR TITLE
Fix PEM bundle contents

### DIFF
--- a/content/rc/security/database-security/tls-ssl.md
+++ b/content/rc/security/database-security/tls-ssl.md
@@ -109,7 +109,7 @@ The download contains a file called `redis_ca.pem`, which includes the following
 
 - Self-signed Redis Cloud Flexible plan Root CA and intermediate CA (deprecated but still in use)
 
-- Publicly trusted GlobalSign Root CA and intermediate CA
+- Publicly trusted GlobalSign Root CA
 
 To inspect the certificates in `redis_ca.pem`, run the `keytool` command:
 


### PR DESCRIPTION
The PEM bundle does not contain the GlobalSign Intermediate CA (only the root)