### PR TITLE
K8s: AA install prereq checklist

### DIFF
--- a/content/kubernetes/active-active/_index.md
+++ b/content/kubernetes/active-active/_index.md
@@ -27,14 +27,13 @@ There are two methods for creating an Active-Active database with Redis Enterpri
 
 We recommend creating new Active-Active databases using the RedisEnterpriseActiveActiveDatabase (REAADB) custom resource. This allows you to manage your Active-Active database with the operator and ensures you have the latest features and functionality.
 
-
 ### Active-Active controller method
 
-Releases 6.4.2 or later support the Active-Active controller. This setup method includes the following steps:
+Versions 6.4.2 or later support the Active-Active controller. This setup method includes the following steps:
 
-1. Collect and apply REC admin credentials for all participating RECs.
-2. Create `RedisEnterpriseRemoteCluster` (RERC) resources.
-3. Create `RedisEnterpriseActiveActiveDatabase` (REAADB) resource.
+1. Gather REC credentials and [prepare participating clusters]({{<relref "/kubernetes/active-active/prepare-clusters.md">}}).
+2. Create [`RedisEnterpriseRemoteCluster` (RERC)]({{<relref "/kubernetes/active-active/create-reaadb#create-rerc">}}) resources.
+3. Create [`RedisEnterpriseActiveActiveDatabase` (REAADB)]({{<relref "/kubernetes/active-active/create-reaadb#create-reaadb">}}) resource.
 
 ### `crdb-cli` method
 

--- a/content/kubernetes/active-active/create-reaadb.md
+++ b/content/kubernetes/active-active/create-reaadb.md
@@ -14,17 +14,33 @@ aliases: {
 }
 ---
 
+{{<note>}}This feature is only available for versions 6.2.4 or later.{{</note>}}
+
 ## Prerequisites
 
-{{<note>}}This feature is only available for versions 6.2.4-4 or later.{{</note>}}
+To create an Active-Active database, make sure you've completed all the following steps and have gathered the information listed below each step.
 
-Before creating an Active-Active database on Redis Enterprise for Kubernetes, you'll need to prepare your participating Redis Enterprise clusters (REC). See [Prepare participating clusters]({{<relref "/kubernetes/active-active/prepare-clusters.md">}}) before creating your Redis Enterprise remote cluster (RERC) and Redis Enterprise Active-Active database (REAADB).
+1. Configure the [admission controller and ValidatingWebhook]({{<relref "/kubernetes/deployment/quick-start.md#enable-the-admission-controller/">}}).
 
-## Create `RedisEnterpriseRemoteCluster` resources
+2. Create two or more [RedisEnterpriseCluster (REC) custom resources]({{<relref "/kubernetes/deployment/quick-start#create-a-redis-enterprise-cluster-rec">}}) with enough [memory resources]({{<relref "/rs/installing-upgrading/install/plan-deployment/hardware-requirements.md">}})).
+   * Name of each REC (`<rec-name>`)
+   * Namespace for each REC (`<rec-namespace>`)
+
+3. Configure the REC [`ingressOrRoutes` field]({{<relref "/kubernetes/networking/ingressorroutespec.md">}}) and [create DNS records]({{<relref "/kubernetes/networking/ingressorroutespec#configure-dns/">}}).
+   * REC API hostname (`api-<rec-name>-<rec-namespace>.<subdomain>`)
+   * Database hostname suffix (`-db-<rec-name>-<rec-namespace>.<subdomain>`)
+
+4. [Prepare participating clusters]({{<relref "/kubernetes/active-active/prepare-clusters.md">}})
+   * RERC name (`<rerc-name`>)
+   * RERC secret name (`redis-enterprise-<rerc-name>`)
+
+For a list of example values used throughout this article, see the [Example values](#example-values) section.
+
+## Create `RedisEnterpriseRemoteCluster` resources {#create-rerc}
 
 1. Create a `RedisEnterpriseRemoteCluster` (RERC) custom resource file for each participating Redis Enterprise cluster (REC).
 
-  Below are examples of RERC resources for two participating clusters. Substitute your own values to create your own resource.
+   Below are examples of RERC resources for two participating clusters. Substitute your own values to create your own resource.
 
     Example RERC (`rerc-ohare`) for the REC named `rec-chicago` in the namespace `ns-illinois`:
 
@@ -36,8 +52,8 @@ Before creating an Active-Active database on Redis Enterprise for Kubernetes, yo
     spec:
       recName: rec-chicago
       recNamespace: ns-illinois
-      apiFqdnUrl: test-example-api-rec-chicago-ns-illinois.redis.com
-      dbFqdnSuffix: -example-cluster-rec-chicago-ns-illinois.redis.com
+      apiFqdnUrl: api-rec-chicago-ns-illinois.redis.com
+      dbFqdnSuffix: -db-rec-chicago-ns-illinois.redis.com
       secretName: redis-enterprise-rerc-ohare
     ```
 
@@ -58,11 +74,11 @@ Before creating an Active-Active database on Redis Enterprise for Kubernetes, yo
 
     For more details on RERC fields, see the [RERC API reference](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_remote_cluster_api.md).
 
-1. Create a Redis Enterprise remote cluster from each RERC custom resource file. 
+1. Create a Redis Enterprise remote cluster from each RERC custom resource file.
   
-    ```sh
-    kubectl create -f <rerc-file>
-    ```
+   ```sh
+   kubectl create -f <rerc-file>
+   ```
 
 1. Check the status of your RERC. If `STATUS` is `Active` and `SPEC STATUS` is `Valid`, then your configurations are correct.
   
@@ -81,32 +97,32 @@ Before creating an Active-Active database on Redis Enterprise for Kubernetes, yo
   
     In case of errors, review the RERC custom resource events and the Redis Enterprise operator logs.
 
-## Create `RedisEnterpriseActiveActiveDatabase` resource
+## Create `RedisEnterpriseActiveActiveDatabase` resource {#create-reaadb}
 
 1. Create a `RedisEnterpriseActiveActiveDatabase` (REAADB) custom resource file meeting the naming requirements and listing the names of the RERC custom resources created in the last step.
 
     Naming requirements:
-    - less than 63 characters
-    - contains only lowercase letters, numbers, or hyphens
-    - starts with a letter
-    - ends with a letter or digit
+    * less than 63 characters
+    * contains only lowercase letters, numbers, or hyphens
+    * starts with a letter
+    * ends with a letter or digit
 
     Example REAADB named `reaadb-boeing` linked to the REC named `rec-chicago` with two participating clusters and a global database configuration with shard count set to 3:
 
-    ```yaml
-    apiVersion: app.redislabs.com/v1alpha1
-    kind: RedisEnterpriseActiveActiveDatabase
-    metadata:
-      name: reaadb-boeing
-    spec:
-      globalConfigurations:
-        databaseSecretName: <my-secret>
-        memorySize: 200MB
-        shardCount: 3
-      participatingClusters:
-          - name: rerc-ohare
-          - name: rerc-reagan
-    ```
+     ```yaml
+     apiVersion: app.redislabs.com/v1alpha1
+     kind: RedisEnterpriseActiveActiveDatabase
+     metadata:
+       name: reaadb-boeing
+     spec:
+       globalConfigurations:
+         databaseSecretName: <my-secret>
+         memorySize: 200MB
+         shardCount: 3
+       participatingClusters:
+           - name: rerc-ohare
+           - name: rerc-reagan
+     ```
 
     For more details on RERC fields, see the [RERC API reference](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_remote_cluster_api.md).
 
@@ -132,3 +148,26 @@ Before creating an Active-Active database on Redis Enterprise for Kubernetes, yo
     ```
   
     In case of errors, review the REAADB custom resource events and the Redis Enterprise operator logs.
+
+## Example values
+
+This article uses the following example values:
+
+#### Example cluster 1
+
+* REC name: `rec-chicago`
+* REC namespace: `ns-illinois`
+* RERC name: `rerc-ohare`
+* RERC secret name: `redis-enterprise-rerc-ohare`
+* API FQDN: `api-rec-chicago-ns-illinois.redis.com`
+* DB FQDN suffix: `-db-rec-chicago-ns-illinois.redis.com`
+
+#### Example cluster 2
+
+* REC name: `rec-arlington`
+* REC namespace: `ns-virginia`
+* RERC name: `rerc-raegan`
+* RERC secret name: `redis-enterprise-rerc-reagan`
+* API FQDN: `api-rec-arlington-ns-virginia.redis.com`
+* DB FQDN suffix: `-db-rec-arlington-ns-virginia.redis.com`
+

--- a/content/kubernetes/active-active/prepare-clusters.md
+++ b/content/kubernetes/active-active/prepare-clusters.md
@@ -17,32 +17,33 @@ aliases: {
 }
 ---
 
+{{<note>}}This feature is only available for versions 6.2.4 or later.{{</note>}}
+
 ## Prepare participating clusters
 
-An Active-Active database can span multiple clusters. Make sure you have enough memory resources available for the database (see [hardware requirements]({{<relref "/rs/installing-upgrading/install/plan-deployment/hardware-requirements.md">}})).
+Before you prepare your clusters to participate in an Active-Active database, make sure you've completed all the following steps and have gathered the information listed below each step.
 
-### Cluster names
+1. Configure the [admission controller and ValidatingWebhook]({{<relref "/kubernetes/deployment/quick-start.md#enable-the-admission-controller/">}}).
 
-The combination of the REC name and namespace (`<rec-name>.<namespace-name>`) must be unique for each participating cluster in the Active-Active database.
+2. Create two or more [RedisEnterpriseCluster (REC) custom resources]({{<relref "/kubernetes/deployment/quick-start#create-a-redis-enterprise-cluster-rec">}}) with enough [memory resources]({{<relref "/rs/installing-upgrading/install/plan-deployment/hardware-requirements.md">}}).
+   * Name of each REC (`<rec-name>`)
+   * Namespace for each REC (`<rec-namespace>`)
 
-For example, if you have two K8s clusters, each with their own REC named `rec-chicago` in a namespace named `ns-illinois`, the value of `<rec-name>.<namespace-name>` for both RECs would be `rec-chicago.ns-illinois`. These can't be used for the same Active-Active database.
+3. Configure the REC [`ingressOrRoutes` field]({{<relref "/kubernetes/networking/ingressorroutespec.md">}}) and [create DNS records]({{<relref "/kubernetes/networking/ingressorroutespec#configure-dns/">}}).
+   * REC API hostname (`api-<rec-name>-<rec-namespace>.<subdomain>`)
+   * Database hostname suffix (`-db-<rec-name>-<rec-namespace>.<subdomain>`)
 
+Next you'll [collect credentials](#collect-rec-credentials) for your participating clusters and create secrets for the RedisEnterprsieRemoteCluster (RERC) to use.
 
-### Configure external routing
+For a list of example values used throughout this article, see the [Example values](#example-values) section.
 
-Active-Active databases require external routing access to sync properly. To configure external routing through an Ingress or OpenShift route, see [Establish external routing on the REC]({{<relref "/kubernetes/networking/ingressorroutespec.md">}}).
-
-### Configure `ValidatingWebhookConfiguration`
-
-The admission controller uses a webhook to dynamically validate resources configured by the operator. The `ValidatingWebhookConfiguration` is required for Active-Active databases. Learn how to enable and configure the admission controller in the [Enable admission controller]({{<relref "/kubernetes/deployment/quick-start.md#enable-the-admission-controller/">}}) section of the [Deploy Redis Enterprise Software for Kubernetes]({{<relref "/kubernetes/deployment/quick-start.md">}}) instructions.
-
-### Collect REC credentials
+## Collect REC credentials
 
 To communicate with other clusters, all participating clusters will need access to the admin credentials for all other clusters.
 
 1. Create a file to hold the admin credentials for all participating RECs (such as `all-rec-secrets.yaml`).
 
-1. Within that file, create a new secret for each participating cluster named `redis-enterprise-<rerc>`.
+1. Within that file, create a new secret for each participating cluster named `redis-enterprise-<rerc-name>`.
 
     The example below shows a file (`all-rec-secrets.yaml`) holding secrets for two participating clusters:
 
@@ -126,3 +127,25 @@ To communicate with other clusters, all participating clusters will need access 
 ## Next steps
 
 Now you are ready to [create your Redis Enterprise Active-Active database]({{<relref "/kubernetes/active-active/create-reaadb.md">}}).
+
+## Example values
+
+This article uses the following example values:
+
+#### Example cluster 1
+
+* REC name: `rec-chicago`
+* REC namespace: `ns-illinois`
+* RERC name: `rerc-ohare`
+* RERC secret name: `redis-enterprise-rerc-ohare`
+* API FQDN: `api-rec-chicago-ns-illinois.redis.com`
+* DB FQDN suffix: `-db-rec-chicago-ns-illinois.redis.com`
+
+#### Example cluster 2
+
+* REC name: `rec-arlington`
+* REC namespace: `ns-virginia`
+* RERC name: `rerc-raegan`
+* RERC secret name: `redis-enterprise-rerc-reagan`
+* API FQDN: `api-rec-arlington-ns-virginia.redis.com`
+* DB FQDN suffix: `-db-rec-arlington-ns-virginia.redis.com`

--- a/content/kubernetes/networking/routes.md
+++ b/content/kubernetes/networking/routes.md
@@ -14,7 +14,7 @@ aliases: [
 ]
 ---
 
-OpenShift routes allow requests to be routed to the database from outside the cluster. For more information about routes, see [OpenShift documentation](https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html).
+OpenShift routes allow requests to be routed to the database or cluster API from outside the cluster. For more information about routes, see [OpenShift documentation](https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html).
 
 ## Prerequisites
 

--- a/content/kubernetes/networking/routes.md
+++ b/content/kubernetes/networking/routes.md
@@ -14,7 +14,7 @@ aliases: [
 ]
 ---
 
-OpenShift routes allow requests to be routed to the REDB from outside the cluster with the need for an Ingress.
+OpenShift routes allow requests to be routed to the database from outside the cluster. For more information about routes, see [OpenShift documentation](https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html).
 
 ## Prerequisites
 


### PR DESCRIPTION
These changes aim to clarify what the user needs to do before they start the AA creation process and lists out the variables they'll need defined. Hopefully this will make the docs easier to use. 

Jira: DOC-2140
Staged preview: 
- https://docs.redis.com/staging/DOC-2140/kubernetes/active-active/prepare-clusters/
- https://docs.redis.com/staging/DOC-2140/kubernetes/active-active/create-reaadb/
