### PR TITLE
DOC-2164 RS 6.4.2 May release notes and docs

### DIFF
--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -53,7 +53,7 @@ Make sure your system meets these requirements:
 
 6. <a name="table-note-6" style="display: block; height: 80px; margin-top: -80px;"></a>Ubuntu 20.04 support was added in Redis Enterprise Software [6.4.2-43]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-43">}}).
 
-7. <a name="table-note-7" style="display: block; height: 80px; margin-top: -80px;"></a>A release candidate for Amazon Linux 2 support was added in Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}).
+7. <a name="table-note-7" style="display: block; height: 80px; margin-top: -80px;"></a>A release candidate for Amazon Linux 2 support was added in Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}). Official support for Amazon Linux 2 was added in Redis Enterprise Software 6.4.2-TBA.
 
 ## Operating system limitations
 
@@ -76,7 +76,7 @@ Due to binary differences in modules between the two operating systems, you cann
 
 ### Modules not supported for Amazon Linux 2 release candidate
 
-A database with modules cannot reside on an Amazon Linux 2 (release candidate) node. Support will be added in a future maintenance release.
+A database with modules cannot reside on an Amazon Linux 2 (release candidate) node. This limitation affects Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}) but was fixed in version 6.4.2-TBA.
 
 ## VMware
 

--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -53,7 +53,7 @@ Make sure your system meets these requirements:
 
 6. <a name="table-note-6" style="display: block; height: 80px; margin-top: -80px;"></a>Ubuntu 20.04 support was added in Redis Enterprise Software [6.4.2-43]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-43">}}).
 
-7. <a name="table-note-7" style="display: block; height: 80px; margin-top: -80px;"></a>A release candidate for Amazon Linux 2 support was added in Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}). Official support for Amazon Linux 2 was added in Redis Enterprise Software 6.4.2-TBA.
+7. <a name="table-note-7" style="display: block; height: 80px; margin-top: -80px;"></a>A release candidate for Amazon Linux 2 support was added in Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}). Official support for Amazon Linux 2 was added in Redis Enterprise Software [6.4.2-69]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-69">}}).
 
 ## Operating system limitations
 
@@ -76,7 +76,7 @@ Due to binary differences in modules between the two operating systems, you cann
 
 ### Modules not supported for Amazon Linux 2 release candidate
 
-A database with modules cannot reside on an Amazon Linux 2 (release candidate) node. This limitation affects Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}) but was fixed in version 6.4.2-TBA.
+A database with modules cannot reside on an Amazon Linux 2 (release candidate) node. This limitation affects Redis Enterprise Software [6.4.2-61]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61">}}) but was fixed in version [6.4.2-69]({{<relref "/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-69">}}).
 
 ## VMware
 

--- a/content/rs/clusters/optimize/optimization.md
+++ b/content/rs/clusters/optimize/optimization.md
@@ -12,36 +12,45 @@ aliases: [
     /rs/clusters/optimize/optimization/,
 ]
 ---
-Redis Enterprise Software employs various algorithms to optimize
-performance. As part of this process, Redis Enterprise Software examines usage characteristics
-and load to adjust its run-time configuration accordingly. Depending
-on your specific usage characteristics and load, it might take Redis Enterprise Software some
-time to adjust itself to optimal performance.
+Redis Enterprise Software uses various algorithms to optimize
+performance. As part of this process, Redis Enterprise Software examines usage
+and load to adjust its runtime configuration. Depending
+on your specific usage and load, Redis Enterprise Software might take some
+time to adjust for optimal performance.
 
 To ensure optimal performance, you must run your workload several times
 and for a long duration until performance stabilizes.
 
-In addition, you can optimize your cluster for two different environments:
+## Failure detection sensitivity policies
 
-- Local-network environment
-- Cloud environment
+You can optimize your cluster's thresholds and timeouts for different environments using the `failure_detection_sensitivity` cluster policy:
 
-Depending on which configuration you choose, Redis Enterprise Software uses different
-thresholds to make operation related decisions.
+- `high` (previously known as `local-network watchdog_profile`) – high failure detection sensitivity, lower thresholds, and faster failure detection and failover
 
-The default configuration is for local-network environments. If you are
-running in a cloud environment, it is advisable that you change the
+- `low` (previously known as `cloud watchdog_profile`) – low failure detection sensitivity and higher tolerance for latency variance (also called network jitter)
+
+Depending on which policy you choose, Redis Enterprise Software uses different
+thresholds to make operation-related decisions.
+
+The default policy is `high` failure detection sensitivity for `local-network` environments. If you are
+running Redis Enterprise in a cloud environment, you should change the
 configuration.
 
-## How to change the cluster environment configuration
+## Change failure detection sensitivity
 
-In the `rladmin` command-line interface (CLI), run the following command:
+To change the cluster's `failure_detection_sensitivity`, run one of the following [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}) commands.
 
-```sh
-rladmin tune cluster watchdog_profile [cloud | local-network]
-```
+- For Redis Enterprise Software version 6.4.2-TBA and later, run:
 
-If after following all of the instructions above, you find that RS still
-does not meet your performance expectations, contact us
-at <support@redislabs.com> to help you optimize RS to your specific
-needs.
+    ```sh
+    rladmin tune cluster failure_detection_sensitivity [ low | high ]
+    ```
+
+- For Redis Enterprise Software version 6.4.2-61 and earlier, run:
+
+    ```sh
+    rladmin tune cluster watchdog_profile [ cloud | local-network ]
+    ```
+
+If Redis Enterprise Software still
+does not meet your performance expectations after following these instructions, [contact support](https://redis.com/company/support/) for help optimizing your environment.

--- a/content/rs/clusters/optimize/optimization.md
+++ b/content/rs/clusters/optimize/optimization.md
@@ -40,7 +40,7 @@ configuration.
 
 To change the cluster's `failure_detection_sensitivity`, run one of the following [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}) commands.
 
-- For Redis Enterprise Software version 6.4.2-TBA and later, run:
+- For Redis Enterprise Software version 6.4.2-69 and later, run:
 
     ```sh
     rladmin tune cluster failure_detection_sensitivity [ low | high ]

--- a/content/rs/networking/port-configurations.md
+++ b/content/rs/networking/port-configurations.md
@@ -57,6 +57,39 @@ rladmin cluster config cm_port <new-port>
 After changing the Redis Enterprise Software web UI port, you must connect any new node added to the cluster to the UI with the custom port number:
 `https://newnode.mycluster.example.com:`**`<nonstandard-port-number>`**
 
+## Change the envoy  ports
+
+For system health monitoring, Redis uses the following ports by default:
+
+- Port 8002 for envoy admin
+
+- Port 8004 for envoy management server
+
+- Port 8006 for gossip envoy admin
+
+You can change each envoy port to a custom port using the [`rladmin cluster config`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/config">}}) command as long as the new port is not in use by another process. When you change `envoy_admin_port`, expect a restart of envoy.
+
+To change the envoy admin port, run:
+
+```sh
+$ rladmin cluster config envoy_admin_port <new-port>
+Updating envoy_admin_port... restarting now
+```
+
+To change the envoy management server port, run:
+
+```sh
+$ rladmin cluster config envoy_mgmt_server_port <new-port>
+Cluster configured successfully
+```
+
+To change the gossip envoy admin port, run:
+
+```sh
+$ rladmin cluster config gossip_envoy_admin_port <new-port>
+Cluster configured successfully
+```
+
 ## Change the REST API port
 
 For the REST API, Redis Enterprise Software uses port 9443 (secure) and port 8080 (not secure), by default. You can change this to a custom port as long as the new port is not in use by another process.

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -21,14 +21,17 @@ Updates the cluster configuration.
         [ cm_port <number> ]
         [ cm_session_timeout <minutes> ]
         [ cnm_http_port <number> ]
-        [ cnm_https_port <number>]
+        [ cnm_https_port <number> ]
         [ data_cipher_list <openSSL cipher list> ]
         [ debuginfo_path <filepath> ]
         [ encrypt_pkeys { enabled | disabled } ]
+        [ envoy_admin_port <new-port> ]
+        [ envoy_mgmt_server_port <new-port> ]
+        [ gossip_envoy_admin_port <new-port> ]
         [ handle_redirects { enabled | disabled } ]
         [ http_support { enabled | disabled } ]
         [ ipv6 { enabled | disabled } ]
-        [ min_control_TLS_version <control_tls_version>]
+        [ min_control_TLS_version <control_tls_version> ]
         [ min_data_TLS_version <data_tls_version> ]
         [ min_sentinel_TLS_version <sentinel_tls_version> ]
         [ s3_url <URL> ]
@@ -56,6 +59,9 @@ Updates the cluster configuration.
 | data_cipher_list | list of ciphers | Cipher suites used by the the data plane (specified in the format understood by the OpenSSL library) |
 | debuginfo_path | filepath | Local directory to place generated support package files |
 | encrypt_pkeys | `enabled`<br />`disabled` | Enable or turn off encryption of private keys |
+| envoy_admin_port | integer, (range:&nbsp;1024-65535) | Envoy admin port. Changing this port during runtime might result in an empty response because envoy serves as the cluster gateway.|
+| envoy_mgmt_server_port | integer, (range:&nbsp;1024-65535) | Envoy management server port|
+| gossip_envoy_admin_port | integer, (range:&nbsp;1024-65535) | Gossip envoy admin port|
 | handle_redirects | `enabled`<br />`disabled` | Enable or turn off handling DNS redirects when DNS is not configured and running behind a load balancer |
 | http_support | `enabled`<br />`disabled` | Enable or turn off using HTTP for REST API connections |
 | ipv6 | `enabled`<br />`disabled` | Enable or turn off IPv6 connections to the admin console |

--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -24,6 +24,7 @@ rladmin tune cluster
         [ redis_provision_node_threshold_percent <percent> ]
         [ redis_migrate_node_threshold_percent <percent> ]
         [ max_simultaneous_backups <size> ]
+        [ failure_detection_sensitivity { high | low } ]
         [ watchdog_profile { cloud | local-network } ]
         [ slave_ha { enabled | disabled } ]
         [ slave_ha_grace_period <seconds> ]
@@ -41,12 +42,6 @@ rladmin tune cluster
         [ acl_pubsub_default { resetchannels | allchannels } ]
 ```
 
-Redis cluster watchdog supports two preconfigured profiles:
-
-- The `cloud` profile is suitable for common cloud environments. It has a higher tolerance for network jitter.
-
-- The `local-network` profile is suitable for dedicated LANs. It has better failure detection and failover times.
-
 ### Parameters
 
 | Parameters                             | Type/Value                        | Description                                                                                                                  |
@@ -57,6 +52,7 @@ Redis cluster watchdog supports two preconfigured profiles:
 | default_concurrent_restore_actions     | integer<br />`all`              | Default number of concurrent actions when restoring a node from a snapshot (positive integer or "all")                         |
 | default_redis_version                  | version number                    | The default Redis database compatibility version used to create new databases.<br/><br/>  The value parameter should be a version number in the form of "x.y" where _x_ represents the major version number and _y_ represents the minor version number.  The final value corresponds to the desired version of Redis.<br/><br/>You cannot set _default_redis_version_ to a value higher than that supported by the current _redis_upgrade_policy_ value. |
 | expose_hostnames_for_all_suffixes      | `enabled`<br />`disabled`       | Exposes hostnames for all DNS suffixes                                                                                       |
+| failure_detection_sensitivity | `high`<br />`low` | Predefined thresholds and timeouts for failure detection (previously known as `watchdog_profile`)<br />• `high` (previously `local-network`) – high failure detection sensitivity, lower thresholds, faster failure detection and failover<br />• `low` (previously `cloud`) – low failure detection sensitivity, higher tolerance for latency variance (also called network jitter) |
 | login_lockout_counter_reset_after      | time in seconds                   | Time after failed login attempt before the counter resets to 0                                                                   |
 | login_lockout_duration                 | time in seconds                   | Time a locked account remains locked ( "0" means only an admin can unlock the account)                                   |
 | login_lockout_threshold                | integer                           | Number of failed sign-in attempts to trigger locking a user account ("0" means never lock the account)                   |
@@ -74,7 +70,7 @@ Redis cluster watchdog supports two preconfigured profiles:
 | slave_ha_bdb_cooldown_period           | time in seconds                   | Time (in seconds) after shard relocation during which databases can't be relocated to another node                           |
 | slave_ha_cooldown_period               | time in seconds                   | Time (in seconds) after shard relocation during which the replica high-availability mechanism can't relocate to another node |
 | slave_ha_grace_period                  | time in seconds                   | Time (in seconds) between when a node fails and when replica high availability starts relocating shards to another node      |
-| watchdog_profile                       | `cloud` <br /> `local-network` | Activates preconfigured watchdog profiles                                                          |
+| watchdog_profile                       | `cloud` <br /> `local-network` | Watchdog profiles with preconfigured thresholds and timeouts (deprecated as of Redis Enterprise Software v6.4.2-TBA; use `failure_detection_sensitivity` instead)<br />• `cloud` is suitable for common cloud environments and has a higher tolerance for latency variance (also called network jitter).<br />• `local-network` is suitable for dedicated LANs and has better failure detection and failover times. |
 
 ### Returns
 

--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -70,7 +70,7 @@ rladmin tune cluster
 | slave_ha_bdb_cooldown_period           | time in seconds                   | Time (in seconds) after shard relocation during which databases can't be relocated to another node                           |
 | slave_ha_cooldown_period               | time in seconds                   | Time (in seconds) after shard relocation during which the replica high-availability mechanism can't relocate to another node |
 | slave_ha_grace_period                  | time in seconds                   | Time (in seconds) between when a node fails and when replica high availability starts relocating shards to another node      |
-| watchdog_profile                       | `cloud` <br /> `local-network` | Watchdog profiles with preconfigured thresholds and timeouts (deprecated as of Redis Enterprise Software v6.4.2-TBA; use `failure_detection_sensitivity` instead)<br />• `cloud` is suitable for common cloud environments and has a higher tolerance for latency variance (also called network jitter).<br />• `local-network` is suitable for dedicated LANs and has better failure detection and failover times. |
+| watchdog_profile                       | `cloud` <br /> `local-network` | Watchdog profiles with preconfigured thresholds and timeouts (deprecated as of Redis Enterprise Software v6.4.2-69; use `failure_detection_sensitivity` instead)<br />• `cloud` is suitable for common cloud environments and has a higher tolerance for latency variance (also called network jitter).<br />• `local-network` is suitable for dedicated LANs and has better failure detection and failover times. |
 
 ### Returns
 

--- a/content/rs/references/rest-api/objects/cluster_settings.md
+++ b/content/rs/references/rest-api/objects/cluster_settings.md
@@ -25,6 +25,7 @@ Cluster resources management policy
 | default_sharded_proxy_policy | `single`<br />`all-master-shards`<br />`all-nodes` | Default proxy_policy for newly created sharded databases' endpoints |
 | default_shards_placement | `dense`<br />`sparse` | Default shards_placement for a newly created databases |
 | endpoint_rebind_propagation_grace_time | integer | Time to wait between the addition and removal of a proxy |
+| failure_detection_sensitivity | `high`<br />`low` | Predefined thresholds and timeouts for failure detection (previously known as `watchdog_profile`)<br />• `high` (previously `local-network`) – high failure detection sensitivity, lower thresholds, faster failure detection and failover<br />• `low` (previously `cloud`) – low failure detection sensitivity, higher tolerance for latency variance (also called network jitter) |
 | login_lockout_counter_reset_after | integer | Number of seconds that must elapse between failed sign in attempts before the lockout counter is reset to 0. |
 | login_lockout_duration | integer | Duration (in secs) of account lockout. If set to 0, the account lockout will persist until released by an admin. |
 | login_lockout_threshold | integer | Number of failed sign in attempts allowed before locking a user account |

--- a/content/rs/references/rest-api/requests/bdbs/actions/optimize_shards_placement.md
+++ b/content/rs/references/rest-api/requests/bdbs/actions/optimize_shards_placement.md
@@ -41,6 +41,23 @@ Get optimized shards placement for the given database.
 GET /bdbs/1/actions/optimize_shards_placement
 ```
 
+#### Query parameters
+
+Include query parameters in a `GET` request to generate an optimized shard placement blueprint for a database, using settings that are different from the database's current configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| avoid_nodes | list of integers | Comma-separated list of cluster node IDs to avoid when placing the database’s shards and binding its endpoints (for example, `avoid_nodes=1,2`) |
+| memory_size | integer (default:&nbsp;0) | Database memory limit (0 is unlimited), expressed in bytes |
+| shards_count | integer, <nobr>(range: 1-512)</nobr> (default:&nbsp;1) | Number of database server-side shards |
+| shards_placement | `dense` <br />`sparse` | Control the density of shards <br /> `dense`: Shards reside on as few nodes as possible <br /> `sparse`: Shards reside on as many nodes as possible |
+
+The following example request includes `shards_count` and `memory_size` as query parameters:
+
+```sh
+GET /bdbs/1/actions/optimize_shards_placement?shards_count=10&memory_size=10000
+```
+
 ### Response {#get-response}
 
 To rearrange the database shards, you can submit the blueprint returned in this response body as the `shards_blueprint` field in the [`PUT`&nbsp;`/bdbs/{uid}`](#put-bdbs-rearrange-shards) request.

--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-69.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-69.md
@@ -1,6 +1,6 @@
 ---
-Title: Redis Enterprise Software release notes 6.4.2-TBA (May 2023)
-linkTitle: 6.4.2-TBA (May 2023)
+Title: Redis Enterprise Software release notes 6.4.2-69 (May 2023)
+linkTitle: 6.4.2-69 (May 2023)
 description: Amazon Linux 2 support. Configure envoy ports using rladmin. Added option to avoid specific nodes when using the optimized shards placement API. Added failure_detection_sensitivity to replace watchdog_profile.
 compatibleOSSVersion: Redis 6.2.6
 weight: 69
@@ -14,14 +14,14 @@ This is a maintenance release for ​[​Redis Enterprise Software version 6.4.2
 
 The following table shows the MD5 checksums for the available packages:
 
-| Package | MD5 checksum (6.4.2-tba May release) |
+| Package | MD5 checksum (6.4.2-69 May release) |
 |---------|---------------------------------------|
-| Ubuntu 16 |  |
-| Ubuntu 18 |  |
-| Ubuntu 20 |  |
-| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 |  |
-| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 <br/>Rocky Enterprise Linux |  |
-| Amazon Linux 2 |  |
+| Ubuntu 16 | 31631248672de0154ec20aee0bff9adc |
+| Ubuntu 18 | 7d9ebd4ea5a23137d2bb3928134ea6ef |
+| Ubuntu 20 | 357ceda7467fd66962f3cb5aa143def7 |
+| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 | 4d53fcce8c80910a05ed37ab64b57a7a |
+| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 <br/>Rocky Enterprise Linux | 88dc6a4d96b948b086f785dc42786d03 |
+| Amazon Linux 2 | 7ed06bc0b35494e4a5c084528d6e8b9f |
 
 ## New features and enhancements
 
@@ -91,6 +91,8 @@ crdb-cli crdb update --crdb-guid <CRDB_GUID> \
 - RS97528 - Prevent [self-signed certificate]({{<relref "/rs/security/certificates/create-certificates">}}) script error on Ubuntu 20.04 by changing the user instructions.
 
 - RS99643 - Fix [`cipher_suites`]({{<relref "/rs/security/tls/ciphers">}}) configuration to allow default cipher suites according to the [control plane]({{<relref "/rs/security/tls/ciphers#control-plane">}}), [data plane]({{<relref "/rs/security/tls/ciphers#data-plane">}}), and [discovery service]({{<relref "/rs/security/tls/ciphers#discovery-service">}}).
+
+- RS99696 - Fix `HINCRBYFLOT` bug/CVE
 
 ## Known limitations
 

--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
@@ -1,7 +1,7 @@
 ---
 Title: Redis Enterprise Software release notes 6.4.2-TBA (May 2023)
 linkTitle: 6.4.2-TBA (May 2023)
-description: Amazon Linux 2 support. Configure envoy ports using rladmin. Added option to avoid specific nodes when using the optimized shards placement API.
+description: Amazon Linux 2 support. Configure envoy ports using rladmin. Added option to avoid specific nodes when using the optimized shards placement API. Added failure_detection_sensitivity to replace watchdog_profile.
 compatibleOSSVersion: Redis 6.2.6
 weight: 69
 alwaysopen: false
@@ -33,13 +33,17 @@ The following table shows the MD5 checksums for the available packages:
 
 - Support the option to avoid specific nodes when using optimized shards placement API  (RS98795)
 
+- Check port availability before installation and upgrade (RS80815)
+
+- Added `failure_detection_sensitivity` policy (previously known as `watchdog_profile`) to [cluster policy REST API requests]({{<relref "/rs/references/rest-api/requests/cluster/policy">}})
+
 #### Redis Stack v6.2.6
 
 Redis Enterprise Software v6.4.2 includes the new features delivered in the latest [Redis Stack release (6.2.6 v6)](https://redis.com/blog/introducing-redis-stack-6-2-6-and-7-0-6/):
 
 - [RediSearch v2.6.6](https://docs.redis.com/latest/modules/redisearch)
 
-- [RedisJSON v2.4.6](https://docs.redis.com/latest/modules/redisjson)
+- [RedisJSON v2.4.7](https://docs.redis.com/latest/modules/redisjson)
 
 - [RedisBloom v2.4.5](https://docs.redis.com/latest/modules/redisbloom)
 
@@ -86,7 +90,7 @@ crdb-cli crdb update --crdb-guid <CRDB_GUID> \
 
 - RS97528 - Prevent [self-signed certificate]({{<relref "/rs/security/certificates/create-certificates">}}) script error on Ubuntu 20.04 by changing the user instructions.
 
-- RS99643 - Fix [`cipher_suites`]({{<relref "/rs/security/tls/ciphers">}}) configuration to allow default values: `HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH`
+- RS99643 - Fix [`cipher_suites`]({{<relref "/rs/security/tls/ciphers">}}) configuration to allow default cipher suites according to the [control plane]({{<relref "/rs/security/tls/ciphers#control-plane">}}), [data plane]({{<relref "/rs/security/tls/ciphers#data-plane">}}), and [discovery service]({{<relref "/rs/security/tls/ciphers#discovery-service">}}).
 
 ## Known limitations
 

--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
@@ -53,6 +53,20 @@ See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-modu
 
 ### Deprecations
 
+#### watchdog_profile
+
+The `watchdog_profile` setting is deprecated and will be removed in a future release. Instead, use the `failure_detection_sensitivity` policy for predefined thresholds and timeouts:
+
+```sh
+rladmin tune cluster failure_detection_sensitivity [ high | low ]
+```
+
+The `failure_detection_sensitivity` policy has the following options:
+
+- `high` (previously known as `local-network watchdog_profile`) – high failure detection sensitivity, lower thresholds, and faster failure detection and failover
+
+- `low` (previously known as `cloud watchdog_profile`) – low failure detection sensitivity and higher tolerance for latency variance (also called network jitter)
+
 #### Ubuntu 16.04
 
 Ubuntu 16 support is deprecated and will be removed in a future release.

--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba.md
@@ -1,0 +1,83 @@
+---
+Title: Redis Enterprise Software release notes 6.4.2-TBA (May 2023)
+linkTitle: 6.4.2-TBA (May 2023)
+description: Amazon Linux 2 support. Configure envoy ports using rladmin. Added option to avoid specific nodes when using the optimized shards placement API.
+compatibleOSSVersion: Redis 6.2.6
+weight: 69
+alwaysopen: false
+toc: "true"
+categories: ["RS"]
+aliases: 
+---
+
+This is a maintenance release for ​[​Redis Enterprise Software version 6.4.2](https://redis.com/redis-enterprise-software/download-center/software/).
+
+The following table shows the MD5 checksums for the available packages:
+
+| Package | MD5 checksum (6.4.2-tba May release) |
+|---------|---------------------------------------|
+| Ubuntu 16 |  |
+| Ubuntu 18 |  |
+| Ubuntu 20 |  |
+| RedHat Enterprise Linux (RHEL) 7<br/>Oracle Enterprise Linux (OL) 7 |  |
+| RedHat Enterprise Linux (RHEL) 8<br/>Oracle Enterprise Linux (OL) 8 <br/>Rocky Enterprise Linux |  |
+| Amazon Linux 2 |  |
+
+## New features and enhancements
+
+- Amazon Linux 2 support
+
+- Enhanced installation logs (RS69079, RS69571, RS89760)
+
+- Added support for `rladmin` envoy port configuration (RS95483)
+
+- Support the option to avoid specific nodes when using optimized shards placement API  (RS98795)
+
+#### Redis Stack v6.2.6
+
+Redis Enterprise Software v6.4.2 includes the new features delivered in the latest [Redis Stack release (6.2.6 v6)](https://redis.com/blog/introducing-redis-stack-6-2-6-and-7-0-6/):
+
+- [RediSearch v2.6.6](https://docs.redis.com/latest/modules/redisearch)
+
+- [RedisJSON v2.4.6](https://docs.redis.com/latest/modules/redisjson)
+
+- [RedisBloom v2.4.5](https://docs.redis.com/latest/modules/redisbloom)
+
+- [RedisGraph v2.10.9](https://docs.redis.com/latest/modules/redisgraph)
+
+- [RedisTimeSeries v1.8.9](https://docs.redis.com/latest/modules/redistimeseries)
+
+See [Upgrade modules](https://docs.redis.com/latest/modules/install/upgrade-module/) to learn how to upgrade a module for a database.
+
+## Version changes
+
+### Deprecations
+
+#### Ubuntu 16.04
+
+Ubuntu 16 support is deprecated and will be removed in a future release.
+
+#### Active-Active database persistence
+
+The RDB snapshot option for [Active-Active database persistence]({{<relref "/rs/databases/active-active/manage#data-persistence">}}) is deprecated and will be removed in a future release.
+
+Please plan to reconfigure any Active-Active databases to use append-only file (AOF) persistence with the following command:
+
+```sh
+crdb-cli crdb update --crdb-guid <CRDB_GUID> \
+    --default-db-config '{"data_persistence": "aof", "aof_policy":"appendfsync-every-sec"}'
+```
+
+## Resolved issues
+
+- RS97528 - Prevent [self-signed certificate]({{<relref "/rs/security/certificates/create-certificates">}}) script error on Ubuntu 20.04 by changing the user instructions.
+
+- RS99643 - Fix [`cipher_suites`]({{<relref "/rs/security/tls/ciphers">}}) configuration to allow default values: `HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH`
+
+## Known limitations
+
+### Operating system limitations
+
+#### Ubuntu 20.04
+
+By default, you cannot use the SHA1 hash algorithm ([OpenSSL’s default security level is set to 2](https://manpages.ubuntu.com/manpages/focal/man3/SSL_CTX_set_security_level.3ssl.html#notes)). The operating system will reject SHA1 certificates even if the `mtls_allow_weak_hashing` option is enabled. You need to replace SHA1 certificates with newer certificates that use SHA-256. Note that the certificates provided with Redis Enterprise Software use SHA-256.


### PR DESCRIPTION
Staged previews:
- [Change envoy ports](https://docs.redis.com/staging/release-rs-diablo-may/rs/networking/port-configurations/#change-the-envoy--ports)
- [rladmin cluster config](https://docs.redis.com/staging/release-rs-diablo-may/rs/references/cli-utilities/rladmin/cluster/config/)
- [Query parameters for optimize shard placement REST API request](https://docs.redis.com/staging/release-rs-diablo-may/rs/references/rest-api/requests/bdbs/actions/optimize_shards_placement/#get-request)
- [rladmin tune cluster](https://docs.redis.com/staging/release-rs-diablo-may/rs/references/cli-utilities/rladmin/tune/)
- [REST API cluster settings object](https://docs.redis.com/staging/release-rs-diablo-may/rs/references/rest-api/objects/cluster_settings/)
- [Cluster environment optimization](https://docs.redis.com/staging/release-rs-diablo-may/rs/clusters/optimize/optimization/)
- [Deprecation notice](https://docs.redis.com/staging/release-rs-diablo-may/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba/#deprecations)
- [Supported platforms table note](https://docs.redis.com/staging/release-rs-diablo-may/rs/installing-upgrading/supported-platforms/#table-note-7)
- [OS limitation](https://docs.redis.com/staging/release-rs-diablo-may/rs/installing-upgrading/supported-platforms/#modules-not-supported-for-amazon-linux-2-release-candidate)
- [Release notes draft](https://docs.redis.com/staging/release-rs-diablo-may/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-tba/)