### PR TITLE
Workaround to Grafana Datasource issue

### DIFF
--- a/static/code/rs/cluster.json
+++ b/static/code/rs/cluster.json
@@ -76,7 +76,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "none",
@@ -160,7 +160,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "none",
@@ -239,7 +239,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "none",
@@ -318,7 +318,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "short",
@@ -420,7 +420,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "fill": 3,
@@ -542,7 +542,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -640,7 +640,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -740,7 +740,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -835,7 +835,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 15,
           "legend": {
@@ -926,7 +926,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 19,
           "legend": {
@@ -1025,7 +1025,7 @@
               "value": "current"
             }
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "filterNull": false,
           "fontSize": "100%",
           "id": 23,
@@ -1076,7 +1076,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 28,
           "legend": {
@@ -1168,7 +1168,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 35,
           "legend": {
@@ -1256,7 +1256,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 0,
           "id": 47,
           "legend": {
@@ -1350,7 +1350,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -1370,7 +1370,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 0,
         "includeAll": true,
         "label": null,

--- a/static/code/rs/database.json
+++ b/static/code/rs/database.json
@@ -90,7 +90,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": null,
           "editable": true,
           "error": false,
@@ -171,7 +171,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "none",
@@ -250,7 +250,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "none",
@@ -329,7 +329,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "editable": true,
           "error": false,
           "format": "none",
@@ -408,7 +408,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -493,7 +493,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -620,7 +620,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 55,
           "legend": {
@@ -709,7 +709,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "description": "",
           "fill": 1,
           "id": 44,
@@ -817,7 +817,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 10,
           "legend": {
@@ -908,7 +908,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 14,
           "legend": {
@@ -1037,7 +1037,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 16,
           "legend": {
@@ -1129,7 +1129,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 43,
           "legend": {
@@ -1260,7 +1260,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 13,
           "legend": {
@@ -1340,7 +1340,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 53,
           "legend": {
@@ -1452,7 +1452,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 17,
           "legend": {
@@ -1537,7 +1537,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 11,
           "legend": {
@@ -1674,7 +1674,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 20,
           "legend": {
@@ -1755,7 +1755,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 21,
           "legend": {
@@ -1848,7 +1848,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 48,
           "legend": {
@@ -1926,7 +1926,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 57,
           "legend": {
@@ -2013,7 +2013,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 49,
           "legend": {
@@ -2117,7 +2117,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 23,
           "legend": {
@@ -2198,7 +2198,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 26,
           "legend": {
@@ -2277,7 +2277,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 47,
           "legend": {
@@ -2366,7 +2366,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 34,
           "legend": {
@@ -2461,7 +2461,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 50,
           "legend": {
@@ -2542,7 +2542,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 30,
           "legend": {
@@ -2620,7 +2620,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 22,
           "legend": {
@@ -2699,7 +2699,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 58,
           "legend": {
@@ -2792,7 +2792,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 51,
           "legend": {
@@ -2886,7 +2886,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 25,
           "legend": {
@@ -3005,7 +3005,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "description": "Positive is RAM, Negative is Flash",
           "fill": 1,
           "id": 52,
@@ -3114,7 +3114,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "description": "Positive is RAM, Negative is Flash",
           "fill": 1,
           "id": 54,
@@ -3201,7 +3201,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 19,
           "legend": {
@@ -3288,7 +3288,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 18,
           "legend": {
@@ -3383,7 +3383,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 33,
           "legend": {
@@ -3460,7 +3460,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 31,
           "legend": {
@@ -3537,7 +3537,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 37,
           "legend": {
@@ -3638,7 +3638,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 29,
           "legend": {
@@ -3715,7 +3715,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 27,
           "legend": {
@@ -3794,7 +3794,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 28,
           "legend": {
@@ -3901,7 +3901,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 32,
           "legend": {
@@ -3978,7 +3978,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 36,
           "legend": {
@@ -4055,7 +4055,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 35,
           "legend": {
@@ -4132,7 +4132,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 40,
           "legend": {
@@ -4219,7 +4219,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 46,
           "legend": {
@@ -4368,7 +4368,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 39,
           "legend": {
@@ -4517,7 +4517,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 42,
           "legend": {
@@ -4595,7 +4595,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 41,
           "legend": {
@@ -4673,7 +4673,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 56,
           "legend": {
@@ -4803,7 +4803,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -4823,7 +4823,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 0,
         "includeAll": false,
         "label": "BDB Id",
@@ -4843,7 +4843,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -4863,7 +4863,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 2,
         "includeAll": false,
         "label": null,

--- a/static/code/rs/node.json
+++ b/static/code/rs/node.json
@@ -75,7 +75,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": null,
           "format": "short",
           "gauge": {
@@ -155,7 +155,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": null,
           "format": "short",
           "gauge": {
@@ -235,7 +235,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": null,
           "format": "short",
           "gauge": {
@@ -315,7 +315,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(245, 54, 54, 0.9)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": 2,
           "format": "percentunit",
           "gauge": {
@@ -394,7 +394,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": null,
           "format": "bytes",
           "gauge": {
@@ -488,7 +488,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "decimals": 2,
           "fill": 6,
           "id": 3,
@@ -654,7 +654,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "description": "display the egress and ingress traffic on the node's NIC",
           "fill": 1,
           "id": 4,
@@ -755,7 +755,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "description": "display the egress and ingress traffic on the node's NIC",
           "fill": 1,
           "id": 32,
@@ -857,7 +857,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 12,
           "legend": {
@@ -950,7 +950,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 27,
           "legend": {
@@ -1050,7 +1050,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -1141,7 +1141,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 13,
           "legend": {
@@ -1233,7 +1233,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 11,
           "legend": {
@@ -1315,7 +1315,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 17,
           "legend": {
@@ -1409,7 +1409,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -1488,7 +1488,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 8,
           "legend": {
@@ -1568,7 +1568,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 29,
           "legend": {
@@ -1659,7 +1659,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 30,
           "legend": {
@@ -1837,7 +1837,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 16,
           "legend": {
@@ -1916,7 +1916,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 28,
           "legend": {
@@ -2002,7 +2002,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 6,
           "id": 22,
           "legend": {
@@ -2118,7 +2118,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 25,
           "legend": {
@@ -2208,7 +2208,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 5,
           "id": 23,
           "legend": {
@@ -2288,7 +2288,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 6,
           "id": 24,
           "legend": {
@@ -2380,7 +2380,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 20,
           "legend": {
@@ -2465,7 +2465,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 18,
           "legend": {
@@ -2551,7 +2551,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 21,
           "legend": {
@@ -2637,7 +2637,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 19,
           "legend": {
@@ -2715,7 +2715,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS1}",
+          "datasource": "DS_PROMETHEUS1",
           "fill": 1,
           "id": 31,
           "legend": {
@@ -2826,7 +2826,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -2846,7 +2846,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -2866,7 +2866,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS1}",
+        "datasource": "DS_PROMETHEUS1",
         "hide": 2,
         "includeAll": false,
         "label": null,


### PR DESCRIPTION
This PR replaces the preconfigured dashboards provided in Step 6 of the [Prometheus integration with Redis Enterprise Software](https://docs.redis.com/latest/rs/clusters/monitoring/prometheus-integration/)

The current json configurations:
- `database.json`
- `node.json`
- `cluster.json`

Use a variable `${DS_PROMETHEUS1}`, however, this causes Grafana to Report a Templating error `Failed to upgrade legacy queries Datasource ${DS_PROMETHEUS1} was not found` and the dashboards will not load.

See [Support dashboard variables in dashboard provisioning](https://github.com/grafana/grafana/issues/10786#top)
#10786] specifically [workaround comment](https://github.com/grafana/grafana/issues/10786#issuecomment-383931147) and [explanation comment](https://github.com/grafana/grafana/issues/10786#issuecomment-392377975)

There is a python script on the ticket, I just used `sed -i` 