### PR TITLE
Update rs-7-2-4-52.md

### DIFF
--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
@@ -729,7 +729,7 @@ Databases hosted on Oracle Linux 7 & 8 cannot load modules.
 As a temporary workaround, you can change the node's `os_name` in the Cluster Configuration Store (CCS):
 
 ```sh
-ccs-cli hset node:<ID> os_name rhel7
+ccs-cli hset node:<ID> os_name rhel
 ```
 
 #### Cluster recovery with manually uploaded modules


### PR DESCRIPTION
I've confirmed both working with a customer and by checking the CCS of an actual RHEL-7 environment. The correct os_name field should be "rhel" not "rhel7". If it is set to "rhel7", modules will fail to load citing "Error:  combination of OS rhel77 [. . .] is not supported".