### PR TITLE
DOC-2381: Remove 6.4 references from breaking changes

### DIFF
--- a/content/embeds/r7.2-breaking-changes.md
+++ b/content/embeds/r7.2-breaking-changes.md
@@ -46,11 +46,11 @@ Upgrading to Redis version 7.2 from version 7.0 introduces the following potenti
 - Command stats are only updated when the command executes ([#11012](https://github.com/redis/redis/pull/11012)).
     - Previously, the command stats were updated even if a command was blocked. The command stats are now updated only if and when the command is executed.
 
-#### Breaking changes from version 6.2 and 6.4
+#### Breaking changes from version 6.2
 
-Upgrading to open source Redis version 7.2 from version 6.2 or 6.4 introduces the following potentially breaking changes to Redis Enterprise.
+Upgrading to open source Redis version 7.2 from version 6.2 introduces the following potentially breaking changes to Redis Enterprise.
 
-All [breaking changes from version 7.0](#breaking-changes-from-version-70) also apply to 6.2 and 6.4.
+All [breaking changes from version 7.0](#breaking-changes-from-version-70) also apply to Redis version 6.2.
 
 ##### Programmability
 


### PR DESCRIPTION
Staging link: https://docs.redis.com/staging/DOC-2381/rc/changelog/june-2023/