### PR TITLE
DOC-1839 replace kubectl with oc

### DIFF
--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -95,7 +95,7 @@ The Redis Enterprise pods must run in OpenShift with privileges set in a [Securi
 
     ```sh
     oc adm policy add-scc-to-user redis-enterprise-scc \
-    system:serviceaccount:<my-project>:<rec>
+      system:serviceaccount:<my-project>:<rec>
     ```
 
   {{<note>}} If you are using version 6.2.18-41 or earlier, add additional permissions for your cluster.
@@ -182,8 +182,8 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
 1. Patch the validating webhook with the certificate.
 
     ```sh
-    oc patch ValidatingWebhookConfiguration /
-    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration \
+      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
 ### Limit the webhook to relevant namespaces
@@ -215,14 +215,14 @@ If not limited, the webhook intercepts requests from all namespaces. If you have
 1. Apply the patch.
 
     ```bash
-    oc patch ValidatingWebhookConfiguration /
-    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration \
+      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
   {{<note>}}
   For releases before 6.4.2-4, use this command instead:
     ```sh
-    oc patch ValidatingWebhookConfiguration /
-    redb-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration \
+      redb-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   The 6.4.2-4 release introduces a new `ValidatingWebhookConfiguration` to replace `redb-admission`. See the [6.4.2-4 release notes]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}).

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -128,7 +128,7 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
 1. Check the cluster status.
 
     ```sh
-    kubectl get pod
+    oc get pod
     ```
 
     You should receive a response similar to the following:
@@ -150,7 +150,7 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
    The operator creates a Kubernetes secret for the admission controller during deployment.
 
       ```sh
-      kubectl get secret admission-tls
+      oc get secret admission-tls
       ```
 
     The response will be similar to this:
@@ -163,13 +163,13 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
 1. Save the automatically generated certificate to a local environment variable.
 
     ```bash
-    CERT=`kubectl get secret admission-tls -o jsonpath='{.data.cert}'`
+    CERT=`oc get secret admission-tls -o jsonpath='{.data.cert}'`
     ```
 
 1. Create a patch file for the Kubernetes webhook using your own values for the namespace and webhook name.
 
     ```sh
-    sed '<your_namespace>' admission/webhook.yaml | kubectl create -f -
+    sed '<your_namespace>' admission/webhook.yaml | oc create -f -
     cat > modified-webhook.yaml <<EOF
     webhooks:
       - name: <your.admission.webhook>
@@ -182,7 +182,7 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
 1. Patch the validating webhook with the certificate.
 
     ```sh
-    kubectl patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
 ### Limit the webhook to relevant namespaces
@@ -215,12 +215,12 @@ If not limited, the webhook intercepts requests from all namespaces. If you have
 1. Apply the patch.
 
     ```bash
-    kubectl patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
   {{<note>}}
   For releases before 6.4.2-4, use this command instead:
     ```sh
-    kubectl patch ValidatingWebhookConfiguration redb-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration redb-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   The 6.4.2-4 release introduces a new `ValidatingWebhookConfiguration` to replace `redb-admission`. See the [6.4.2-4 release notes]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}).
@@ -231,7 +231,7 @@ If not limited, the webhook intercepts requests from all namespaces. If you have
 Apply an invalid resource as shown below to force the admission controller to reject it. If it applies successfully, the admission controller is not installed correctly.
 
 ```bash
-  $ kubectl apply -f - << EOF
+  $ oc apply -f - << EOF
    apiVersion: app.redislabs.com/v1alpha1
    kind: RedisEnterpriseDatabase
    metadata:

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -182,7 +182,8 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
 1. Patch the validating webhook with the certificate.
 
     ```sh
-    oc patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration /
+    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
 ### Limit the webhook to relevant namespaces
@@ -209,18 +210,19 @@ If not limited, the webhook intercepts requests from all namespaces. If you have
         matchLabels:
           namespace-name: staging
     EOF
-
     ```
 
 1. Apply the patch.
 
     ```bash
-    oc patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration /
+    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
   {{<note>}}
   For releases before 6.4.2-4, use this command instead:
     ```sh
-    oc patch ValidatingWebhookConfiguration redb-admission --patch "$(cat modified-webhook.yaml)"
+    oc patch ValidatingWebhookConfiguration /
+    redb-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   The 6.4.2-4 release introduces a new `ValidatingWebhookConfiguration` to replace `redb-admission`. See the [6.4.2-4 release notes]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}).
@@ -231,7 +233,7 @@ If not limited, the webhook intercepts requests from all namespaces. If you have
 Apply an invalid resource as shown below to force the admission controller to reject it. If it applies successfully, the admission controller is not installed correctly.
 
 ```bash
-  $ oc apply -f - << EOF
+  oc apply -f - << EOF
    apiVersion: app.redislabs.com/v1alpha1
    kind: RedisEnterpriseDatabase
    metadata:

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -24,8 +24,7 @@ Use these steps to set up a Redis Enterprise Software cluster with OpenShift.
 ## Prerequisites
 
 - [OpenShift cluster](https://docs.openshift.com/container-platform/4.8/installing/index.html) with at least 3 nodes (each meeting the [minimum requirements for a development installation]({{< relref "/rs/installing-upgrading/hardware-requirements.md" >}}))
-- [kubectl tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version 1.9 or higher
-- [OpenShift CLI](https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html) 
+- [OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
 
 ## Deploy the operator
 

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -49,18 +49,17 @@ Throughout this guide, each command is applied to the namespace in which the Red
 
 1. Create a new namespace
 
-    ```sh
-    kubectl create namespace <rec-namespace>
-    ```
+  ```sh
+  kubectl create namespace <rec-namespace>
+  ```
 
-2. Change the namespace context to make the newly created namespace default for future commands.
+. Change the namespace context to make the newly created namespace default for future commands.
 
-    ```sh
-    kubectl config set-context --current --namespace=<rec-namespace>
-    ```
+  ```sh
+  kubectl config set-context --current --namespace=<rec-namespace>
+  ```
 
 You can use an existing namespace as long as it does not contain any existing Redis Enterprise cluster resources. It's best practice to create a new namespace to make sure there are no Redis Enterprise resources that could interfere with the deployment.
-
 
 ## Install the operator
 
@@ -129,16 +128,16 @@ The following example creates a minimal Redis Enterprise cluster. See the [Redis
 
 1. Create a file (`my-rec.yaml`) that defines a Redis Enterprise cluster with three nodes:
 
-    ```sh
-    cat <<EOF > my-rec.yaml
-    apiVersion: "app.redislabs.com/v1"
-    kind: "RedisEnterpriseCluster"
-    metadata:
-      name: my-rec
-    spec:
-      nodes: 3
-    EOF
-    ```
+  ```sh
+  cat <<EOF > my-rec.yaml
+  apiVersion: "app.redislabs.com/v1"
+  kind: "RedisEnterpriseCluster"
+  metadata:
+    name: my-rec
+  spec:
+    nodes: 3
+  EOF
+  ```
 
     This will request a cluster with three Redis Enterprise nodes using the
     default requests (i.e., 2 CPUs and 4GB of memory per node).
@@ -146,45 +145,44 @@ The following example creates a minimal Redis Enterprise cluster. See the [Redis
     To test with a larger configuration, use the example below to add node resources to the `spec` section of your test cluster (`my-rec.yaml`).
 
     ```yaml
-      redisEnterpriseNodeResources:
-        limits:
-          cpu: 2000m
-          memory: 16Gi
-        requests:
-          cpu: 2000m
-          memory: 16Gi
+    redisEnterpriseNodeResources:
+      limits:
+        cpu: 2000m
+        memory: 16Gi
+      requests:
+        cpu: 2000m
+        memory: 16Gi
     ```
     {{<note>}}
 Each cluster must have at least 3 nodes. Single-node RECs are not supported.
     {{</note>}}
 
-    See the [Redis Enterprise hardware requirements]({{< relref "/rs/installing-upgrading/hardware-requirements.md">}}) for more
-    information on sizing Redis Enterprise node resource requests.
+  See the [Redis Enterprise hardware requirements]({{< relref "/rs/installing-upgrading/hardware-requirements.md">}}) for more information on sizing Redis Enterprise node resource requests.
   
 1. Apply your custom resource file in the same namespace as `my-rec.yaml`.
 
-    ```sh
-    kubectl apply -f my-rec.yaml
-    ```
+  ```sh
+  kubectl apply -f my-rec.yaml
+  ```
 
-    You should see a result similar to this:
+  You should see a result similar to this:
 
-    ```sh
-    redisenterprisecluster.app.redislabs.com/my-rec created
-    ```
+  ```sh
+  redisenterprisecluster.app.redislabs.com/my-rec created
+  ```
 
 1. You can verify the creation of the cluster with:
 
-    ```sh
-    kubectl get rec
-    ```
+  ```sh
+  kubectl get rec
+  ```
 
-    You should see a result similar to this:
+  You should see a result similar to this:
 
-    ```sh
-    NAME           AGE
-    my-rec   1m
-    ```
+  ```sh
+  NAME           AGE
+  my-rec   1m
+  ```
 
    At this point, the operator will go through the process of creating various
    services and pod deployments.
@@ -244,14 +242,16 @@ As part of the REC creation process, the operator stores the admission controlle
 1. Patch the webhook with the certificate.
 
     ```sh
-    kubectl patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    kubectl patch ValidatingWebhookConfiguration /
+    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   {{<note>}}
 
   For releases before 6.4.2-4, use this command instead:
     ```sh
-    kubectl patch ValidatingWebhookConfiguration redb-admission --patch "$(cat modified-webhook.yaml)"
+    kubectl patch ValidatingWebhookConfiguration /
+    redb-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   The 6.4.2-4 release introduces a new `ValidatingWebhookConfiguration` to replace `redb-admission`. See the [6.4.2-4 release notes]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}).
@@ -288,7 +288,8 @@ The operator bundle includes a webhook file. The webhook will intercept requests
 1. Apply the patch.
 
     ```sh
-    kubectl patch ValidatingWebhookConfiguration redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    kubectl patch ValidatingWebhookConfiguration /
+    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
 ## Verify the admission controller is working
@@ -296,7 +297,7 @@ The operator bundle includes a webhook file. The webhook will intercept requests
 1. Verify the admission controller is installed correctly by applying an invalid resource. This should force the admission controller to correct it.
 
     ```sh
-    $ kubectl apply -f - << EOF
+    kubectl apply -f - << EOF
     apiVersion: app.redislabs.com/v1alpha1
     kind: RedisEnterpriseDatabase
     metadata:

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -242,16 +242,16 @@ As part of the REC creation process, the operator stores the admission controlle
 1. Patch the webhook with the certificate.
 
     ```sh
-    kubectl patch ValidatingWebhookConfiguration /
-    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    kubectl patch ValidatingWebhookConfiguration \
+      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   {{<note>}}
 
   For releases before 6.4.2-4, use this command instead:
     ```sh
-    kubectl patch ValidatingWebhookConfiguration /
-    redb-admission --patch "$(cat modified-webhook.yaml)"
+    kubectl patch ValidatingWebhookConfiguration \
+      redb-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
   The 6.4.2-4 release introduces a new `ValidatingWebhookConfiguration` to replace `redb-admission`. See the [6.4.2-4 release notes]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}).
@@ -288,8 +288,8 @@ The operator bundle includes a webhook file. The webhook will intercept requests
 1. Apply the patch.
 
     ```sh
-    kubectl patch ValidatingWebhookConfiguration /
-    redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    kubectl patch ValidatingWebhookConfiguration \
+      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
     ```
 
 ## Verify the admission controller is working


### PR DESCRIPTION
DOC-1839
Replace kubectl commands in the OpenShift CLI guide with the oc command. 
Staged preview: https://docs.redis.com/staging/DOC-1839/kubernetes/deployment/openshift/openshift-cli/