### PR TITLE
Update internode-encryption.md

### DIFF
--- a/content/rs/security/internode-encryption.md
+++ b/content/rs/security/internode-encryption.md
@@ -84,5 +84,5 @@ All certificates signed by the internal CA expire after ninety (90) days and aut
 You can use the Redis Enterprise Software REST API to rotate certificates manually:
 
 ``` rest
-put /v1/cluster/certificates/rotate
+post /v1/cluster/certificates/rotate
 ```

--- a/content/rs/security/internode-encryption.md
+++ b/content/rs/security/internode-encryption.md
@@ -84,5 +84,5 @@ All certificates signed by the internal CA expire after ninety (90) days and aut
 You can use the Redis Enterprise Software REST API to rotate certificates manually:
 
 ``` rest
-post /v1/cluster/certificates/rotate
+POST /v1/cluster/certificates/rotate
 ```


### PR DESCRIPTION
The REST API call for rotate certificates is a POST instead of a PUT.

Fixing documentation error.