### PR TITLE
RS: Cluster recovery with manually uploaded modules (7.2.4 release notes)

### DIFF
--- a/content/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -256,3 +256,11 @@ As a temporary workaround, you can change the node's `os_name` in the Cluster Co
 ```sh
 ccs-cli hset node:<ID> os_name rhel7
 ```
+
+#### Cluster recovery with manually uploaded modules
+
+For clusters containing databases with manually uploaded modules, [cluster recovery]({{<relref "/rs/clusters/cluster-recovery">}}) requires an extra step.
+
+After installing Redis Enterprise Software on the cluster nodes, upload compatible modules to `modulesdir` (`/opt/redislabs/lib/modules`) before continuing the recovery process.
+
+This limitation will be removed in a future maintenance release.

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
@@ -730,6 +730,14 @@ As a temporary workaround, you can change the node's `os_name` in the Cluster Co
 ccs-cli hset node:<ID> os_name rhel7
 ```
 
+#### Cluster recovery with manually uploaded modules
+
+For clusters containing databases with manually uploaded modules, [cluster recovery]({{<relref "/rs/clusters/cluster-recovery">}}) requires an extra step.
+
+After installing Redis Enterprise Software on the cluster nodes, upload compatible modules to `modulesdir` (`/opt/redislabs/lib/modules`) before continuing the recovery process.
+
+This limitation will be removed in a future maintenance release.
+
 ## Security
 
 #### Open source Redis security fixes compatibility


### PR DESCRIPTION
Staged previews:
- [7.2.4 release notes index page](https://docs.redis.com/staging/rrelledge-patch-2/rs/release-notes/rs-7-2-4-releases/#cluster-recovery-with-manually-uploaded-modules)
- [7.2.4-52 release notes](https://docs.redis.com/staging/rrelledge-patch-2/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52/#cluster-recovery-with-manually-uploaded-modules)