### PR TITLE
Max simultaneous backups defaults to 4

### DIFF
--- a/content/rc/api/examples/back-up-and-import-data.md
+++ b/content/rc/api/examples/back-up-and-import-data.md
@@ -19,7 +19,7 @@ with a [backup path]({{<relref "/rc/databases/back-up-data">}}).
 This parameter enables periodic and on-demand backup operations for the specified database.
 
 {{<note>}}
-The number of database backups that can run simultaneously on a cluster node is limited to 4 by default.
+The number of database backups that can run simultaneously on a cluster is limited to 4 by default.
 {{</note>}}
 
 The API operation for on-demand backups is `POST /subscriptions/{subscriptionId}/databases/{databaseId}/backup`.

--- a/content/rc/api/examples/back-up-and-import-data.md
+++ b/content/rc/api/examples/back-up-and-import-data.md
@@ -18,6 +18,10 @@ When you create or update a database in a Flexible or Annual account, you can sp
 with a [backup path]({{<relref "/rc/databases/back-up-data">}}).
 This parameter enables periodic and on-demand backup operations for the specified database.
 
+{{<note>}}
+The number of database backups that can run simultaneously on a cluster node is limited to 4 by default.
+{{</note>}}
+
 The API operation for on-demand backups is `POST /subscriptions/{subscriptionId}/databases/{databaseId}/backup`.
 On-demand database backup is an [asynchronous operation]({{<relref "/rc/api/get-started/process-lifecycle.md#asynchronous-operations">}}).
 

--- a/content/rc/databases/back-up-data.md
+++ b/content/rc/databases/back-up-data.md
@@ -21,9 +21,13 @@ The backup options for Redis Enterprise Cloud databases depend on your plan:
 
 - Free plans cannot perform backups through the Redis Cloud console.
 
+{{<note>}}
+The number of database backups that can run simultaneously on a cluster node is limited to 4 by default.
+{{</note>}}
+
 Backups are saved to predefined storage locations available to your subscription.
 
-Backup locations need to be available before you turn on database backups.  To learn more, see [Set up backup storage locations](#set-up-backup-storage-locations)
+Backup locations need to be available before you turn on database backups.  To learn more, see [Set up backup storage locations](#set-up-backup-storage-locations).
 
 Here, you'll learn how to store backups using different cloud providers.
 

--- a/content/rc/databases/back-up-data.md
+++ b/content/rc/databases/back-up-data.md
@@ -22,7 +22,7 @@ The backup options for Redis Enterprise Cloud databases depend on your plan:
 - Free plans cannot perform backups through the Redis Cloud console.
 
 {{<note>}}
-The number of database backups that can run simultaneously on a cluster node is limited to 4 by default.
+The number of database backups that can run simultaneously on a cluster is limited to 4 by default.
 {{</note>}}
 
 Backups are saved to predefined storage locations available to your subscription.

--- a/content/rs/databases/import-export/schedule-backups.md
+++ b/content/rs/databases/import-export/schedule-backups.md
@@ -40,7 +40,7 @@ Redis Enterprise Software creates a backup file for each shard in the configurat
 - Make sure that you have enough space available in your storage location.
     If there is not enough space in the backup location, the backup fails.
 - The backup configuration only applies to the database it is configured on.
-- To limit the parallel backup for shards, set both [`tune cluster max_simultaneous_backups`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}) and [`tune node max_redis_forks`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-node">}}). 
+- To limit the parallel backup for shards, set both [`tune cluster max_simultaneous_backups`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}) and [`tune node max_redis_forks`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-node">}}). `max_simultaneous_backups` is set to 4 by default.
 
 {{< /note >}}
 

--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -23,7 +23,7 @@ rladmin tune cluster
         [ redis_migrate_node_threshold <size> ]
         [ redis_provision_node_threshold_percent <percent> ]
         [ redis_migrate_node_threshold_percent <percent> ]
-        [ max_simultaneous_backups <size> ]
+        [ max_simultaneous_backups <number> ]
         [ watchdog_profile { cloud | local-network } ]
         [ slave_ha { enabled | disabled } ]
         [ slave_ha_grace_period <seconds> ]
@@ -61,7 +61,7 @@ Redis cluster watchdog supports two preconfigured profiles:
 | login_lockout_duration                 | time in seconds                   | Time a locked account remains locked ( "0" means only an admin can unlock the account)                                   |
 | login_lockout_threshold                | integer                           | Number of failed sign-in attempts to trigger locking a user account ("0" means never lock the account)                   |
 | max_saved_events_per_type              | integer                           | Maximum number of events each type saved in CCS per object type                                                              |
-| max_simultaneous_backups               | integer                           | Number of database backups allowed to run at the same time. Combines with `max_redis_forks` (set by [`tune node`](#tune-node)) to determine the number of shard backups allowed to run simultaneously.                                                                                  |
+| max_simultaneous_backups               | integer <nobr>(default: 4)</nobr>                      | Number of database backups allowed to run at the same time. Combines with `max_redis_forks` (set by [`tune node`](#tune-node)) to determine the number of shard backups allowed to run simultaneously.                                                                                  |
 | parallel_shards_upgrade                | integer<br />`all`              | Number of shards upgraded in parallel during DB upgrade (positive integer or "all")                                          |
 | redis_migrate_node_threshold           | size in MB                        | Memory (in MBs by default or can be specified) needed to migrate a database between nodes                                   |
 | redis_migrate_node_threshold_percent   | percentage                | Memory (in percentage) needed to migrate a database between nodes                                                            |

--- a/content/rs/references/rest-api/objects/cluster_settings.md
+++ b/content/rs/references/rest-api/objects/cluster_settings.md
@@ -29,7 +29,7 @@ Cluster resources management policy
 | login_lockout_duration | integer | Duration (in secs) of account lockout. If set to 0, the account lockout will persist until released by an admin. |
 | login_lockout_threshold | integer | Number of failed sign in attempts allowed before locking a user account |
 | max_saved_events_per_type | integer | Maximum saved events per event type |
-| max_simultaneous_backups | integer | Maximum number of backup processes allowed at the same time |
+| max_simultaneous_backups | integer <nobr>(default: 4)</nobr> | Maximum number of backup processes allowed at the same time |
 | parallel_shards_upgrade | integer | Maximum number of shards to upgrade in parallel |
 | rack_aware | boolean | Cluster operates in a rack-aware mode |
 | redis_migrate_node_threshold | integer | Minimum free memory (excluding reserved memory) allowed on a node before automatic migration of shards from it to free more memory |


### PR DESCRIPTION
Staged previews:
- Cloud
  - [Back up a database](https://docs.redis.com/staging/DOC-2235/rc/databases/back-up-data/)
  - [Database backup REST API example](https://docs.redis.com/staging/DOC-2235/rc/api/examples/back-up-and-import-data/)
- Software
  - [Schedule periodic backups](https://docs.redis.com/staging/DOC-2235/rs/databases/import-export/schedule-backups/)
  - [rladmin tune cluster reference](https://docs.redis.com/staging/DOC-2235/rs/references/cli-utilities/rladmin/tune/#tune-cluster)
  - [Cluster settings REST API object refeference](https://docs.redis.com/staging/DOC-2235/rs/references/rest-api/objects/cluster_settings/)