### PR TITLE
DOC-2478: K8s: Backslash in reapplying security context command

### DIFF
--- a/content/kubernetes/re-clusters/upgrade-redis-cluster.md
+++ b/content/kubernetes/re-clusters/upgrade-redis-cluster.md
@@ -124,7 +124,8 @@ oc apply -f openshift/scc.yaml
 ```
 
 ```sh
-oc adm policy add-scc-to-user redis-enterprise-scc-v2 \ system:serviceaccount:<my-project>:<rec-name>
+oc adm policy add-scc-to-user redis-enterprise-scc-v2 \
+  system:serviceaccount:<my-project>:<rec-name>
 ```
 
 If you are upgrading from operator version 6.4.2-6 or before, see the ["after upgrading"](#after-upgrading) section to delete the old SCC and role binding after all clusters are running 6.4.2-6 or later.


### PR DESCRIPTION
Staging link: http://docs.reds.com/staging/DOC-2748/kubernetes/re-clusters/upgrade-redis-cluster/#reapply-the-scc