### PR TITLE
K8s: Admission controller steps DOC-2224 DOC-2227 

### DIFF
--- a/content/embeds/k8s-642-redb-admission-webhook-name-change.md
+++ b/content/embeds/k8s-642-redb-admission-webhook-name-change.md
@@ -1,0 +1,13 @@
+ [Version 6.4.2]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}) uses a new `ValidatingWebhookConfiguration` resource to replace `redb-admission`. To use the 6.4.2 releases, delete the old webhook resource and apply the new file.
+
+1. Delete the existing `ValidatingWebhookConfiguration` on the Kubernetes cluster (named `redb-admission`).
+
+    ```sh
+    kubectl delete ValidatingWebhookConfiguration redb-admission
+    ```
+
+1. Apply the resource from the new file.
+
+    ```sh
+    kubectl apply -f deploy/admission/webhook.yaml
+    ```

--- a/content/embeds/k8s-admission-webhook-cert.md
+++ b/content/embeds/k8s-admission-webhook-cert.md
@@ -1,0 +1,48 @@
+1. Verify the `admission-tls` secret exists .
+
+    ```sh
+     kubectl get secret admission-tls
+    ```
+  
+    The output will look similar to
+  
+    ```
+     NAME            TYPE     DATA   AGE
+     admission-tls   Opaque   2      2m43s
+    ```
+
+1. Save the certificate to a local environment variable.
+
+    ```sh
+    CERT=`kubectl get secret admission-tls -o jsonpath='{.data.cert}'`
+    ```
+
+1. Create a patch file for the Kubernetes validating webhook.
+
+    ```sh
+    sed 's/NAMESPACE_OF_SERVICE_ACCOUNT/demo/g' admission/webhook.yaml | kubectl create -f -
+
+    cat > modified-webhook.yaml <<EOF
+    webhooks:
+    - name: redisenterprise.admission.redislabs
+      clientConfig:
+        caBundle: $CERT
+      admissionReviewVersions: ["v1beta1"]
+    EOF
+    ```
+
+1. Patch the webhook with the certificate.
+
+    ```sh
+    kubectl patch ValidatingWebhookConfiguration \
+      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
+    ```
+
+  For releases before 6.4.2-4, use this command instead:
+
+  ```sh
+    kubectl patch ValidatingWebhookConfiguration \
+      redb-admission --patch "$(cat modified-webhook.yaml)"
+  ```
+
+  Releases prior to [6.2.4]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) use the ValidatingWebhookConfiguration named `redb-admission`.

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -206,57 +206,7 @@ The admission controller dynamically validates REDB resources configured by the 
 
 As part of the REC creation process, the operator stores the admission controller certificate in a Kubernetes secret called `admission-tls`. You may have to wait a few minutes after creating your REC to see the secret has been created.
 
-1. Verify the secret has been created.
-
-    ```sh
-     kubectl get secret admission-tls
-    ```
-  
-    The output will look similar to
-  
-    ```
-     NAME            TYPE     DATA   AGE
-     admission-tls   Opaque   2      2m43s
-    ```
-
-1. Save the certificate to a local environment variable.
-
-    ```sh
-    CERT=`kubectl get secret admission-tls -o jsonpath='{.data.cert}'`
-    ```
-
-1. Create a patch file for the Kubernetes validating webhook.
-
-    ```sh
-    sed 's/NAMESPACE_OF_SERVICE_ACCOUNT/demo/g' admission/webhook.yaml | kubectl create -f -
-
-    cat > modified-webhook.yaml <<EOF
-    webhooks:
-    - name: redisenterprise.admission.redislabs
-      clientConfig:
-        caBundle: $CERT
-      admissionReviewVersions: ["v1beta1"]
-    EOF
-    ```
-
-1. Patch the webhook with the certificate.
-
-    ```sh
-    kubectl patch ValidatingWebhookConfiguration \
-      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
-    ```
-
-  {{<note>}}
-
-  For releases before 6.4.2-4, use this command instead:
-    ```sh
-    kubectl patch ValidatingWebhookConfiguration \
-      redb-admission --patch "$(cat modified-webhook.yaml)"
-    ```
-
-  The 6.4.2-4 release introduces a new `ValidatingWebhookConfiguration` to replace `redb-admission`. See the [6.4.2-4 release notes]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}).
-  {{</note>}}
-
+{{< embed-md "k8s-admission-webhook-cert.md"  >}}
 
 ### Limit the webhook to the relevant namespaces {#webhook}
 

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -96,28 +96,17 @@ customresourcedefinition.apiextensions.k8s.io/redisenterprisedatabases.app.redis
 deployment.apps/redis-enterprise-operator configured
 ```
 
-### Reapply other manual configurations
+### Reapply the admission controller webhook {#reapply-webhook}
 
-When upgrading the operator, there are few configurations you'll need to reapply.
-
-If you have the admission controller enabled, you need to manually reapply the `ValidatingWebhookConfiguration`. See the [Enable the admission controller]({{<relref "/kubernetes/deployment/quick-start#enable-the-admission-controller">}}) step during deployment for more details.
+If you have the admission controller enabled, you need to manually reapply the `ValidatingWebhookConfiguration`.
 
 {{<note>}}
-
-The [6.4.2-4 release]({{<relref "/kubernetes/release-notes/6-4-2-releases/">}}) uses a new `ValidatingWebhookConfiguration` resource that replaces the old webhook resource. To use the 6.4.2-4 release, delete the old webhook resource and apply the new file.
-
-1. Delete the existing `ValidatingWebhookConfiguration` on the Kubernetes cluster (named `redb-admission`).
-
-    ```sh
-    kubectl delete ValidatingWebhookConfiguration redb-admission
-    ```
-
-1. Apply the resource from the new file.
-
-    ```sh
-    kubectl apply -f deploy/admission/webhook.yaml
-    ```
+{{< embed-md "k8s-642-redb-admission-webhook-name-change.md" >}}
 {{</note>}}
+
+{{< embed-md "k8s-admission-webhook-cert.md"  >}}
+
+### Reapply the SCC
 
 If you are using OpenShift, you will also need to manually reapply the [Security context constraints](https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html) file ([`scc.yaml`]({{<relref "/kubernetes/deployment/openshift/openshift-cli#deploy-the-operator" >}})).
 

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -34,19 +34,7 @@ New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref
 
 ## Upgrade to 6.4.2-5
 
-This release uses a new `ValidatingWebhookConfiguration` resource that replaces the old webhook resource. To use the 6.4.2-5 release, delete the old webhook resource and apply the new file.
-
-1. Delete the existing `ValidatingWebhookConfiguration` on the Kubernetes cluster (named `redb-admission`).
-
-    ```sh
-    kubectl delete ValidatingWebhookConfiguration redb-admission
-    ```
-
-1. Apply the resource from the new file.
-
-    ```sh
-    kubectl apply -f deploy/admission/webhook.yaml
-    ```
+This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use the 6.4.2-5 release, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.
 
 ## Feature enhancements
 

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -36,19 +36,7 @@ The key features, bug fixes, and known limitations are described below.
 
 ## Upgrade to 6.4.2-4
 
-This release uses a new `ValidatingWebhookConfiguration` resource that replaces the old webhook resource. To use the 6.4.2-4 release, delete the old webhook resource and apply the new file.
-
-1. Delete the existing `ValidatingWebhookConfiguration` on the Kubernetes cluster (named `redb-admission`).
-
-    ```sh
-    kubectl delete ValidatingWebhookConfiguration redb-admission
-    ```
-
-1. Apply the resource from the new file.
-
-    ```sh
-    kubectl apply -f deploy/admission/webhook.yaml
-    ```
+This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use the 6.4.2-4 release, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.
 
 ## New features
 


### PR DESCRIPTION
Jira: DOC-2224 DOC-2227
Staged preview:

- https://docs.redis.com/staging/DOC-2227/kubernetes/deployment/quick-start/#enable-the-admission-controller
- https://docs.redis.com/staging/DOC-2227/kubernetes/re-clusters/upgrade-redis-cluster/#reapply-webhook
- https://docs.redis.com/staging/DOC-2227/kubernetes/release-notes/6-4-2-releases/6-4-2-5/#upgrade-to-642-5
- https://docs.redis.com/staging/DOC-2227/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4/#upgrade-to-642-4