### PR TITLE
Update rs-6-4-2.md

### DIFF
--- a/content/rs/release-notes/rs-6-4-2.md
+++ b/content/rs/release-notes/rs-6-4-2.md
@@ -104,7 +104,7 @@ See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-modu
 
 When a database is configured as [rack-aware]({{<relref "/rs/clusters/configure/rack-zone-awareness">}}) and replication is turned off, the resharding operation fails.
 
-RS97971 - Fix will be included in the April maintenance release       
+RS97971 - This limitation will be fixed in a future 6.4.2 maintenance release.    
 
 Workaround:
 
@@ -133,7 +133,7 @@ $ yum install -y chrpath
 $ find $installdir -name "crdt.so" | xargs -n1 -I {} /bin/bash -c 'chrpath -r ${libdir} {}'
 ```
 
-This limitation was fixed in Redis Enterprise v6.4.2-43 (March maintenance release).
+This limitation will be fixed in a future 6.4.2 maintenance release.
 
 #### Ubuntu 20.04
 


### PR DESCRIPTION
hi @maayanagranat I've changed the wording to a general declaration instead of specifying an exact maintenance release because we have no guarantee of the content of any release until it's in the website. We can never commit to a specific release. In this case, the release notes declare that RS95344 will be fixed in March where it is fixed on April