### PR TITLE
k8s: Fix possible typo for REDB deletion warning

### DIFF
--- a/content/kubernetes/re-clusters/delete_custom_resources.md
+++ b/content/kubernetes/re-clusters/delete_custom_resources.md
@@ -86,7 +86,7 @@ If the operator isn't running, or some other fatal error occurs, the finalizer i
 
 If this happens, you can remove the finalizer manually.
 
-{{<warning>}} If you remove the finalizer manually, there is no guarantee that the underlying REC has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
+{{<warning>}} If you remove the finalizer manually, there is no guarantee that the underlying REDB has been deleted. This may cause resource issues and require manual intervention. {{</warning>}}
 
 ```sh
 kubectl patch redb <your-db-name> --type=json -p \


### PR DESCRIPTION
We received a report of a possible typo in this REDB deletion warning.

Here's a [staged preview](https://docs.redis.com/staging/typo-fix/kubernetes/re-clusters/delete_custom_resources/#troubleshoot-redb-deletion) that includes the suggested fix.