### PR TITLE
RS: RESP3 support - policy flag

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -40,6 +40,7 @@ rladmin tune cluster
         [ data_internode_encryption { enabled | disabled } ]
         [ db_conns_auditing { enabled | disabled } ]
         [ acl_pubsub_default { resetchannels | allchannels } ]
+        [ resp3_default { enabled | disabled } ]
 ```
 
 ### Parameters
@@ -65,6 +66,7 @@ rladmin tune cluster
 | redis_provision_node_threshold_percent | percentage                | Memory (in percentage) needed to provision a new database                                                                    |
 | redis_upgrade_policy                   | `latest`<br />`major`           | When you upgrade or create a new Redis database, this policy determines which version of Redis database compatibility is used.<br /><br />Supported values are:<ul><li><p>`latest`, which applies the most recent Redis compatibility update \(_effective default prior to v6.2.4_)<p></li><li>`major`, which applies the most recent major release compatibility update (_default as of v6.2.4_).</li></ul>                                                                                                                 |
 | repl_diskless                          | `enabled`<br />`disabled`       | Activates or deactivates diskless replication (can be overwritten per database)                                              |
+| resp3_default | `enabled` <br /> `disabled` | Determines the default value of the `resp3` option upon upgrading a database to version 7.2 (defaults to `enabled`) |
 | show_internals                         | `enabled`<br />`disabled`       | Controls the visibility of internal databases that are only used for the cluster's management                                |
 | slave_ha                               | `enabled` <br /> `disabled`   | Activates or deactivates replica high availability                                                                           |
 | slave_ha_bdb_cooldown_period           | time in seconds                   | Time (in seconds) after shard relocation during which databases can't be relocated to another node                           |

--- a/content/rs/references/compatibility/resp.md
+++ b/content/rs/references/compatibility/resp.md
@@ -17,7 +17,7 @@ RESP (Redis Serialization Protocol) is the protocol that clients use to communic
 
 - RESP3 is supported by Redis Enterprise 7.2 and later.
 
-## Enable RESP3 for a database
+## Enable RESP3 for a database {#enable-resp3}
 
 To use RESP3 with a Redis Enterprise Software database:
 
@@ -44,7 +44,7 @@ To use RESP3 with a Redis Enterprise Software database:
         { "resp3": true }
         ```
 
- ## Deactivate RESP3 for a database
+ ## Deactivate RESP3 for a database {#deactivate-resp3}
 
  To deactivate RESP3 support for a database:
 

--- a/content/rs/references/compatibility/resp.md
+++ b/content/rs/references/compatibility/resp.md
@@ -17,9 +17,9 @@ RESP (Redis Serialization Protocol) is the protocol that clients use to communic
 
 - RESP3 is supported by Redis Enterprise 7.2 and later.
 
-## Enable RESP3
+## Enable RESP3 for a database
 
-To use RESP3 with Redis Enterprise:
+To use RESP3 with a Redis Enterprise Software database:
 
 1. Upgrade Redis servers to version 7.2 or later.
 
@@ -31,23 +31,60 @@ To use RESP3 with Redis Enterprise:
 
 1. Enable RESP3 support for your database (`enabled` by default):
 
-    ```sh
-    rladmin tune db db:<ID> resp3 enabled
-    ```
+    - [`rladmin tune db`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-db">}}):
 
- ## Deactivate RESP3
+        ```sh
+        rladmin tune db db:<ID> resp3 enabled
+        ```
+
+    - [Update database configuration]({{<relref "/rs/references/rest-api/requests/bdbs#put-bdbs">}}) REST API request:
+
+        ```sh
+        PUT /v1/bdbs/<database_id> 
+        { "resp3": true }
+        ```
+
+ ## Deactivate RESP3 for a database
 
  To deactivate RESP3 support for a database:
 
- ```sh
- rladmin tune db db:<ID> resp3 disabled
- ```
+- [`rladmin tune db`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-db">}}):
+
+     ```sh
+    rladmin tune db db:<ID> resp3 disabled
+    ```
+
+- [Update database configuration]({{<relref "/rs/references/rest-api/requests/bdbs#put-bdbs">}}) REST API request:
+
+    ```sh
+    PUT /v1/bdbs/<database_id> 
+    { "resp3": false }
+    ```
 
  When RESP3 is deactivated, connected clients that use RESP3 are disconnected from the database.
 
 {{<note>}}
 You cannot use sharded pub/sub if you deactivate RESP3 support.
 {{</note>}}
+
+## Change default RESP3 option
+
+The cluster-wide option `resp3_default` determines the default value of the `resp3` option, which enables or deactivates RESP3 for a database, upon upgrading a database to version 7.2. `resp3_default` is set to `enabled` by default.
+
+To change `resp3_default` to `disabled`, use one of the following methods:
+
+- [`rladmin tune cluster`]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}})
+
+    ```sh
+    rladmin tune cluster resp3_default disabled
+    ```
+
+- [Update cluster policy]({{<relref "/rs/references/rest-api/requests/cluster/policy#put-cluster-policy">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster/policy 
+    { "resp3_default": false }
+    ```
 
 ## Client prerequisites for Redis 7.2 upgrade
 

--- a/content/rs/references/rest-api/objects/bdb/_index.md
+++ b/content/rs/references/rest-api/objects/bdb/_index.md
@@ -141,6 +141,7 @@ An API object that represents a managed database in the cluster.
 | [replica_sync]({{<relref "/rs/references/rest-api/objects/bdb/replica_sync">}}) | 'enabled'<br /> **'disabled'** <br />'paused'<br />'stopped' | Enable, disable, or pause syncing from specified replica_sources |
 | replica_sync_dist | boolean | Enable/disable distributed syncer in replica-of |
 | replication | boolean (default:&nbsp;false) | In-memory database replication mode |
+| resp3 | boolean (default:&nbsp;true) | Enables or deactivates RESP3 support |
 | roles_permissions | {{<code>}}
 [{
   "role_uid": integer,

--- a/content/rs/references/rest-api/objects/cluster_settings.md
+++ b/content/rs/references/rest-api/objects/cluster_settings.md
@@ -38,6 +38,7 @@ Cluster resources management policy
 | redis_provision_node_threshold | integer | Minimum free memory (excluding reserved memory) allowed on a node before new shards can no longer be added to it |
 | redis_provision_node_threshold_p | integer | Minimum free memory (excluding reserved memory) allowed on a node before new shards can no longer be added to it |
 | redis_upgrade_policy | **`major`** <br />`latest` | Create/upgrade Redis Enterprise software on databases in the cluster by compatibility with major versions or latest versions of OSS Redis |
+| resp3_default | boolean (default:&nbsp;true) | Determines the default value of the `resp3` option upon upgrading a database to version 7.2 |
 | shards_overbooking | boolean | If true, all databases' memory_size is ignored during shards placement |
 | show_internals | boolean | Show internal databases (and their shards and endpoints) REST APIs |
 | slave_ha | boolean | Enable the replica high-availability mechanism |


### PR DESCRIPTION
Staged previews:
- [RESP3 compatibility](https://docs.redis.com/staging/DOC-2585/rs/references/compatibility/resp/)
- [rladmin tune cluster](https://docs.redis.com/staging/DOC-2585/rs/references/cli-utilities/rladmin/tune/)
- [Cluster settings REST API object](https://docs.redis.com/staging/DOC-2585/rs/references/rest-api/objects/cluster_settings/)
- [BDB REST API object](https://docs.redis.com/staging/DOC-2585/rs/references/rest-api/objects/bdb/)