### PR TITLE
Update api.md to include username for Redis Cluster

### DIFF
--- a/content/ri/using-redisinsight/api.md
+++ b/content/ri/using-redisinsight/api.md
@@ -75,6 +75,7 @@ The following additional parameters are required for Redis Cluster databases.
 | Parameter  | Type   | Description                                                        |
 |------------|--------|--------------------------------------------------------------------|
 | seedNodes  | array  | An array of objects describing the nodes of the cluster. At least one node should be specified. The objects must contain properties `host` (string) and `port` (integer) |
+| username   | string | (optional) The username for your Redis datanase.                                  |
 | password   | string | (optional) The password for your Redis datanase.                                  |
 | tls        | object | (optional) [TLS parameters for the database](#tls-parameters)      |
 

--- a/content/ri/using-redisinsight/api.md
+++ b/content/ri/using-redisinsight/api.md
@@ -86,6 +86,8 @@ The following additional parameters are required for Redis Cluster databases.
 {
     "name": "QA Redis Cluster DB",
     "connectionType": "CLUSTER",
+    "username": "USERNAME",
+    "password": "PASSWORD",
     "seedNodes": [
         {
             "host": "redis-cluster-node-1.acme.com",

--- a/content/ri/using-redisinsight/api.md
+++ b/content/ri/using-redisinsight/api.md
@@ -75,8 +75,8 @@ The following additional parameters are required for Redis Cluster databases.
 | Parameter  | Type   | Description                                                        |
 |------------|--------|--------------------------------------------------------------------|
 | seedNodes  | array  | An array of objects describing the nodes of the cluster. At least one node should be specified. The objects must contain properties `host` (string) and `port` (integer) |
-| username   | string | (optional) The username for your Redis datanase.                                  |
-| password   | string | (optional) The password for your Redis datanase.                                  |
+| username   | string | (optional) The username for your Redis database.                                  |
+| password   | string | (optional) The password for your Redis database.                                  |
 | tls        | object | (optional) [TLS parameters for the database](#tls-parameters)      |
 
 


### PR DESCRIPTION
## tl;dr;

api.md missing `username` info in ACL authentication, which is mandatory for Redis Cluster.

I've confirm I can add Redis Cluster (ElastiCache ACL & MemoryDB) with following JSON.

```json
{ "name": "Cache","connectionType": "CLUSTER","seedNodes": [{ "host": "clustercfg.CLUSTER_NAME.xxxxxx.apne1.cache.amazonaws.com","port": 6379 }], "username": "USERNAME", "password": "PASSWORD","tls": { "useTls": true, "clientAuth": false } }
```
