### PR TITLE
Fix scroll bar bug in scrollable table shortcode

### DIFF
--- a/layouts/shortcodes/table-scrollable.html
+++ b/layouts/shortcodes/table-scrollable.html
@@ -1,3 +1,3 @@
-<div style="overflow-x: scroll;">
+<div style="overflow-x: auto;">
     {{ .Inner | markdownify }}
-    </div>
+</div>


### PR DESCRIPTION
Found a bug where a phantom scrollbar appeared below tables on small displays. Try viewing the tables on the following page with different window sizes to test.

[Staged preview](https://docs.redis.com/staging/fix-scrollable-table/kubernetes/reference/supported_k8s_distributions/)