### PR TITLE
RS: Fixed incorrect command for load modules workaround

### DIFF
--- a/content/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -254,7 +254,7 @@ Databases hosted on Oracle Linux 7 & 8 cannot load modules.
 As a temporary workaround, you can change the node's `os_name` in the Cluster Configuration Store (CCS):
 
 ```sh
-ccs-cli hset node:<ID> os_name rhel7
+ccs-cli hset node:<ID> os_name rhel
 ```
 
 #### Cluster recovery with manually uploaded modules

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
@@ -729,7 +729,7 @@ Databases hosted on Oracle Linux 7 & 8 cannot load modules.
 As a temporary workaround, you can change the node's `os_name` in the Cluster Configuration Store (CCS):
 
 ```sh
-ccs-cli hset node:<ID> os_name rhel7
+ccs-cli hset node:<ID> os_name rhel
 ```
 
 #### Cluster recovery with manually uploaded modules


### PR DESCRIPTION
DOC-2677

Staged previews:
- [7.2.4 release notes index](https://docs.redis.com/staging/DOC-2677/rs/release-notes/rs-7-2-4-releases/#modules-cannot-load-in-oracle-linux-7--8)
- [7.2.4-52 release notes](https://docs.redis.com/staging/DOC-2677/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52/#modules-cannot-load-in-oracle-linux-7--8)