### PR TITLE
K8s: correct webhook steps

### DIFF
--- a/content/embeds/k8s-admission-webhook-cert.md
+++ b/content/embeds/k8s-admission-webhook-cert.md
@@ -17,10 +17,10 @@
     CERT=`kubectl get secret admission-tls -o jsonpath='{.data.cert}'`
     ```
 
-1. Create a patch file for the Kubernetes validating webhook.
+1. Create a patch file for the Kubernetes validating webhook, replacing `<namespace>` with the namespace where the REC was installed.
 
     ```sh
-    sed 's/NAMESPACE_OF_SERVICE_ACCOUNT/demo/g' admission/webhook.yaml | kubectl create -f -
+    sed 's/NAMESPACE_OF_SERVICE_ACCOUNT/<namespace>/g' webhook.yaml | kubectl create -f -
 
     cat > modified-webhook.yaml <<EOF
     webhooks:

--- a/content/kubernetes/deployment/openshift/openshift-cli.md
+++ b/content/kubernetes/deployment/openshift/openshift-cli.md
@@ -146,46 +146,7 @@ Each Redis Enterprise cluster requires at least 3 nodes. Single-node RECs are no
 
 ## Configure the admission controller
 
-1. Verify the Kubernetes secret.
-   
-   The operator creates a Kubernetes secret for the admission controller during deployment.
-
-      ```sh
-      oc get secret admission-tls
-      ```
-
-    The response will be similar to this:
-
-    ```bash
-    NAME            TYPE     DATA   AGE
-    admission-tls   Opaque   2      2m43s
-    ```
-
-1. Save the automatically generated certificate to a local environment variable.
-
-    ```bash
-    CERT=`oc get secret admission-tls -o jsonpath='{.data.cert}'`
-    ```
-
-1. Create a patch file for the Kubernetes webhook using your own values for the namespace and webhook name.
-
-    ```sh
-    sed '<your_namespace>' admission/webhook.yaml | oc create -f -
-    cat > modified-webhook.yaml <<EOF
-    webhooks:
-      - name: <your.admission.webhook>
-        clientConfig:
-          caBundle: $CERT
-      admissionReviewVersions: ["v1beta1"]
-    EOF
-    ```
-
-1. Patch the validating webhook with the certificate.
-
-    ```sh
-    oc patch ValidatingWebhookConfiguration \
-      redis-enterprise-admission --patch "$(cat modified-webhook.yaml)"
-    ```
+{{< embed-md "k8s-admission-webhook-cert.md"  >}}
 
 ### Limit the webhook to relevant namespaces
 


### PR DESCRIPTION
Jira: DOC-2582
Staged preview: The same embedded block exists on these pages: 
https://docs.redis.com/staging/DOC-2582/kubernetes/deployment/quick-start/
https://docs.redis.com/staging/DOC-2582/kubernetes/deployment/openshift/openshift-cli/
https://docs.redis.com/staging/DOC-2582/kubernetes/re-clusters/upgrade-redis-cluster/