### PR TITLE
RS: Deprecated watchdog_profile & added failure_detection_sensitivity

### DIFF
--- a/content/rs/clusters/optimize/optimization.md
+++ b/content/rs/clusters/optimize/optimization.md
@@ -12,36 +12,45 @@ aliases: [
     /rs/clusters/optimize/optimization/,
 ]
 ---
-Redis Enterprise Software employs various algorithms to optimize
-performance. As part of this process, Redis Enterprise Software examines usage characteristics
-and load to adjust its run-time configuration accordingly. Depending
-on your specific usage characteristics and load, it might take Redis Enterprise Software some
-time to adjust itself to optimal performance.
+Redis Enterprise Software uses various algorithms to optimize
+performance. As part of this process, Redis Enterprise Software examines usage
+and load to adjust its runtime configuration. Depending
+on your specific usage and load, Redis Enterprise Software might take some
+time to adjust for optimal performance.
 
 To ensure optimal performance, you must run your workload several times
 and for a long duration until performance stabilizes.
 
-In addition, you can optimize your cluster for two different environments:
+## Failure detection sensitivity policies
 
-- Local-network environment
-- Cloud environment
+You can optimize your cluster's thresholds and timeouts for different environments using the `failure_detection_sensitivity` cluster policy:
 
-Depending on which configuration you choose, Redis Enterprise Software uses different
-thresholds to make operation related decisions.
+- `high` (previously known as `local-network watchdog_profile`) – high failure detection sensitivity, lower thresholds, and faster failure detection and failover
 
-The default configuration is for local-network environments. If you are
-running in a cloud environment, it is advisable that you change the
+- `low` (previously known as `cloud watchdog_profile`) – low failure detection sensitivity and higher tolerance for latency variance (also called network jitter)
+
+Depending on which policy you choose, Redis Enterprise Software uses different
+thresholds to make operation-related decisions.
+
+The default policy is `high` failure detection sensitivity for `local-network` environments. If you are
+running Redis Enterprise in a cloud environment, you should change the
 configuration.
 
-## How to change the cluster environment configuration
+## Change failure detection sensitivity
 
-In the `rladmin` command-line interface (CLI), run the following command:
+To change the cluster's `failure_detection_sensitivity`, run one of the following [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}) commands.
 
-```sh
-rladmin tune cluster watchdog_profile [cloud | local-network]
-```
+- For Redis Enterprise Software version 6.4.2-TBA and later, run:
 
-If after following all of the instructions above, you find that RS still
-does not meet your performance expectations, contact us
-at <support@redislabs.com> to help you optimize RS to your specific
-needs.
+    ```sh
+    rladmin tune cluster failure_detection_sensitivity [ low | high ]
+    ```
+
+- For Redis Enterprise Software version 6.4.2-61 and earlier, run:
+
+    ```sh
+    rladmin tune cluster watchdog_profile [ cloud | local-network ]
+    ```
+
+If Redis Enterprise Software still
+does not meet your performance expectations after following these instructions, [contact support](https://redis.com/company/support/) for help optimizing your environment.

--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -24,6 +24,7 @@ rladmin tune cluster
         [ redis_provision_node_threshold_percent <percent> ]
         [ redis_migrate_node_threshold_percent <percent> ]
         [ max_simultaneous_backups <size> ]
+        [ failure_detection_sensitivity { high | low } ]
         [ watchdog_profile { cloud | local-network } ]
         [ slave_ha { enabled | disabled } ]
         [ slave_ha_grace_period <seconds> ]
@@ -41,12 +42,6 @@ rladmin tune cluster
         [ acl_pubsub_default { resetchannels | allchannels } ]
 ```
 
-Redis cluster watchdog supports two preconfigured profiles:
-
-- The `cloud` profile is suitable for common cloud environments. It has a higher tolerance for network jitter.
-
-- The `local-network` profile is suitable for dedicated LANs. It has better failure detection and failover times.
-
 ### Parameters
 
 | Parameters                             | Type/Value                        | Description                                                                                                                  |
@@ -57,6 +52,7 @@ Redis cluster watchdog supports two preconfigured profiles:
 | default_concurrent_restore_actions     | integer<br />`all`              | Default number of concurrent actions when restoring a node from a snapshot (positive integer or "all")                         |
 | default_redis_version                  | version number                    | The default Redis database compatibility version used to create new databases.<br/><br/>  The value parameter should be a version number in the form of "x.y" where _x_ represents the major version number and _y_ represents the minor version number.  The final value corresponds to the desired version of Redis.<br/><br/>You cannot set _default_redis_version_ to a value higher than that supported by the current _redis_upgrade_policy_ value. |
 | expose_hostnames_for_all_suffixes      | `enabled`<br />`disabled`       | Exposes hostnames for all DNS suffixes                                                                                       |
+| failure_detection_sensitivity | `high`<br />`low` | Predefined thresholds and timeouts for failure detection (previously known as `watchdog_profile`)<br />• `high` (previously `local-network`) – high failure detection sensitivity, lower thresholds, faster failure detection and failover<br />• `low` (previously `cloud`) – low failure detection sensitivity, higher tolerance for latency variance (also called network jitter) |
 | login_lockout_counter_reset_after      | time in seconds                   | Time after failed login attempt before the counter resets to 0                                                                   |
 | login_lockout_duration                 | time in seconds                   | Time a locked account remains locked ( "0" means only an admin can unlock the account)                                   |
 | login_lockout_threshold                | integer                           | Number of failed sign-in attempts to trigger locking a user account ("0" means never lock the account)                   |
@@ -74,7 +70,7 @@ Redis cluster watchdog supports two preconfigured profiles:
 | slave_ha_bdb_cooldown_period           | time in seconds                   | Time (in seconds) after shard relocation during which databases can't be relocated to another node                           |
 | slave_ha_cooldown_period               | time in seconds                   | Time (in seconds) after shard relocation during which the replica high-availability mechanism can't relocate to another node |
 | slave_ha_grace_period                  | time in seconds                   | Time (in seconds) between when a node fails and when replica high availability starts relocating shards to another node      |
-| watchdog_profile                       | `cloud` <br /> `local-network` | Activates preconfigured watchdog profiles                                                          |
+| watchdog_profile                       | `cloud` <br /> `local-network` | Watchdog profiles with preconfigured thresholds and timeouts (deprecated as of Redis Enterprise Software v6.4.2-TBA; use `failure_detection_sensitivity` instead)<br />• `cloud` is suitable for common cloud environments and has a higher tolerance for latency variance (also called network jitter).<br />• `local-network` is suitable for dedicated LANs and has better failure detection and failover times. |
 
 ### Returns
 

--- a/content/rs/references/rest-api/objects/cluster_settings.md
+++ b/content/rs/references/rest-api/objects/cluster_settings.md
@@ -25,6 +25,7 @@ Cluster resources management policy
 | default_sharded_proxy_policy | `single`<br />`all-master-shards`<br />`all-nodes` | Default proxy_policy for newly created sharded databases' endpoints |
 | default_shards_placement | `dense`<br />`sparse` | Default shards_placement for a newly created databases |
 | endpoint_rebind_propagation_grace_time | integer | Time to wait between the addition and removal of a proxy |
+| failure_detection_sensitivity | `high`<br />`low` | Predefined thresholds and timeouts for failure detection (previously known as `watchdog_profile`)<br />• `high` (previously `local-network`) – high failure detection sensitivity, lower thresholds, faster failure detection and failover<br />• `low` (previously `cloud`) – low failure detection sensitivity, higher tolerance for latency variance (also called network jitter) |
 | login_lockout_counter_reset_after | integer | Number of seconds that must elapse between failed sign in attempts before the lockout counter is reset to 0. |
 | login_lockout_duration | integer | Duration (in secs) of account lockout. If set to 0, the account lockout will persist until released by an admin. |
 | login_lockout_threshold | integer | Number of failed sign in attempts allowed before locking a user account |

--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
@@ -55,7 +55,13 @@ See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-modu
 
 #### watchdog_profile
 
-The `watchdog_profile` setting is deprecated and will be removed in a future release. Instead, use the `failure_detection_sensitivity` policy, which has the following options for predefined thresholds and timeouts:
+The `watchdog_profile` setting is deprecated and will be removed in a future release. Instead, use the `failure_detection_sensitivity` policy for predefined thresholds and timeouts:
+
+```sh
+rladmin tune cluster failure_detection_sensitivity [ high | low ]
+```
+
+The `failure_detection_sensitivity` policy has the following options:
 
 - `high` (previously known as `local-network watchdog_profile`) – high failure detection sensitivity, lower thresholds, and faster failure detection and failover
 

--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
@@ -53,6 +53,14 @@ See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-modu
 
 ### Deprecations
 
+#### watchdog_profile
+
+The `watchdog_profile` setting is deprecated and will be removed in a future release. Instead, use the `failure_detection_sensitivity` policy, which has the following options for predefined thresholds and timeouts:
+
+- `high` (previously known as `local-network watchdog_profile`) – high failure detection sensitivity, lower thresholds, and faster failure detection and failover
+
+- `low` (previously known as `cloud watchdog_profile`) – low failure detection sensitivity and higher tolerance for latency variance (also called network jitter)
+
 #### Ubuntu 16.04
 
 Ubuntu 16 support is deprecated and will be removed in a future release.


### PR DESCRIPTION
Staged previews:
- [rladmin tune cluster](https://docs.redis.com/staging/DOC-2225/rs/references/cli-utilities/rladmin/tune/)
- [REST API cluster settings object](https://docs.redis.com/staging/DOC-2225/rs/references/rest-api/objects/cluster_settings/)
- [Cluster environment optimization](https://docs.redis.com/staging/DOC-2225/rs/clusters/optimize/optimization/)
- [Deprecation notice](https://docs.redis.com/staging/DOC-2225/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba/#deprecations)