### PR TITLE
Redis ACL support tables

### DIFF
--- a/content/embeds/acl-command-compatibility.md
+++ b/content/embeds/acl-command-compatibility.md
@@ -1,0 +1,14 @@
+| Command | Supported |
+|:--------|:----------|
+| [ACL CAT](https://redis.io/commands/acl-cat) | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</span> 
+| [ACL DELUSER](https://redis.io/commands/acl-deluser) | <span title="Not supported">&#x274c; Not supported</span>| <span title="Not supported">&#x274c; Not supported</span>|  |
+| [ACL GENPASS](https://redis.io/commands/acl-genpass) | <span title="Not supported">&#x274c; Not supported</span>| <span title="Not supported">&#x274c; Not supported</span>|  |
+| [ACL GETUSER](https://redis.io/commands/acl-getuser) | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</span> 
+| [ACL HELP](https://redis.io/commands/acl-help) | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</span> 
+| [ACL LIST](https://redis.io/commands/acl-list) | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</span> 
+| [ACL LOAD](https://redis.io/commands/acl-load) | <span title="Not supported">&#x274c; Not supported</span>| <span title="Not supported">&#x274c; Not supported</span>|  |
+| [ACL LOG](https://redis.io/commands/acl-log) | <span title="Not supported">&#x274c; Not supported</span>| <span title="Not supported">&#x274c; Not supported</span>|  |
+| [ACL SAVE](https://redis.io/commands/acl-save) | <span title="Not supported">&#x274c; Not supported</span>| <span title="Not supported">&#x274c; Not supported</span>|  |
+| [ACL SETUSER](https://redis.io/commands/acl-setuser) | <span title="Not supported">&#x274c; Not supported</span>| <span title="Not supported">&#x274c; Not supported</span>|  |
+| [ACL USERS](https://redis.io/commands/acl-users) | <span title="Supported">&#x2705; Supported</span> |
+| [ACL WHOAMI](https://redis.io/commands/acl-whoami) | <span title="Supported">&#x2705; Supported</span> |

--- a/content/rc/security/database-security/passwords-users-roles.md
+++ b/content/rc/security/database-security/passwords-users-roles.md
@@ -87,11 +87,9 @@ In open source Redis, you can create users and assign ACLs to them using the `AC
 Redis does not support generic roles.
 
 In Redis Enterprise Cloud, you configure RBAC using the admin console. As a result, certain open source Redis ACL
-subcommands are not available in Redis Cloud.
+subcommands are not available in Redis Cloud. The following table shows which ACL commands are supported.
 
-Specifically, Redis Cloud databases block the following ACL subcommands: `LOAD`, `SAVE`, `SETUSER`, `DELUSER`, `GENPASS`, and `LOG`.
-
-Redis Cloud databases allow these ACL subcommands: `LIST`, `USERS`, `GETUSER`, `CAT`, `WHOAMI`, and `HELP`.
+{{<embed-md "acl-command-compatibility.md">}}
 
 In open source Redis, you must explicitly provide access to the `MULTI`, `EXEC`, and `DISCARD` commands.
 In Redis Cloud, these commands, which are used in transactions, are always permitted. However, the commands

--- a/content/rs/security/access-control/configure-acl.md
+++ b/content/rs/security/access-control/configure-acl.md
@@ -90,27 +90,11 @@ To make default pub/sub permissions restrictive:
         { "acl_pubsub_default": "resetchannels" }
         ```
 
-## Blocked ACL commands
+## ACL command support
 
-The following ACL commands are blocked in Redis Enterprise: 
+Redis Enterprise Software does not support certain open source Redis ACL commands. Instead, you can manage access controls from the admin console.
 
-- `LOAD` 
-- `SAVE` 
-- `SETUSER`
-- `DELUSER`
-- `GENPASS`
-- `LOG`
-
-## Allowed ACL subcommands
-
-The following ACL subcommands are allowed in Redis Enterprise: 
-
-- `LIST` 
-- `USER`
-- `GETUSER`
-- `CAT`
-- `WHOAMI`
-- `HELP`
+{{<embed-md "acl-command-compatibility.md">}}
 
 {{<note>}}
 The `MULTI`, `EXEC`, `DISCARD` commands are always allowed, but ACLs are enforced on `MULTI` subcommands.


### PR DESCRIPTION
Replaced the lists of blocked/allowed ACL commands with a table.

Staged previews:
- [Software ACL command support](https://docs.redis.com/staging/jira-doc-1894/rs/security/access-control/configure-acl/#acl-command-support)
- [Cloud ACL command support](https://docs.redis.com/staging/jira-doc-1894/rc/security/database-security/passwords-users-roles/#oss-redis-acls-vs-redis-enterprise-cloud-rbac)
