### PR TITLE
chore: remove the outdated section from Uptrace integration

### DIFF
--- a/content/rs/clusters/monitoring/uptrace-integration.md
+++ b/content/rs/clusters/monitoring/uptrace-integration.md
@@ -1,30 +1,32 @@
 ---
 Title: Uptrace integration with Redis Enterprise Software
 linkTitle: Uptrace integration
-description: To collect, display, and monitor metrics data from your databases and other cluster components, you can connect Uptrace to your Redis Enterprise cluster using OpenTelemetry Collector.
+description: To collect, view, and monitor metrics data from your databases and other cluster components, you can connect Uptrace to your Redis Enterprise cluster using OpenTelemetry Collector.
 weight: 50
 alwaysopen: false
 categories: ["RS"]
 ---
 
-To collect, display, and monitor metrics data from your databases and other cluster components, you can connect Uptrace to your Redis Enterprise cluster using OpenTelemetry Collector.
+To collect, view, and monitor metrics data from your databases and other cluster components, you can connect Uptrace to your Redis Enterprise cluster using OpenTelemetry Collector.
 
-[Uptrace](https://uptrace.dev/get/) is an open source application performance monitoring (APM) tool that supports distributed tracing, metrics, and logs. You can use it to monitor applications and set up automatic alerts to receive notifications.
+Uptrace is an [open source APM tool](https://uptrace.dev/get/open-source-apm.html) that supports distributed tracing, metrics, and logs. You can use it to monitor applications and set up automatic alerts to receive notifications.
 
-With [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), you can receive, process, and export telemetry data to any monitoring tool. You can use it to scrape Prometheus metrics provided by Redis and then export those metrics to Uptrace.
+Uptrace uses OpenTelemetry to collect and export telemetry data from software applications such as Redis. OpenTelemetry is an open source observability framework that aims to provide a single standard for all types of observability signals such as traces, metrics, and logs.
+
+With OpenTelemetry Collector, you can receive, process, and export telemetry data to any [OpenTelemetry backend](https://uptrace.dev/blog/opentelemetry-backend.html). You can also use Collector to scrape Prometheus metrics provided by Redis and then export those metrics to Uptrace.
 
 You can use Uptrace to:
 
 - Collect and display data metrics not available in the [admin console]({{< relref "/rs/references/metrics" >}}).
 - Use prebuilt dashboard templates maintained by the Uptrace community.
 - Set up automatic alerts and receive notifications via email, Slack, Telegram, and others.
-- Monitor your app performance and logs using [tracing](https://uptrace.dev/opentelemetry/distributed-tracing.html).
+- Monitor your app performance and logs using [OpenTelemetry tracing](https://uptrace.dev/opentelemetry/distributed-tracing.html).
 
 ![uptrace-redis-nodes](/images/rs/uptrace-redis-nodes.png)
 
 ## Install Collector and Uptrace
 
-Because installing OpenTelemetry Collector and Uptrace can take some time, you can use the [docker-compose](https://github.com/uptrace/uptrace/tree/master/example/redis-enterprise) example that also comes with Redis Enterprise cluster and AlertManager.
+Because installing OpenTelemetry Collector and Uptrace can take some time, you can use the [docker-compose](https://github.com/uptrace/uptrace/tree/master/example/redis-enterprise) example that also comes with Redis Enterprise cluster.
 
 After you download the Docker example, you can edit the following configuration files in the `uptrace/example/redis-enterprise` directory before you start the Docker containers:
 
@@ -34,7 +36,7 @@ After you download the Docker example, you can edit the following configuration 
 You can also install OpenTelemetry and Uptrace from scratch using the following guides:
 
 - [Getting started with OpenTelemetry Collector](https://uptrace.dev/opentelemetry/collector.html)
-- [Getting started with Uptrace](https://uptrace.dev/get/install.html)
+- [Getting started with Uptrace](https://uptrace.dev/get/get-started.html)
 
 After you install Uptrace, you can access the Uptrace UI at [http://localhost:14318/](http://localhost:14318/).
 
@@ -67,27 +69,26 @@ receivers:
       http:
 
 exporters:
-  otlp:
+  otlp/uptrace:
     # Uptrace is accepting metrics on this port
     endpoint: localhost:14317
     headers: { "uptrace-dsn": "http://project1_secret_token@localhost:14317/1" }
-    tls:
-      insecure: true
+    tls: { insecure: true }
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp]
+      exporters: [otlp/uptrace]
     metrics:
       receivers: [otlp, prometheus_simple/cluster1]
       processors: [batch]
-      exporters: [otlp]
+      exporters: [otlp/uptrace]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp]
+      exporters: [otlp/uptrace]
 ```
 
 Don't forget to restart the Collector and then check logs for any errors:
@@ -114,85 +115,58 @@ When metrics start arriving to Uptrace, you should see a couple of dashboards in
 
 ## Monitor metrics
 
-To start monitoring metrics, you need to add some alerting rules.
+To start monitoring metrics, you need to create metrics monitors using Uptrace UI:
 
-For example, the following rule uses the `group by node` expression to create an alert whenever an individual Redis shard is down:
+- Open "Alerts" -> "Monitors".
+- Click "Create monitor" -> "Create metrics monitor".
+
+For example, the following monitor uses the `group by node` expression to create an alert whenever an individual Redis shard is down:
 
 ```yaml
-# /etc/uptrace/uptrace.yml
-
-alerting:
-  rules:
-    - name: Redis shard is down
-      metrics:
-        - redis_up as $redis_up
-      query:
-        - group by cluster # monitor each cluster,
-        - group by bdb # each database,
-        - group by node # and each shard
-        - $redis_up == 0
-      # shard should be down for 5 minutes to trigger an alert
-      for: 5m
-      # only monitor Uptrace projects with these ids
-      projects: [1]
+monitors:
+  - name: Redis shard is down
+    metrics:
+      - redis_up as $redis_up
+    query:
+      - group by cluster # monitor each cluster,
+      - group by bdb # each database,
+      - group by node # and each shard
+      - $redis_up
+    min_allowed_value: 1
+    # shard should be down for 5 minutes to trigger an alert
+    for_duration: 5m
 ```
 
 You can also create queries with more complex expressions.
 
-For example, the following rules create an alert when the keyspace hit rate is lower than 75% or memory fragmentation is too high:
+For example, the following monitors create an alert when the keyspace hit rate is lower than 75% or memory fragmentation is too high:
 
 ```yaml
-# /etc/uptrace/uptrace.yml
+monitors:
+  - name: Redis read hit rate < 75%
+    metrics:
+      - redis_keyspace_read_hits as $hits
+      - redis_keyspace_read_misses as $misses
+    query:
+      - group by cluster
+      - group by bdb
+      - group by node
+      - $hits / ($hits + $misses) as hit_rate
+    min_allowed_value: 0.75
+    for_duration: 5m
 
-alerting:
-  rules:
-    - name: Redis read hit rate < 75%
-      metrics:
-        - redis_keyspace_read_hits as $hits
-        - redis_keyspace_read_misses as $misses
-      query:
-        - group by cluster
-        - group by bdb
-        - group by node
-        - $hits / ($hits + $misses) < 0.75
-      for: 5m
-      projects: [1]
-
-    - name: Memory fragmentation is too high
-      metrics:
-        - redis_used_memory as $mem_used
-        - redis_mem_fragmentation_ratio as $fragmentation
-      query:
-        - group by cluster
-        - group by bdb
-        - group by node
-        - $mem_used > 32mb and $fragmentation > 3
-      for: 5m
-      projects: [1]
+  - name: Memory fragmentation is too high
+    metrics:
+      - redis_used_memory as $mem_used
+      - redis_mem_fragmentation_ratio as $fragmentation
+    query:
+      - group by cluster
+      - group by bdb
+      - group by node
+      - where $mem_used > 32mb
+      - $fragmentation
+    max_allowed_value: 3
+    for_duration: 5m
 ```
 
 You can learn more about the query language [here](https://uptrace.dev/get/querying-metrics.html).
-
-## Send notifications
-
-Uptrace does not manage notifications by itself and instead provides an [integration](https://uptrace.dev/get/alerting.html) with AlertManager.
-
-AlertManager handles alerts sent by client applications such as Uptrace and takes care of deduplicating, grouping, and routing notifications to configured receivers via email, Slack, Telegram, and many others.
-
-To connect Uptrace to AlertManager and enable alert notifications, add the AlertManager API endpoint to `uptrace.yml`:
-
-```yaml
-# /etc/uptrace/uptrace.yml
-
-##
-## AlertManager client configuration.
-## See https://uptrace.dev/get/alerting.html for details.
-##
-## Note that this is NOT an AlertManager config and you need to configure AlertManager separately.
-## See https://prometheus.io/docs/alerting/latest/configuration/ for details.
-##
-alertmanager_client:
-  # AlertManager API endpoints that Uptrace uses to manage alerts.
-  urls:
-    - "http://localhost:9093/api/v2/alerts"
-```


### PR DESCRIPTION
I've update some links and reworked the last section regarding notifications, because Uptrace is now able to send notifications out-of-the-box and does not require AlertManager.