### PR TITLE
K8s: Red-102241 Upgrade path info

### DIFF
--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -25,6 +25,10 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 Review the following warnings before starting your upgrade.
 
+### Supported upgrade paths**
+
+   If you are using a version earlier than 6.2.10-45, you must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
 ### OpenShift clusters running 6.2.12 or earlier
 
    Version 6.4.2-6 includes a new SCC (`redis-enterprise-scc-v2`) that you need to bind to your service account before upgrading. OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later might get stuck if you skip this step. See [reapply SCC](#reapply-the-scc) for details.

--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -47,7 +47,7 @@ Use `kubectl get rec` and verify the `LICENSE STATE` is valid on your REC before
 
 On clusters with more than 9 REC nodes, running versions 6.2.18-3 through 6.2.4-4, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
 
-A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
+A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. 
 
 ## Upgrade the operator
 

--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -50,3 +50,7 @@ Each release of Redis Enterprise for Kubernetes is thoroughly tested against a s
 |                         | deprecated | deprecated | supported  |            |            |            |
 
 \* Support added in latest release
+
+### Supported upgrade paths**
+
+   If you are using a version earlier than 6.2.10-45, you must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -14,17 +14,20 @@ aliases: [
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
 
-**Supported upgrade paths**
+### Supported upgrade paths
 
-  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+If you are using operator version 6.2.8-15 or earlier, you cannot upgrade directly to operator versions 6.2.12 through 6.4.2-5. You must upgrade to operator version 6.2.10-45 before you can upgrade to operator versions between 6.2.12 and 6.4.2-5. However, upgrades directly to operator version 6.4.2-6 are supported.
+  
+### OpenShift versions 6.2.12 or earlier
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
+Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
-For more detail and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
-{{</warning>}}
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
 
-{{<note>}}
-On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
-{{</note>}}
+Operator version 6.4.2-6 includes a fix for this issue.
+
+### Large clusters
+
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. 
 
 {{<table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes" columnSources="LinkTitle,Description" enableLinks="LinkTitle">}}

--- a/content/kubernetes/release-notes/6-2-18-releases/_index.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/_index.md
@@ -10,6 +10,14 @@ aliases: [
 
 ]
 ---
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+**Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
 For more detail and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -89,15 +89,27 @@ Below is a table showing supported distributions at the time of this release. Se
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
 
-* **Supported upgrade paths**
+### Supported upgrade paths
 
-  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+If you are using operator version 6.2.8-15 or earlier, you cannot upgrade directly to operator versions 6.2.12 through 6.4.2-5. You must upgrade to operator version 6.2.10-45 before you can upgrade to operator versions between 6.2.12 and 6.4.2-5. However, upgrades directly to operator version 6.4.2-6 are supported.
+  
+### OpenShift versions 6.2.12 or earlier
+
+Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
+
+For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
+
+Operator version 6.4.2-6 includes a fix for this issue.
+
+### Large clusters
+
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster.
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 * Long cluster names cause routes to be rejected  (RED-25871)
 

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3.md
@@ -21,11 +21,6 @@ The key bug fixes, new features, and known limitations are described below.
 If you use NGINX as an ingress controller for Redis Enterprise, **do not upgrade** to the 6.2.18-3 release. Skip this release and upgrade to version [6.2.18-41]({{<relref "/kubernetes/release-notes/6-2-18-releases/">}}) instead.
 {{</warning>}}
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
-
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
-{{</warning>}}
-
 ## Images
 
 This release includes the following container images:
@@ -89,6 +84,14 @@ Below is a table showing supported distributions at the time of this release. Se
 |                         |            | supported  | supported  | supported* |            |
 
 \* Support added in this release
+
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+* **Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
 
 ## Known limitations
 

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -51,7 +51,7 @@ See [Redis Enterprise for Kubernetes release notes 6.2.18-41 (Dec 2022)]({{<relr
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
 
-* **Supported upgrade paths**
+ ### Supported upgrade paths
 
   If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
 

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41-jan-2023.md
@@ -47,6 +47,14 @@ DockerHub images are available at `docker.io/`.
 
 See [Redis Enterprise for Kubernetes release notes 6.2.18-41 (Dec 2022)]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}).
 
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+* **Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
 ## Known limitations
 
 See [Redis Enterprise for Kubernetes release notes 6.2.18-41 (Dec 2022)]({{<relref "/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md">}}).

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -66,6 +66,14 @@ Below is a table showing supported distributions at the time of this release. Se
 
 \* Support added in this release
 
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+* **Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
 ## Known limitations
 
 * On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -70,7 +70,7 @@ Below is a table showing supported distributions at the time of this release. Se
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
 
-* **Supported upgrade paths**
+ ### Supported upgrade paths
 
   If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
 

--- a/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
+++ b/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41.md
@@ -76,9 +76,9 @@ Be aware the following changes included in this release affect the upgrade proce
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 * Long cluster names cause routes to be rejected  (RED-25871)
 

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md
@@ -15,11 +15,6 @@ This is a maintenance release of Redis Enterprise for Kubernetes 6.4.2-4 that ad
 
 New images and fixes are listed below. Refer to [6.2.4-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}) for compatibility notes and known limitations.
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
-
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
-{{</warning>}}
-
 ## Images
 
 * **Redis Enterprise**: `redislabs/redis:6.4.2-61`
@@ -37,10 +32,6 @@ For more info and steps to prevent this issue, see [upgrade a Redis Enterprise c
 
 * Redis Enterprise operator bundle version: `v6.4.2-5.0`
 
-## Upgrade to 6.4.2-5
-
-This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use the 6.4.2-5 release, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.
-
 ## Feature enhancements
 
 * Upgraded to support Redis Enterprise 6.4.2-61
@@ -52,6 +43,18 @@ This release uses a new `ValidatingWebhookConfiguration` resource to replace the
 ## Compatibility notes
 
 See [Redis Enterprise for Kubernetes release notes 6.4.2-4 (March 2023)]({{<relref "/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md">}}).
+
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading,
+
+* **Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
+* **ValidatingWebhookConfiguration**
+
+  This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use releases 6.4.2-4 or later, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.
 
 ## Known limitations
 

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-6.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-6.md
@@ -112,7 +112,7 @@ The following table shows supported distributions at the time of this release. Y
 
 {{<note>}} Redis Enterprise for Kubernetes now uses RKE2 as the default for Rancher distributions. {{</note>}}
 
-## Upgrade to 6.4.2-6
+## Before upgrading
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading to 6.4.2-6.
 

--- a/content/kubernetes/release-notes/6-4-2-releases/6-4-2-6.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/6-4-2-6.md
@@ -116,10 +116,6 @@ The following table shows supported distributions at the time of this release. Y
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading to 6.4.2-6.
 
-* **Supported upgrade paths**
-
-  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
-
 * **ValidatingWebhookConfiguration**
 
   This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use releases 6.4.2-4 or later, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -10,6 +10,15 @@ aliases: [
 
 ]
 ---
+
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+**Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+  
 {{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
 For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).

--- a/content/kubernetes/release-notes/6-4-2-releases/_index.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/_index.md
@@ -15,17 +15,21 @@ aliases: [
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
 
-**Supported upgrade paths**
+### Supported upgrade paths
 
-  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+If you are using operator version 6.2.8-15 or earlier, you cannot upgrade directly to operator versions 6.2.12 through 6.4.2-5. You must upgrade to operator version 6.2.10-45 before you can upgrade to operator versions between 6.2.12 and 6.4.2-5. However, upgrades directly to operator version 6.4.2-6 are supported.
   
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
+### OpenShift versions 6.2.12 or earlier
+
+Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
 
 For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
-{{</warning>}}
 
-{{<note>}}
-On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster.
-{{</note>}}
+Operator version 6.4.2-6 includes a fix for this issue.
+
+### Large clusters
+
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster.
+
 
 {{<table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes" columnSources="LinkTitle,Description" enableLinks="LinkTitle">}}

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -17,11 +17,6 @@ The Redis Enterprise K8s 6.4.2-4 release supports Redis Enterprise Software 6.4.
 
 The key features, bug fixes, and known limitations are described below.
 
-{{<warning>}} Due to a change in the SCC, on OpenShift clusters running version 6.2.12 or earlier upgrading to version 6.2.18 or later, where `node:1` is <b>not</b> the master node, the upgrade might get stuck.
-
-For more info and steps to prevent this issue, see [upgrade a Redis Enterprise cluster (REC)]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#before-upgrading">}}).
-{{</warning>}}
-
 ## Images
 
 * **Redis Enterprise**: `redislabs/redis:6.4.2-43`
@@ -38,10 +33,6 @@ For more info and steps to prevent this issue, see [upgrade a Redis Enterprise c
 ### OpenShift OLM bundles
 
 * Redis Enterprise operator bundle version: `v6.4.2-4.0`
-
-## Upgrade to 6.4.2-4
-
-This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use the 6.4.2-4 release, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.
 
 ## New features
 
@@ -102,6 +93,18 @@ The following table shows supported distributions at the time of this release. Y
 |                         |            | deprecated | supported  | supported  |            |            |
 
 \* Support added in this release
+
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+* **Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
+* **ValidatingWebhookConfiguration**
+
+  This release uses a new `ValidatingWebhookConfiguration` resource to replace the `redb-admission` webhook resource. To use releases 6.4.2-4 or later, delete the old webhook resource and apply the new file. See [upgrade Redis cluster]({{<relref "/kubernetes/re-clusters/upgrade-redis-cluster#reapply-webhook">}}) for instructions.
 
 ## Active-Active preview known limitations
 

--- a/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
+++ b/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4.md
@@ -134,9 +134,9 @@ Be aware the following changes included in this release affect the upgrade proce
 
   To avoid this, use the YAML view. This will be fixed in the next release.
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 * Resharding fails for rack-aware databases with no replication (RED-97971)
   

--- a/content/kubernetes/release-notes/k8s-6-2-10-34-2022-05.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-34-2022-05.md
@@ -92,9 +92,9 @@ Below is a table showing supported distributions at the time of this release. Se
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 * **Warning** Openshift customers using modules cannot use 6.2.10-34 version
   {{<warning>}}

--- a/content/kubernetes/release-notes/k8s-6-2-10-4-2022-03 copy.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-4-2022-03 copy.md
@@ -49,9 +49,9 @@ This release includes the following container images:
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 ### Long cluster names cause routes to be rejected  (RED-25871)
 

--- a/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
+++ b/content/kubernetes/release-notes/k8s-6-2-10-45-2022-07.md
@@ -79,9 +79,9 @@ Below is a table showing supported distributions at the time of this release. Se
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 * Long cluster names cause routes to be rejected  (RED-25871)
 

--- a/content/kubernetes/release-notes/k8s-6-2-12-1.md
+++ b/content/kubernetes/release-notes/k8s-6-2-12-1.md
@@ -89,15 +89,15 @@ Below is a table showing supported distributions at the time of this release. Se
 
 Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
 
-* **Supported upgrade paths**
+### Supported upgrade paths
 
-  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+If you are using operator version 6.2.8-15 or earlier, you cannot upgrade directly to operator versions 6.2.12 through 6.4.2-5. You must upgrade to operator version 6.2.10-45 before you can upgrade to operator versions between 6.2.12 and 6.4.2-5. However, upgrades directly to operator version 6.4.2-6 are supported.
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 * Long cluster names cause routes to be rejected  (RED-25871)
 

--- a/content/kubernetes/release-notes/k8s-6-2-12-1.md
+++ b/content/kubernetes/release-notes/k8s-6-2-12-1.md
@@ -85,6 +85,14 @@ Below is a table showing supported distributions at the time of this release. Se
 * Rancher 2.6 1.19, 1.20
 * VMware TKGI 1.10
 
+## Before upgrading
+
+Be aware the following changes included in this release affect the upgrade process. Please read carefully before upgrading.
+
+* **Supported upgrade paths**
+
+  If you are using a version earlier than 6.2.10-45, you cannot upgrade directly to this release. You must upgrade to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+
 ## Known limitations
 
 * On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.

--- a/content/kubernetes/release-notes/k8s-6-2-4-1-2021-09.md
+++ b/content/kubernetes/release-notes/k8s-6-2-4-1-2021-09.md
@@ -49,9 +49,9 @@ This release includes the following container images:
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 ### Applying bundle.yaml generated a warning
 

--- a/content/kubernetes/release-notes/k8s-6-2-8-11-2022-01.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-11-2022-01.md
@@ -41,9 +41,9 @@ This release includes the following container images:
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 ### Upgrading with the bundle using `kubectl apply -f` fails (RED-69515)
 

--- a/content/kubernetes/release-notes/k8s-6-2-8-15-2022-01.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-15-2022-01.md
@@ -35,9 +35,9 @@ This release includes the following container images:
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 ### Long cluster names cause routes to be rejected  (RED-25871)
 

--- a/content/kubernetes/release-notes/k8s-6-2-8-2-2021-11.md
+++ b/content/kubernetes/release-notes/k8s-6-2-8-2-2021-11.md
@@ -43,9 +43,9 @@ This release includes the following container images:
 
 ## Known limitations
 
-* On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases.
+### Large clusters
 
-  A fix is available in the 6.4.2-5 release. Upgrade your Redis cluster to [6.4.2-5]({{<relref "/kubernetes/release-notes/6-4-2-releases/6-4-2-5.md">}}) before upgrading your Kubernetes cluster. (RED-93025)
+On clusters with more than 9 REC nodes, a Kubernetes upgrade can render the Redis cluster unresponsive in some cases. A fix is available in the 6.4.2-5 release. Upgrade your operator version to 6.4.2-5 or later before upgrading your Kubernetes cluster. (RED-93025)
 
 ### Long cluster names cause routes to be rejected  (RED-25871)
 


### PR DESCRIPTION
Pages updated: Supported distributions, Upgrade Redis Enterprise clusters, all 6.4.2 release notes, all 6.2.18 release notes, 6.2.12 release notes.

Preview: 

- https://docs.redis.com/staging/RED-102241/kubernetes/reference/supported_k8s_distributions/
- https://docs.redis.com/staging/RED-102241/kubernetes/re-clusters/upgrade-redis-cluster/#before-upgrading/
- https://docs.redis.com/staging/RED-102241/content/kubernetes/release-notes/6-4-2-releases/6-4-2-6/
- https://docs.redis.com/staging/RED-102241/content/kubernetes/release-notes/6-4-2-releases/k8s-6-4-2-4/
- https://docs.redis.com/staging/RED-102241/content/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41/
- https://docs.redis.com/staging/RED-102241/content/kubernetes/release-notes/k8s-6-2-12-1/