### PR TITLE
DOC-2724: Incorrect link in "Monitor database performance" document

### DIFF
--- a/content/rc/databases/monitor-performance.md
+++ b/content/rc/databases/monitor-performance.md
@@ -58,7 +58,7 @@ Several metric graphs are available:
 | [Expired objects/sec]({{< relref "/rs/references/metrics/database-operations#expired-objectssec" >}}) | Number of expired objects per second. An expired object is an object with expired TTL that was deleted from the database. |
 | [Hit ratio]({{< relref "/rs/references/metrics/database-operations#hit-ratio" >}}) | Percent of operations on existing keys out of the total number database operations |
 
-For more detailed analysis, consider using [RedisInsight]({{< relref "/ri/" >}}) or [Prometheus and Grafana]({{< relref "/rc/cloud-integrations/" >}}).
+For more detailed analysis, consider using [RedisInsight]({{< relref "/ri/" >}}) or [Prometheus and Grafana]({{< relref "/rc/cloud-integrations/prometheus-integration" >}}).
 
 ## Configure metric alerts
 


### PR DESCRIPTION
DOC-2724

Staging link: https://docs.redis.com/staging/DOC-2724/databases/monitor-performance/#metric-definitions