### PR TITLE
Update rs-6-2-10-february-2022.md

### DIFF
--- a/content/rs/release-notes/rs-6-2-10-february-2022.md
+++ b/content/rs/release-notes/rs-6-2-10-february-2022.md
@@ -47,7 +47,7 @@ The following table shows the MD5 checksums for the available packages.
 
 - Upgrades from versions earlier than v6.0 are not supported.
 
-- If you plan to upgrade your cluster to RHEL 8, refer to [v6.2.8 release notes](https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2022/) for known limitations.
+- If you plan to upgrade your cluster to RHEL 8, refer to [v6.2.8 release notes]([https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2021/](https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2021/)) for known limitations.
 
 - If you are using Active-Active or Active-Passive (ReplicaOf) databases and experience synchronization issues as a result of the upgrade, see RS67434 details in [Resolved issues](#resolved-issues) for help resolving the problem.
 

--- a/content/rs/release-notes/rs-6-2-10-february-2022.md
+++ b/content/rs/release-notes/rs-6-2-10-february-2022.md
@@ -47,7 +47,7 @@ The following table shows the MD5 checksums for the available packages.
 
 - Upgrades from versions earlier than v6.0 are not supported.
 
-- If you plan to upgrade your cluster to RHEL 8, refer to [v6.2.8 release notes]([https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2021/](https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2021/)) for known limitations.
+- If you plan to upgrade your cluster to RHEL 8, refer to [v6.2.8 release notes](https://docs.redis.com/latest/rs/release-notes/rs-6-2-8-october-2021/) for known limitations.
 
 - If you are using Active-Active or Active-Passive (ReplicaOf) databases and experience synchronization issues as a result of the upgrade, see RS67434 details in [Resolved issues](#resolved-issues) for help resolving the problem.
 


### PR DESCRIPTION
Broken link to the 6.2.8 release notes (and typo 2021 instead of 2022)