### PR TITLE
DOC-2323 RED-102100 warning for SCC upgrade bug

### DIFF
--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -43,7 +43,7 @@ To prevent this, set `node:1` as the master node.
 oc exec -it <rec-pod-name> -- rladmin cluster master set 1
 ```
 
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later.
+This may also affect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later.
 
 This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
 

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -25,7 +25,7 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 Review the following warnings before starting your upgrade:
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -25,7 +25,7 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 Review the following warnings before starting your upgrade:
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -25,7 +25,17 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 Review the following warnings before starting your upgrade:
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -31,7 +31,7 @@ Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earl
 
 You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
 
-```sh
+```text
 services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
 ...
 ... pods <POD NAME> is forbidden: unable to validate against any security context constraint

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -25,11 +25,12 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 Review the following warnings before starting your upgrade:
 
-{{<warning>}} If your OpenShift clusters running version 6.2.12 or earlier are upgrading to version 6.2.18 or later, and `node:1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod." <br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
 <br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and are unable to wait to fix it, contact Redis support.
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
 {{</warning>}}
 
 {{< warning >}}

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -23,10 +23,12 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 ## Before upgrading
 
-Review the following warnings before starting your upgrade:
+Review the following warnings before starting your upgrade.
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
+#### OpenShift clusters running 6.2.12 or earlier
+
+Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
+
 You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
 
 ```sh
@@ -35,28 +37,31 @@ services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
 ... pods <POD NAME> is forbidden: unable to validate against any security context constraint
 ```
 
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
+To prevent this, set `node:1` as the master node.
+
+```sh
+oc exec -it <rec-pod-name> -- rladmin cluster master set 1
+```
+
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later.
+
 This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
-{{</warning>}}
 
-{{< warning >}}
-When upgrading existing Redis Enterprise clusters running on RHEL7-based images, make sure to select a RHEL7-based image for the new version. See [release notes]({{<relref "/kubernetes/release-notes/">}}) for more info.{{</warning>}}
+#### RHEL7-based images
 
-{{<warning>}}
-Verify your license is valid before upgrading your REC. Invalid licenses will cause the upgrade to fail.<br/>
-<br/>
+When upgrading existing Redis Enterprise clusters running on RHEL7-based images, make sure to select a RHEL7-based image for the new version. See [release notes]({{<relref "/kubernetes/release-notes/">}}) for more info.
+
+#### Invalid license
+
+Verify your license is valid before upgrading your REC. Invalid licenses will cause the upgrade to fail.
+
 Use `kubectl get rec` and verify the `LICENSE STATE` is valid on your REC before you start the upgrade process.
-{{</warning>}}
 
-{{<warning>}}
-On clusters with more than 9 REC nodes, running versions 6.2.18-3 through 6.2.4-4, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. <br/>
-<br/>
+#### Large clusters
+
+On clusters with more than 9 REC nodes, running versions 6.2.18-3 through 6.2.4-4, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+
 A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
-{{</warning>}}
 
 ## Upgrade the operator
 
@@ -72,7 +77,6 @@ You can download the bundle for the latest release with the following `curl` com
 VERSION=`curl --silent https://api.github.com/repos/RedisLabs/redis-enterprise-k8s-docs/releases/latest | grep tag_name | awk -F'"' '{print $4}'`
 curl --silent -O https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/$VERSION/bundle.yaml
 ```
-
 
 For OpenShift environments, the name of the bundle is `openshift.bundle.yaml`, and so the `curl` command to run is:
 

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -1,5 +1,5 @@
 ---
-Title: Upgrade a Redis Enterprise cluster (REC) on Kubernetes
+Title: Upgrade a Redis Enterprise cluster (REC)
 linkTitle: Upgrade a Redis cluster
 description: This task describes how to upgrade a Redis Enterprise cluster via the operator.
 weight: 19
@@ -23,21 +23,29 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 ## Before upgrading
 
-Before you upgrade, verify you are using the correct image and your license is valid.
+Review the following warnings before starting your upgrade:
+
+{{<warning>}} If your OpenShift clusters running version 6.2.12 or earlier are upgrading to version 6.2.18 or later, and `node:1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod." <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and are unable to wait to fix it, contact Redis support.
+{{</warning>}}
 
 {{< warning >}}
-When upgrading existing Redis Enterprise clusters running on RHEL7-based images, make sure to select a RHEL7-based image for the new version. See [release notes]({{<relref "/kubernetes/release-notes/">}}) for more info. 
-  {{</warning>}}
+When upgrading existing Redis Enterprise clusters running on RHEL7-based images, make sure to select a RHEL7-based image for the new version. See [release notes]({{<relref "/kubernetes/release-notes/">}}) for more info.{{</warning>}}
 
 {{<warning>}}
-Verify your license is valid before upgrading your REC. Invalid licenses will cause the upgrade to fail.
-
+Verify your license is valid before upgrading your REC. Invalid licenses will cause the upgrade to fail.<br/>
+<br/>
 Use `kubectl get rec` and verify the `LICENSE STATE` is valid on your REC before you start the upgrade process.
 {{</warning>}}
 
-{{<note>}}
-On clusters with more than 9 REC nodes, running versions 6.2.18-3 through 6.2.4-4, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
-{{</note>}}
+{{<warning>}}
+On clusters with more than 9 REC nodes, running versions 6.2.18-3 through 6.2.4-4, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. <br/>
+<br/>
+A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
+{{</warning>}}
 
 ## Upgrade the operator
 

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -10,7 +10,17 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -10,7 +10,7 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -10,7 +10,7 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -12,7 +12,7 @@ aliases: [
 ---
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more detail and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more detail and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 {{<note>}}

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -10,22 +10,9 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
-You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-```sh
-services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
-...
-... pods <POD NAME> is forbidden: unable to validate against any security context constraint
-```
-
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+For more detail and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 {{<note>}}

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -10,6 +10,14 @@ aliases: [
 
 ]
 ---
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
+
 {{<note>}}
 On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
 {{</note>}}

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -21,6 +21,14 @@ The key bug fixes, new features, and known limitations are described below.
 If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade** to the 6.2.18-3 release. Skip this release and upgrade to version [6.2.18-41]({{<relref "/kubernetes/release-notes/6-2-18-releases/">}}) instead.
 {{</warning>}}
 
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
+
 ## Images
 
 This release includes the following container images:

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -21,7 +21,7 @@ The key bug fixes, new features, and known limitations are described below.
 If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade** to the 6.2.18-3 release. Skip this release and upgrade to version [6.2.18-41]({{<relref "/kubernetes/release-notes/6-2-18-releases/">}}) instead.
 {{</warning>}}
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -21,22 +21,9 @@ The key bug fixes, new features, and known limitations are described below.
 If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade** to the 6.2.18-3 release. Skip this release and upgrade to version [6.2.18-41]({{<relref "/kubernetes/release-notes/6-2-18-releases/">}}) instead.
 {{</warning>}}
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
-You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-```sh
-services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
-...
-... pods <POD NAME> is forbidden: unable to validate against any security context constraint
-```
-
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -21,7 +21,17 @@ The key bug fixes, new features, and known limitations are described below.
 If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade** to the 6.2.18-3 release. Skip this release and upgrade to version [6.2.18-41]({{<relref "/kubernetes/release-notes/6-2-18-releases/">}}) instead.
 {{</warning>}}
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -23,7 +23,7 @@ If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade
 
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -21,7 +21,7 @@ The key bug fixes, new features, and known limitations are described below.
 If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade** to the 6.2.18-3 release. Skip this release and upgrade to version [6.2.18-41]({{<relref "/kubernetes/release-notes/6-2-18-releases/">}}) instead.
 {{</warning>}}
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -16,7 +16,17 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.2.18-41 that 
 
 New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -16,6 +16,14 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.2.18-41 that 
 
 New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}) for compatibility notes and known limitations.
 
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
+
 ## Images
 
 DockerHub images are available at `docker.io/`.

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -16,7 +16,7 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.2.18-41 that 
 
 New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -18,7 +18,7 @@ New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref 
 
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -16,7 +16,7 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.2.18-41 that 
 
 New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -16,22 +16,9 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.2.18-41 that 
 
 New images and fixes are listed below. Refer to [6.2.18-41 (Dec 2022]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
-You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-```sh
-services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
-...
-... pods <POD NAME> is forbidden: unable to validate against any security context constraint
-```
-
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -18,7 +18,7 @@ The key bug fixes and known limitations are described below.
 
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -16,7 +16,7 @@ The Redis Enterprise K8s 6.2.18-41 is a maintenance release which supports the R
 
 The key bug fixes and known limitations are described below.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -16,6 +16,14 @@ The Redis Enterprise K8s 6.2.18-41 is a maintenance release which supports the R
 
 The key bug fixes and known limitations are described below.
 
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
+
 ## Images
 
 

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -16,22 +16,9 @@ The Redis Enterprise K8s 6.2.18-41 is a maintenance release which supports the R
 
 The key bug fixes and known limitations are described below.
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
-You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-```sh
-services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
-...
-... pods <POD NAME> is forbidden: unable to validate against any security context constraint
-```
-
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -16,7 +16,7 @@ The Redis Enterprise K8s 6.2.18-41 is a maintenance release which supports the R
 
 The key bug fixes and known limitations are described below.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -16,7 +16,17 @@ The Redis Enterprise K8s 6.2.18-41 is a maintenance release which supports the R
 
 The key bug fixes and known limitations are described below.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -15,7 +15,17 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.4.2-4 that ad
 
 New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -15,7 +15,7 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.4.2-4 that ad
 
 New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -15,7 +15,7 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.4.2-4 that ad
 
 New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -15,6 +15,14 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.4.2-4 that ad
 
 New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}) for compatibility notes and known limitations.
 
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
+
 ## Images
 
 * **Redis Enterprise**: `redislabs/redis:6.4.2-61`

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -17,7 +17,7 @@ New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref
 
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -15,22 +15,9 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.4.2-4 that ad
 
 New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
-You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-```sh
-services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
-...
-... pods <POD NAME> is forbidden: unable to validate against any security context constraint
-```
-
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -10,7 +10,7 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod." <br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -10,7 +10,17 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod." <br/><br/>
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
+<br/>
+You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+
+```sh
+services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
+...
+... pods <POD NAME> is forbidden: unable to validate against any security context constraint
+```
+
+ <br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -10,22 +10,9 @@ aliases: [
 
 ]
 ---
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. <br/>
-<br/>
-You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see this error:
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-```sh
-services-rigger.services - ERROR - couldn't update pod <POD NAME> labels
-...
-... pods <POD NAME> is forbidden: unable to validate against any security context constraint
-```
-
- <br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 {{<note>}}

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -12,7 +12,7 @@ aliases: [
 ---
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 {{<note>}}

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -10,10 +10,16 @@ aliases: [
 
 ]
 ---
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
 
 {{<note>}}
 On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
-
 {{</note>}}
 
 {{<table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes" columnSources="LinkTitle,Description" enableLinks="LinkTitle">}}

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -17,12 +17,9 @@ The Redis Enterprise K8s 6.4.2-4 release supports Redis Enterprise Software 6.4.
 
 The key features, bug fixes, and known limitations are described below.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
-This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
-<br/>
-To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
-<br/>
-This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
+
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
 {{</warning>}}
 
 ## Images

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -17,7 +17,7 @@ The Redis Enterprise K8s 6.4.2-4 release supports Redis Enterprise Software 6.4.
 
 The key features, bug fixes, and known limitations are described below.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -17,7 +17,7 @@ The Redis Enterprise K8s 6.4.2-4 release supports Redis Enterprise Software 6.4.
 
 The key features, bug fixes, and known limitations are described below.
 
-{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is not the master node, the upgrade might get stuck. You might see pods older than 5 minutes that are still unavailable and an error in the ServicesRigger log containing "couldn't update pod."<br/><br/>
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is not the master node, the upgrade might get stuck. You might have a pod that doesn't become fully ready and start seeing restarts. In the ServicesRigger log, you'll see an error message containing "couldn't update pod."<br/><br/>
 This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
 <br/>
 To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -17,6 +17,14 @@ The Redis Enterprise K8s 6.4.2-4 release supports Redis Enterprise Software 6.4.
 
 The key features, bug fixes, and known limitations are described below.
 
+{{<warning>}} Due to an change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is not the master node, the upgrade might get stuck. You'll see the upgrade is still incomplete after x minutes and and the ServicesRigger log shows an error containing "couldn't update pod."<br/><br/>
+This may also effect OpenShift clusters containing two RECs running different versions, if one is running version 6.2.12 or earlier and the other is running 6.2.18 or later. <br/>
+<br/>
+To prevent this, set node1 as the master node with `rladmin master set 1`. <br/>
+<br/>
+This is a newly discovered issue and more information will be available soon. If you have already encountered the error and need it fixed immediately, contact Redis support.
+{{</warning>}}
+
 ## Images
 
 * **Redis Enterprise**: `redislabs/redis:6.4.2-43`

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -19,7 +19,7 @@ The key features, bug fixes, and known limitations are described below.
 
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster.md#before-upgrading">}}).
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 {{</warning>}}
 
 ## Images


### PR DESCRIPTION
Jira: DOC-2323

Added warning to upgrade article and all release notes for versions 6.2.18 and later. 

Staged previews: 

[Upgrade a Redis Enterprise Cluster (REC)](https://docs.redis.com/staging/DOC-2323/kubernetes/re-clusters/upgrade-redis-cluster/)
[6.4.2 release notes](https://docs.redis.com/staging/DOC-2323/kubernetes/release-notes/6-4-2-releases/)
[6.2.18 release notes](https://docs.redis.com/staging/DOC-2323/kubernetes/release-notes/6-2-18-releases/)
