### PR TITLE
K8s: RED-104136 add OLM admission controller note to AA

### DIFF
--- a/content/kubernetes/active-active/create-reaadb.md
+++ b/content/kubernetes/active-active/create-reaadb.md
@@ -21,6 +21,7 @@ aliases: {
 To create an Active-Active database, make sure you've completed all the following steps and have gathered the information listed below each step.
 
 1. Configure the [admission controller and ValidatingWebhook]({{<relref "/kubernetes/deployment/quick-start.md#enable-the-admission-controller/">}}).
+   {{<note>}}These are installed and enabled by default on clusters created via the OpenShift OperatorHub. {{</note>}}
 
 2. Create two or more [RedisEnterpriseCluster (REC) custom resources]({{<relref "/kubernetes/deployment/quick-start#create-a-redis-enterprise-cluster-rec">}}) with enough [memory resources]({{<relref "/rs/installing-upgrading/install/plan-deployment/hardware-requirements.md">}})).
    * Name of each REC (`<rec-name>`)


### PR DESCRIPTION
Added note the REAADB instructions explaining the admission controller and webhook are enabled by default on clusters created via OLM. 

Staged preview: https://docs.redis.com/staging/RED-104136/kubernetes/active-active/create-reaadb/