### PR TITLE
DOC-1921 RS v6.4.2-43 March release notes and docs

### DIFF
--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -14,7 +14,7 @@ Make sure your system meets these requirements:
 
 | **Platform** | **Versions/Information** |
 |------------|-----------------|
-| Ubuntu | 16.04 (deprecated), 18.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
+| Ubuntu | 16.04 (deprecated), 18.04, 20.04<br>Server version is recommended for production installations. Desktop version is only recommended for development deployments. |
 | Red Hat Enterprise Linux (RHEL) 7, CentOS 7 | 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9<br>Requires OpenSSL 1.0.2 and [firewall configuration]({{< relref "/rs/installing-upgrading/configuring/centos-rhel-7-firewall.md" >}}) |
 | <nobr>RHEL 8, CentOS 8</nobr> | 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, and 8.7 |
 | <nobr>Oracle Linux 7, Oracle Linux 8</nobr> | Based on the corresponding RHEL version |
@@ -30,6 +30,12 @@ Be aware that Redis Enterprise Software relies on certain components that requir
 To illustrate, version 6.2.8 of Redis Enterprise Software removed support for TLS 1.0 and TLS 1.1 on Red Hat Enterprise Linux 8 (RHEL 8) because that operating system [does not enable support](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening) for these versions by default.  
 
 If you have trouble enabling specific components, features, or versions, verify that they're supported by your operating system and that they're configured correctly.
+
+### Ubuntu 20 rejects SHA1 certificates
+
+With Ubuntu 20.04, you cannot use the SHA1 hash algorithm because [OpenSSL's security level is set to 2 by default](https://manpages.ubuntu.com/manpages/focal/man3/SSL_CTX_set_security_level.3ssl.html#notes). As a result, the operating system rejects SHA1 certificates, even if you enable the `mtls_allow_weak_hashing` option.
+
+To avoid issues with SHA1 certificates, replace them with new certificates that use SHA-256. Note that certificates provided by Redis Enterprise Software use SHA-256.
 
 ### Upgrade RHEL when using modules
 

--- a/content/rs/databases/import-export/import-data.md
+++ b/content/rs/databases/import-export/import-data.md
@@ -40,7 +40,7 @@ To import data into a database:
 
 You can import data from a variety of services, ranging from local servers to cloud services.
 
-Earlier versions of Redis Enterprise Software supported OpenStack Swift a storage location; however, that support ended [30 November 2020]({{< relref "/rs/release-notes/rs-5-6-0-april-2020#end-of-life" >}}).  As a result, that option is no longer available.
+Earlier versions of Redis Enterprise Software supported OpenStack Swift a storage location; however, that support ended [30 November 2020]({{< relref "/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020#end-of-life" >}}).  As a result, that option is no longer available.
 
 ### HTTP server
 

--- a/content/rs/databases/import-export/import-data.md
+++ b/content/rs/databases/import-export/import-data.md
@@ -40,7 +40,7 @@ To import data into a database:
 
 You can import data from a variety of services, ranging from local servers to cloud services.
 
-Earlier versions of Redis Enterprise Software supported OpenStack Swift a storage location; however, that support ended [30 November 2020]({{< relref "/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020#end-of-life" >}}).  As a result, that option is no longer available.
+Earlier versions of Redis Enterprise Software supported OpenStack Swift as a storage location; however, that support ended [30 November 2020]({{< relref "/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020#end-of-life" >}}).  As a result, that option is no longer available.
 
 ### HTTP server
 

--- a/content/rs/networking/port-configurations.md
+++ b/content/rs/networking/port-configurations.md
@@ -43,6 +43,7 @@ Redis Enterprise Software's port usage falls into three general categories:
 | TCP | 20000-29999 | Internal | Database shard traffic |
 | TCP | 8002, 8004, 8006 | Internal | System health monitoring |
 | TCP | 8444, 9080 | Internal | Traffic between web proxy and cnm_http/cm |
+| TCP | 1024-65535 | Internal | Cluster gateway (envoy admin, envoy management server, gossip envoy admin) |
 
 ## Change the admin console port
 
@@ -59,7 +60,7 @@ After changing the Redis Enterprise Software web UI port, you must connect any n
 
 ## Change the REST API port
 
-For the REST API, Redis Enterprise Software uses port 9443 (secure) and port 8080 (unsecure), by default. You can change this to a custom port as long as the new port is not in use by another process.
+For the REST API, Redis Enterprise Software uses port 9443 (secure) and port 8080 (not secure), by default. You can change this to a custom port as long as the new port is not in use by another process.
 
 To change these ports, run:
 
@@ -71,25 +72,26 @@ rladmin cluster config cnm_http_port <new-port>
 rladmin cluster config cnm_https_port <new-port>
 ```
 
-## Disable HTTP support for API endpoints
+## Require HTTPS for API endpoints
 
-To harden deployments, you can disable the HTTP support for API endpoints that is supported by default.
-Before you disable HTTP support, make sure you migrate any scripts or proxy configurations that use HTTP to the encrypted API endpoint to prevent broken connections.
+By default, the Redis Enterprise Software API supports communication over HTTP and HTTPS. However, you can turn off HTTP support to ensure that API requests are encrypted.
 
-To disable HTTP support for API endpoints, run:
+Before you turn off HTTP support, make sure you migrate any scripts or proxy configurations that use HTTP to the encrypted API endpoint to prevent broken connections.
+
+To turn off HTTP support for API endpoints, run:
 
 ```sh
 rladmin cluster config http_support disabled
 ```
 
-After you disable HTTP support, traffic sent to the unencrypted API endpoint is blocked.
+After you turn off HTTP support, traffic sent to the unencrypted API endpoint is blocked.
 
 
 ## HTTP to HTTPS redirection
-Starting with version 6.0.12, the automatic HTTP to HTTPS redirection is disabled.
+Starting with version 6.0.12, you cannot use automatic HTTP to HTTPS redirection.
 To poll metrics from the `metrics_exporter` or to access the admin console, use HTTPS in your request. HTTP requests won't be automatically redirected to HTTPS for those services. 
 
-# Nodes on different VLANs
+## Nodes on different VLANs
 
 Nodes in the same cluster must reside on the same VLAN. If you can't
 host the nodes on the same VLAN, then you must open [all ports]({{< relref "/rs/networking/port-configurations.md" >}}) between them.

--- a/content/rs/references/cli-utilities/rladmin/node/remove.md
+++ b/content/rs/references/cli-utilities/rladmin/node/remove.md
@@ -13,7 +13,7 @@ aliases:
 Removes the specified node from the cluster.
 
 ```sh
-rladmin node <ID> remove
+rladmin node <ID> remove [ wait_for_persistence { enabled | disabled } ]
 ```
 
 ### Parameters
@@ -21,6 +21,7 @@ rladmin node <ID> remove
 | Parameter             | Type/Value                     | Description                                                 |
 |-----------------------|--------------------------------|-------------------------------------------------------------|
 | node                  | integer                        | The node to remove from the cluster                    |
+| wait_for_persistence  | `enabled`<br />`disabled`      | Ensures persistence files are available for recovery. The cluster policy `persistent_node_removal` determines the default value. |
 
 ### Returns
 

--- a/content/rs/references/rest-api/objects/bdb/_index.md
+++ b/content/rs/references/rest-api/objects/bdb/_index.md
@@ -34,12 +34,12 @@ An API object that represents a managed database in the cluster.
 [{
   "CN": string,
   "O": string,
-  "OU": string,
+  "OU": [array of strings],
   "L": string,
   "ST": string,
   "C": string
 }, ...]
-{{</code>}} | A list of valid subjects used for additional certificate validations during TLS client authentication. All subject attributes are case-sensitive.<br />**Required subject fields**:<br />"CN" for Common Name<br />**Optional subject fields:**<br />"O" for Organization<br />"OU" for Organizational Unit<br />"L" for Locality (city)<br />"ST" for State/Province<br />"C" for 2-letter country code  |
+{{</code>}} | A list of valid subjects used for additional certificate validations during TLS client authentication. All subject attributes are case-sensitive.<br />**Required subject fields**:<br />"CN" for Common Name<br />**Optional subject fields:**<br />"O" for Organization<br />"OU" for Organizational Unit (array of strings)<br />"L" for Locality (city)<br />"ST" for State/Province<br />"C" for 2-letter country code  |
 | avoid_nodes | array of strings | Cluster node UIDs to avoid when placing the database's shards and binding its endpoints |
 | background_op | {{<code>}}
 [{

--- a/content/rs/references/rest-api/objects/cluster/_index.md
+++ b/content/rs/references/rest-api/objects/cluster/_index.md
@@ -28,7 +28,10 @@ An API object that represents the cluster.
 | email_alerts | boolean (default:&nbsp;false) | Send node/cluster email alerts (requires valid SMTP and email_from settings) |
 | email_from | string | Sender email for automated emails |
 | encrypt_pkeys | boolean (default:&nbsp;false) | Enable or turn off encryption of private keys |
+| envoy_admin_port | integer, (range:&nbsp;1024-65535) | Envoy admin port. Changing this port during runtime might result in an empty response since envoy serves as the cluster gateway.|
 | envoy_max_downstream_connections | integer, (range:&nbsp;100-2048) | The max downstream connections envoy is allowed to open |
+| envoy_mgmt_server_port | integer, (range:&nbsp;1024-65535) | Envoy management server port|
+| gossip_envoy_admin_port | integer, (range:&nbsp;1024-65535) | Gossip envoy admin port|
 | handle_redirects | boolean (default:&nbsp;false) | Handle API HTTPS requests and redirect to the master node internally |
 | http_support | boolean (default:&nbsp;false) | Enable or turn off HTTP support |
 | min_control_TLS_version | '1' <br />'1.1' <br />'1.2' <br />'1.3' | The minimum version of TLS protocol which is supported at the control path |

--- a/content/rs/references/rest-api/objects/cluster/_index.md
+++ b/content/rs/references/rest-api/objects/cluster/_index.md
@@ -28,7 +28,7 @@ An API object that represents the cluster.
 | email_alerts | boolean (default:&nbsp;false) | Send node/cluster email alerts (requires valid SMTP and email_from settings) |
 | email_from | string | Sender email for automated emails |
 | encrypt_pkeys | boolean (default:&nbsp;false) | Enable or turn off encryption of private keys |
-| envoy_admin_port | integer, (range:&nbsp;1024-65535) | Envoy admin port. Changing this port during runtime might result in an empty response since envoy serves as the cluster gateway.|
+| envoy_admin_port | integer, (range:&nbsp;1024-65535) | Envoy admin port. Changing this port during runtime might result in an empty response because envoy serves as the cluster gateway.|
 | envoy_max_downstream_connections | integer, (range:&nbsp;100-2048) | The max downstream connections envoy is allowed to open |
 | envoy_mgmt_server_port | integer, (range:&nbsp;1024-65535) | Envoy management server port|
 | gossip_envoy_admin_port | integer, (range:&nbsp;1024-65535) | Gossip envoy admin port|

--- a/content/rs/release-notes/legacy-release-notes/_index.md
+++ b/content/rs/release-notes/legacy-release-notes/_index.md
@@ -1,9 +1,10 @@
 ---
 Title: Previous releases
 linkTitle: Previous releases
-description: Release notes for Redis Enterprise Software 5.4.14 (February 2020) and earlier versions.
+description: Release notes for Redis Enterprise Software 5.6.0 (April 2020) and earlier versions.
 weight: 100
 alwaysopen: false
 categories: ["RS"]
 ---
-{{< allchildren style="h2" sort="Weight" >}}
+
+{{<table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes,OSS&nbsp;Redis compatibility" columnSources="LinkTitle,Description,compatibleOSSVersion" enableLinks="LinkTitle">}}

--- a/content/rs/release-notes/legacy-release-notes/rs-5-5-preview-april-2019.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-5-preview-april-2019.md
@@ -1,10 +1,11 @@
 ---
 Title: Redis Enterprise Software Release Notes 5.5 Preview (April 2019)
-linkTitle: 5.5 Preview (April 2019)
+linkTitle: 5.5 preview (April 2019)
 description: Preview release.  Databases support multiple modules.  
-weight: 87
+weight: 81
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-5-preview-april-2019/
 ---
 Redis Enterprise Software (RS) 5.5 Preview Edition is now available.
 

--- a/content/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise Software Release Notes 5.6.0 (April 2020)
 linkTitle: 5.6.0 (April 2020)
-description: Install improvements for RHEL 6 and 7.  Active-Active support for HyperLogLog.  Redis on Flash now supports RedisJSON.  Active-Active default changes for high availability and OSS Cluster API support.  Backup support for Google Cloud Storage and Azure Blob storage.
+description: Install improvements for RHEL 6 and 7. Active-Active support for HyperLogLog. Redis on Flash now supports RedisJSON. Active-Active default changes for high availability and OSS Cluster API support. Backup support for Google Cloud Storage and Azure Blob storage.
 compatibleOSSVersion: Redis 5.0.8
 weight: 80
 alwaysopen: false

--- a/content/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-6-0-april-2020.md
@@ -3,9 +3,10 @@ Title: Redis Enterprise Software Release Notes 5.6.0 (April 2020)
 linkTitle: 5.6.0 (April 2020)
 description: Install improvements for RHEL 6 and 7.  Active-Active support for HyperLogLog.  Redis on Flash now supports RedisJSON.  Active-Active default changes for high availability and OSS Cluster API support.  Backup support for Google Cloud Storage and Azure Blob storage.
 compatibleOSSVersion: Redis 5.0.8
-weight: 81
+weight: 80
 alwaysopen: false
 categories: ["RS"]
+aliases: /rs/release-notes/rs-5-6-0-april-2020/
 ---
 [Redis Enterprise Software (RS) 5.6.0](https://redislabs.com/download-center/) is now available. This major version release includes:
 

--- a/content/rs/release-notes/rs-6-4-2.md
+++ b/content/rs/release-notes/rs-6-4-2.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise Software release notes 6.4.2 (February 2023)
 linkTitle: 6.4.2 (February 2023)
-description: Pub/sub ACLs & default permissions. Validate client certificates by subject attributes.
+description: Pub/sub ACLs & default permissions. Validate client certificates by subject attributes. Ubuntu 20.04 support.
 compatibleOSSVersion: Redis 6.2.6
 weight: 72
 alwaysopen: false
@@ -11,6 +11,100 @@ aliases: [ /rs/release-notes/rs-6-4-2/,
            /rs/release-notes/rs-6-4-2,
            /rs/release-notes/rs-6-4-2.md ]
 ---
+
+## 6.4.2-43 (March 2023)
+
+This is a maintenance release for ​[​Redis Enterprise Software version 6.4.2](https://redis.com/redis-enterprise-software/download-center/software/).
+
+The following table shows the MD5 checksums for the available packages:
+
+| Package | MD5 checksum (6.4.2 March release) |
+|---------|---------------------------------------|
+| Ubuntu 16 | TBD |
+| Ubuntu 18 | TBD |
+| Ubuntu 20 | TBD |
+| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | TBD |
+| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 <br/>Rocky Enterprise Linux | TBD |
+
+### Features and enhancements
+
+#### Support for Ubuntu 20
+
+Added operating system support for Ubuntu 20.04.
+
+#### Validate client certificates by subject attributes
+
+- Added the ability to enter multiple `Organizational Unit (OU)` values to a certificate validation's subject entry. Subject validation only succeeds if all `OU` values match.
+
+- Validation fails if the certificate’s subject contains an extra field which is missing from the certificate’s configured subject (empty field).
+
+#### Safe node removal (RS92095)
+
+As of this release, the node removal task waits for persistence files to be created on a new node before finishing removal. For more information, see [Remove a cluster node](https://docs.redis.com/latest/rs/clusters/remove-node/) and [`rladmin node remove`](https://docs.redis.com/latest/rs/references/cli-utilities/rladmin/node/remove/).
+
+#### Allow port configuration for gossip_envoy service (RS72028) 
+
+You can use the REST API to configure the `gossip_envoy_admin_port` during bootstrapping or runtime. See the [cluster object reference]({{<relref "/rs/references/rest-api/objects/cluster">}}) for more details.
+
+Support for `rladmin` will be added in a future 6.4.2 maintenance release.
+
+### Known operating system limitations
+
+#### RHEL 7 and RHEL 8
+
+RS95344 - CRDB database will not start on Redis Enterprise v6.4.2 with a custom installation path.
+
+For a workaround, use the following commands to add the relevant CRDB files to the Redis library:
+
+```sh
+$ yum install -y chrpath
+$ find $installdir -name "crdt.so" | xargs -n1 -I {} /bin/bash -c 'chrpath -r ${libdir} {}'
+```
+
+This limitation was fixed in Redis Enterprise v6.4.2-43 (March maintenance release).
+
+#### Ubuntu 20.04
+
+- By default, you cannot use the SHA1 hash algorithm ([OpenSSL’s default security level is set to 2](https://manpages.ubuntu.com/manpages/focal/man3/SSL_CTX_set_security_level.3ssl.html#notes)). The operating system will reject SHA1 certificates even if the `mtls_allow_weak_hashing` option is enabled. You need to replace SHA1 certificates with newer certificates that use SHA-256. Note that the certificates provided with Redis Enterprise Software use SHA-256.  
+
+- RS95824 - Can't run `rl_rdbconvert` manually on Debian-based systems
+
+### Redis modules 
+
+Redis Enterprise Software v6.4.2 includes the new features delivered in the latest [Redis Stack release (v6.2.6)](https://redis.com/blog/introducing-redis-stack-6-2-6-and-7-0-6/ ):
+
+- [RediSearch v2.6.4](https://docs.redis.com/latest/modules/redisearch/release-notes/redisearch-2.6-release-notes/#v264-december-2022)
+
+- [RedisJSON v2.4.5](https://docs.redis.com/latest/modules/redisjson/release-notes/redisjson-2.4-release-notes/#v245-february-2023)
+
+- [RedisBloom v2.4.3](https://docs.redis.com/latest/modules/redisbloom/release-notes/redisbloom-2.4-release-notes/#v24-ga-v243-november-2022)
+
+- [RedisGraph v2.10.5](https://docs.redis.com/latest/modules/redisgraph/release-notes/redisgraph-2.10-release-notes/#v2105-december-2022)
+
+- [RedisTimeSeries v1.8.5](https://docs.redis.com/latest/modules/redistimeseries/release-notes/redistimeseries-1.8-release-notes/#v185-january-2023)
+
+### Resolved issues
+
+- RS95344 - Fix custom installation linkage bug for files related to Active-Active
+
+- RS91554 - Enhance visibility of `redis_mgr` 
+
+- RS90496 - Improve cross-node communication to support failovers
+
+- RS93004 - Allow positive `audit_port` configuration
+
+- RS58918 - Reduce the number of blocked clients by blocking only clients requested to flush until completion. Other clients won’t be affected.
+
+- RS85447 - When creating a database, the memory size is total memory for the database, not total dataset size. Therefore, if you enable replication and the database has two shards, each shard will have half of the allocated memory size.
+
+- RS90556 -  `Heartbeatd` - upgrade [`sysinfo`](https://crates.io/crates/sysinfo) dependency 0.19.1 -> 0.27.7
+
+- RS62552 - Fix database authentication failures for LDAP users when the password contains the `%` character
+
+- RS93566 - Added [`rlcheck`](https://docs.redis.com/latest/rs/references/cli-utilities/rlcheck/) validation step to verify that all needed modules (modules used during the initial creation of any CRDBs on the cluster) are actually available on the cluster. In some cases, if a specific module version is required, the user will need to upload it in order to upgrade the cluster. After the upgrade is complete, you can delete the required module.
+
+
+## 6.4.2 GA (6.4.2-30) (February 2023)
 
 ​[​Redis Enterprise Software version 6.4.2](https://redis.com/redis-enterprise-software/download-center/software/) is now available!
 
@@ -36,16 +130,16 @@ This version offers:
 
 - Additional enhancements and bug fixes
 
-## Features and enhancements
+### Features and enhancements
 
-### Validate client certificates by subject attributes
+#### Validate client certificates by subject attributes
 
 You can now validate client certificates by their `Subject` attributes. When a client attempts to connect to a database, Redis Enterprise Software compares the values of the client certificate subject attributes to the subject values allowed by the database. Clients can connect to the database only if the subject values match. This gives more flexibility in controlling which clients can access which databases.
 
 See [Enable TLS](https://docs.redis.com/latest/rs/security/tls/enable-tls/) for more information.
 
 
-### Default pub/sub ACL permissions
+#### Default pub/sub ACL permissions
 
 Redis is continuously enhancing its ACL (access control list) functionality and coverage. Redis version 6.2 enhances [ACLs](https://redis.io/docs/management/security/acl/) to allow and disallow pub/sub channels. 
 
@@ -57,13 +151,13 @@ To allow certain users to access specific pub/sub channels, define the appropria
 
 If you use ACLs and pub/sub channels, we recommend you review your databases and ACL settings and plan to change your cluster to restricted mode. This will help you prepare for future Redis Enterprise Software releases that use restrictive `resetchannels` as the new default for `acl-pubsub-default`.
 
-## Version changes 
+### Version changes 
 
-### Breaking changes
+#### Breaking changes
 
 - REST API: the `authorized_names` field of the [BDB object](https://docs.redis.com/latest/rs/references/rest-api/objects/bdb/) is deprecated. Use the new `authorized_subjects` field instead.
 
-### New default Redis DB version
+#### New default Redis DB version
 
 Both Redis Enterprise Software versions 6.2.x and 6.4.x package two Redis DB versions: Redis DB 6.0 and Redis DB 6.2. Until now, the default Redis DB version for creating new databases and upgrading existing databases was 6.0 (enforced by the `redis_upgrade_policy` parameter).
 
@@ -113,25 +207,25 @@ The 3DES encryption cipher is considered deprecated in favor of stronger ciphers
 Please verify that all clients, apps, and connections support the AES cipher. Support for 3DES will be removed in a future release.
 Certain operating systems, such as RHEL 8, have already removed support for 3DES. Redis Enterprise Software cannot support cipher suites that are not supported by the underlying operating system.
 
-## Redis modules 
+### Redis modules 
 
 Redis Enterprise Software v6.4.2 includes the following Redis modules:
 
-- [RediSearch v2.4.16](https://docs.redis.com/latest/modules/redisearch/)
+- [RediSearch v2.4.16](https://docs.redis.com/latest/modules/redisearch/release-notes/redisearch-2.4-release-notes/#v2416-november-2022)
 
-- [RedisJSON v2.2.0](https://docs.redis.com/latest/modules/redisjson/release-notes/redisjson-2.0-release-notes/)
+- [RedisJSON v2.2.0](https://docs.redis.com/latest/modules/redisjson/release-notes/redisjson-2.2-release-notes/#v220-july-2022)
 
-- [RedisBloom v2.2.18](https://docs.redis.com/latest/modules/redisbloom/release-notes/redisbloom-2.2-release-notes/)
+- [RedisBloom v2.2.18](https://docs.redis.com/latest/modules/redisbloom/release-notes/redisbloom-2.2-release-notes/#v2218-july-2022)
 
-- [RedisGraph v2.8.20](https://docs.redis.com/latest/modules/redisgraph/)
+- [RedisGraph v2.8.20](https://docs.redis.com/latest/modules/redisgraph/release-notes/redisgraph-2.8-release-notes/#v2820-september-2022)
 
-- [RedisTimeSeries v1.6.17](https://docs.redis.com/latest/modules/redistimeseries/)
+- [RedisTimeSeries v1.6.17](https://docs.redis.com/latest/modules/redistimeseries/release-notes/redistimeseries-1.6-release-notes/#v1617-july-2022)
 
 See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-module/) to learn how to upgrade a module for a database. 
 
-## Additional enhancements
+### Additional enhancements
 
-### Installations, upgrades, and troubleshooting
+#### Installations, upgrades, and troubleshooting
 
 - Added the ability for `install.sh` to run even if “upgrade mode” is already enabled to allow reruns in case of a previous run failure (RS77319)
 
@@ -143,7 +237,7 @@ See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-modu
 
 - Added an alert to notify when a node operation (such as maintenance mode) failed, aborted, or was canceled. The alert is enabled by default (RS76089)
 
-## Resolved issues
+### Resolved issues
 
 - RS72866 - Improved performance for client connections which use TLS
 
@@ -163,9 +257,9 @@ See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-modu
 
 - RS87191 - Fixed a cross slot error when using Redis on Flash with Replica Of, in case a key on the source database swapped from RAM to flash and expired while it was also part of Lua script execution
 
-## Security
+### Security
 
-### Open source Redis security fixes compatibility
+#### Open source Redis security fixes compatibility
 
 As part of Redis's commitment to security, Redis Enterprise Software implements the latest [security fixes](https://github.com/redis/redis/releases) available with [open source Redis](https://github.com/redis/redis). The following open source Redis [CVEs](https://github.com/redis/redis/security/advisories) do not affect Redis Enterprise:
 

--- a/content/rs/release-notes/rs-6-4-2.md
+++ b/content/rs/release-notes/rs-6-4-2.md
@@ -71,7 +71,7 @@ This limitation was fixed in Redis Enterprise v6.4.2-43 (March maintenance relea
 
 #### Ubuntu 16, 18, 20
 
-RS95824 - Error occurs when running `rl_rdbconvert` manually.
+RS95824 - An error occurs when running `rl_rdbconvert` manually.
 
 As a workaround, run the following command:
 

--- a/content/rs/release-notes/rs-6-4-2.md
+++ b/content/rs/release-notes/rs-6-4-2.md
@@ -93,7 +93,7 @@ Redis Enterprise Software v6.4.2 includes the new features delivered in the late
 
 - RS93004 - Allow positive `audit_port` configuration
 
-- RS58918 - Reduce the number of blocked clients by blocking only clients requested to flush until completion. Other clients won't be affected.
+- RS58918 - Reduce the number of clients blocked by flushing a database. Only the client that requested the flush will be blocked until the action finishes. Other clients won't be affected.
 
 - RS85447 - When creating a database, the memory size is total memory for the database, not the total dataset size. Therefore, if you enable replication and the database has two shards, each shard will have half of the allocated memory size.
 

--- a/content/rs/release-notes/rs-6-4-2.md
+++ b/content/rs/release-notes/rs-6-4-2.md
@@ -93,9 +93,9 @@ Redis Enterprise Software v6.4.2 includes the new features delivered in the late
 
 - RS93004 - Allow positive `audit_port` configuration
 
-- RS58918 - Reduce the number of blocked clients by blocking only clients requested to flush until completion. Other clients won’t be affected.
+- RS58918 - Reduce the number of blocked clients by blocking only clients requested to flush until completion. Other clients won't be affected.
 
-- RS85447 - When creating a database, the memory size is total memory for the database, not total dataset size. Therefore, if you enable replication and the database has two shards, each shard will have half of the allocated memory size.
+- RS85447 - When creating a database, the memory size is total memory for the database, not the total dataset size. Therefore, if you enable replication and the database has two shards, each shard will have half of the allocated memory size.
 
 - RS90556 -  `Heartbeatd` - upgrade [`sysinfo`](https://crates.io/crates/sysinfo) dependency 0.19.1 -> 0.27.7
 

--- a/content/rs/release-notes/rs-6-4-2.md
+++ b/content/rs/release-notes/rs-6-4-2.md
@@ -20,11 +20,11 @@ The following table shows the MD5 checksums for the available packages:
 
 | Package | MD5 checksum (6.4.2 March release) |
 |---------|---------------------------------------|
-| Ubuntu 16 | TBD |
-| Ubuntu 18 | TBD |
-| Ubuntu 20 | TBD |
-| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | TBD |
-| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 <br/>Rocky Enterprise Linux | TBD |
+| Ubuntu 16 | bb3d3ab7590834790d2d9d9e3dcdf788 |
+| Ubuntu 18 | 55e99e6db76277c15fa46c49d58995b5 |
+| Ubuntu 20 | cccfa62ca7ea955b8c19d9c40bdc1fea |
+| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | eed4083b0b4c066d31ea9b8ba60a34f5 |
+| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 <br/>Rocky Enterprise Linux | 7fd4321f6a5502c76197fc039f44ffa3 |
 
 ### Features and enhancements
 
@@ -68,6 +68,16 @@ This limitation was fixed in Redis Enterprise v6.4.2-43 (March maintenance relea
 - By default, you cannot use the SHA1 hash algorithm ([OpenSSL’s default security level is set to 2](https://manpages.ubuntu.com/manpages/focal/man3/SSL_CTX_set_security_level.3ssl.html#notes)). The operating system will reject SHA1 certificates even if the `mtls_allow_weak_hashing` option is enabled. You need to replace SHA1 certificates with newer certificates that use SHA-256. Note that the certificates provided with Redis Enterprise Software use SHA-256.  
 
 - RS95824 - Can't run `rl_rdbconvert` manually on Debian-based systems
+
+#### Ubuntu 16, 18, 20
+
+RS95824 - Error occurs when running `rl_rdbconvert` manually.
+
+As a workaround, run the following command:
+
+```sh
+LD_LIBRARY_PATH=$libdir rl_rdbconvert
+```
 
 ### Redis modules 
 

--- a/content/rs/security/tls/enable-tls.md
+++ b/content/rs/security/tls/enable-tls.md
@@ -58,7 +58,7 @@ You can enable TLS by editing the configuration of an existing database (as show
         | _State / Province (ST)_ | The organization's state or province |
         | _Country (C)_ | 2-letter code that represents the organization's country |
 
-        You can only enter a single value for each field. If your client certificate has a `Subject` attribute with multiple values (such as OU=unit1; OU=unit2), add a separate `Subject` entry for each.
+        You can only enter a single value for each field, except for the _Organizational Unit (OU)_ field. If your client certificate has a `Subject` with multiple  _Organizational Unit (OU)_ values, enter a comma-separated list of values with each value enclosed in quotation marks (for example `"unit1","unit2"`).
 
         **Breaking change:** If you use the [REST API]({{<relref "/rs/references/rest-api">}}) instead of the admin console to configure additional certificate validations, note that `authorized_names` is deprecated as of Redis Enterprise v6.4.2. Use `authorized_subjects` instead. See the [BDB object reference]({{<relref "/rs/references/rest-api/objects/bdb">}}) for more details.
 


### PR DESCRIPTION
Staged previews:
- [Release notes](https://docs.redis.com/staging/release-rs-diablo-m1/rs/release-notes/rs-6-4-2/)
- [Supported platforms](https://docs.redis.com/staging/release-rs-diablo-m1/rs/installing-upgrading/supported-platforms/#supported-platforms) and [Ubuntu 20](https://docs.redis.com/staging/release-rs-diablo-m1/rs/installing-upgrading/supported-platforms/#ubuntu-20-rejects-sha1-certificates)
- [mTLS full subject](https://docs.redis.com/staging/release-rs-diablo-m1/rs/security/tls/enable-tls/#client) updates - allow multiple Organizational Unit (OU) values
