### PR TITLE
RS: Configure DB defaults in new UI

### DIFF
--- a/content/rs/databases/configure/db-defaults.md
+++ b/content/rs/databases/configure/db-defaults.md
@@ -27,7 +27,11 @@ To edit default database configuration using the Cluster Manager UI:
 
 ### Replica high availability
 
-**Replica High Availability** determines if [replica high availability]({{<relref "/rs/databases/configure/replica-ha">}}) is enabled by default for new databases.
+If [replica high availability]({{<relref "/rs/databases/configure/replica-ha">}}) is enabled, the cluster automatically migrates replica shards to an available node if a replica node fails or is promoted after a primary (master) node fails.
+
+To enable or turn off replica high availability by default, use one of the following methods:
+
+- Cluster Manager UI – Edit **Replica High Availability** in [**Database defaults**](#edit-database-defaults)
 
 - [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
     
@@ -46,6 +50,11 @@ To edit default database configuration using the Cluster Manager UI:
 
 When you upgrade an existing database or create a new one, it uses the default Redis version (**Database version**) unless you specify the database version explicitly with `redis_version` in the [REST API]({{<relref "/rs/references/rest-api/requests/bdbs">}}) or [`rladmin upgrade db`]({{<relref "/rs/references/cli-utilities/rladmin/upgrade#upgrade-db">}}).
 
+To configure the Redis database version, use one of the following methods:
+
+- Cluster Manager UI – Edit **Database version** in [**Database defaults**](#edit-database-defaults)
+
+
 - [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
     
     ```sh
@@ -61,7 +70,11 @@ When you upgrade an existing database or create a new one, it uses the default R
 
 ### S3 URL
 
-**S3 URL** is the default S3 host for [importing and exporting data]({{<relref "/rs/databases/import-export">}}).
+The S3 URL is the default S3 host for [importing and exporting data]({{<relref "/rs/databases/import-export">}}).
+
+To configure the default S3 URL, use one of the following methods:
+
+- Cluster Manager UI – Edit **S3 URL** in [**Database defaults**](#edit-database-defaults)
 
 - [rladmin cluster config]({{<relref "/rs/references/cli-utilities/rladmin/cluster/config">}}): 
     
@@ -78,7 +91,11 @@ When you upgrade an existing database or create a new one, it uses the default R
 
 ### Internode encryption
 
-Enable [**Internode Encryption**]({{<relref "/rs/security/internode-encryption">}}) to encrypt data in transit between nodes for new databases by default.
+Enable [internode encryption]({{<relref "/rs/security/internode-encryption">}}) to encrypt data in transit between nodes for new databases by default.
+
+To enable or turn off internode encryption by default, use one of the following methods:
+
+- Cluster Manager UI – Edit **Internode Encryption** in [**Database defaults**](#edit-database-defaults)
 
 - [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
     

--- a/content/rs/databases/configure/db-defaults.md
+++ b/content/rs/databases/configure/db-defaults.md
@@ -1,0 +1,94 @@
+---
+Title: Configure database defaults
+linkTitle: Database defaults
+description: Cluster-wide policies that determine default settings when creating new databases.
+weight: 10
+alwaysopen: false
+toc: "true"
+categories: ["RS"]
+aliases: 
+---
+
+Database defaults are cluster-wide policies that determine default settings when creating new databases.
+
+## Edit database defaults
+
+To edit default database configuration using the Cluster Manager UI:
+
+1. On the **Databases** screen, select <img src="/images/rs/buttons/button-toggle-actions-vertical.png#no-click" alt="Toggle actions button" width="22px"> to open a list of additional actions.
+
+1. Select **Database defaults**.
+
+1. Configure [database defaults](#db-defaults).
+
+1. Select **Save**.
+
+## Database defaults {#db-defaults}
+
+### Replica high availability
+
+**Replica High Availability** determines if [replica high availability]({{<relref "/rs/databases/configure/replica-ha">}}) is enabled by default for new databases.
+
+- [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
+    
+    ```sh
+    rladmin tune cluster slave_ha { enabled | disabled }
+    ```
+
+- [Update cluster policy]({{<relref "/rs/references/rest-api/requests/cluster/policy#put-cluster-policy">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster/policy 
+    { "slave_ha": <boolean> }
+    ```
+
+### Database version
+
+When you upgrade an existing database or create a new one, it uses the default Redis version (**Database version**) unless you specify the database version explicitly with `redis_version` in the [REST API]({{<relref "/rs/references/rest-api/requests/bdbs">}}) or [`rladmin upgrade db`]({{<relref "/rs/references/cli-utilities/rladmin/upgrade#upgrade-db">}}).
+
+- [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
+    
+    ```sh
+    rladmin tune cluster default_redis_version <x.y>
+    ```
+
+- [Update cluster policy]({{<relref "/rs/references/rest-api/requests/cluster/policy#put-cluster-policy">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster/policy 
+    { "default_provisioned_redis_version": "x.y" }
+    ```
+
+### S3 URL
+
+**S3 URL** is the default S3 host for [importing and exporting data]({{<relref "/rs/databases/import-export">}}).
+
+- [rladmin cluster config]({{<relref "/rs/references/cli-utilities/rladmin/cluster/config">}}): 
+    
+    ```sh
+    rladmin cluster config s3_url <URL>
+    ```
+
+- [Update cluster settings]({{<relref "/rs/references/rest-api/requests/cluster#put-cluster">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster
+    { "s3_url": "<URL>" }
+    ```
+
+### Internode encryption
+
+Enable [**Internode Encryption**]({{<relref "/rs/security/internode-encryption">}}) to encrypt data in transit between nodes for new databases by default.
+
+- [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
+    
+    ```sh
+    rladmin tune cluster data_internode_encryption { enabled | disabled }
+    ```
+
+- [Update cluster policy]({{<relref "/rs/references/rest-api/requests/cluster/policy#put-cluster-policy">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster/policy 
+    { "data_internode_encryption": <boolean> }
+    ```

--- a/content/rs/databases/configure/replica-ha.md
+++ b/content/rs/databases/configure/replica-ha.md
@@ -47,10 +47,9 @@ For example:
 - Replica HA migrates as many shards as possible based on available DRAM in the target node. When no DRAM is available, replica HA stops migrating replica shards to that node.
 {{< /note >}}
 
-## Configuring high availability for replica shards
+## Configure high availability for replica shards
 
-Using `rladmin` or the REST API, replica HA is controlled on the database level and on the cluster level.
-You can enable or disable replica HA for a database or for the entire cluster.
+You can enable or turn off replica high availability for a database or for the entire cluster using the Cluster Manager UI, `rladmin`, or the REST API.
 
 When replica HA is enabled for both the cluster and a database,
 replica shards for that database are automatically migrated to another node in the event of a master or replica shard failure.
@@ -58,18 +57,41 @@ If replica HA is disabled at the cluster level,
 replica HA will not migrate replica shards even if replica HA is enabled for a database.
 
 {{< note >}}
-By default, replica HA is enabled for the cluster and disabled for each database.
+By default, replica HA is enabled for the cluster but not enabled for each database.
 {{< /note >}}
 
 {{< note >}}
 For Active-Active databases, replica HA is enabled for the database by default to make sure that replica shards are available for Active-Active replication.
 {{< /note >}}
 
-To enable replica HA for a cluster using `rladmin`, run:
+### Configure cluster policy for replica HA
 
-``` text
-rladmin tune cluster slave_ha enabled
-```
+To enable or turn off replica high availability by default for the entire cluster, use one of the following methods:
+
+- Cluster Manager UI:
+
+    1. On the **Databases** screen, select <img src="/images/rs/buttons/button-toggle-actions-vertical.png#no-click" alt="Toggle actions button" width="22px"> to open a list of additional actions.
+
+    1. Select **Database defaults**.
+
+    1. Enable or turn off **Replica High Availability**.
+
+    1. Select **Save**.
+
+- [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
+    
+    ```sh
+    rladmin tune cluster slave_ha { enabled | disabled }
+    ```
+
+- [Update cluster policy]({{<relref "/rs/references/rest-api/requests/cluster/policy#put-cluster-policy">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster/policy 
+    { "slave_ha": <boolean> }
+    ```
+
+### Turn off replica HA for a database
 
 To disable replica HA for a specific database using `rladmin`, run:
 

--- a/content/rs/security/internode-encryption.md
+++ b/content/rs/security/internode-encryption.md
@@ -54,11 +54,36 @@ To enable internode encryption for a database (also called _data plane encryptio
 
 When you change the data internode encryption setting for a database, all active remote client connections are disconnected.  This restarts the internal (DMC) proxy and disconnects all client connections.
 
-To enable data plane encryption by default for new databases, use `rladmin` to tune the cluster:
+## Change cluster policy
 
-``` shell
-rladmin tune cluster data_internode_encryption enable
-```
+To enable internode encryption for new databases by default, use one of the following methods:
+
+- Cluster Manager UI
+
+    1. On the **Databases** screen, select <img src="/images/rs/buttons/button-toggle-actions-vertical.png#no-click" alt="Toggle actions button" width="22px"> to open a list of additional actions.
+
+    1. Select **Database defaults**.
+
+    1. Go to **Internode Encryption** and click **Change**.
+
+    1. Select **Enabled** to enable internode encryption for new databases by default.
+
+    1. Click **Change**.
+
+    1. Select **Save**.
+
+- [rladmin tune cluster]({{<relref "/rs/references/cli-utilities/rladmin/tune#tune-cluster">}}): 
+    
+    ```sh
+    rladmin tune cluster data_internode_encryption enabled
+    ```
+
+- [Update cluster policy]({{<relref "/rs/references/rest-api/requests/cluster/policy#put-cluster-policy">}}) REST API request:
+
+    ```sh
+    PUT /v1/cluster/policy 
+    { "data_internode_encryption": true }
+    ```
 
 ## Encryption ciphers and settings
 


### PR DESCRIPTION
Staged previews:
- [Configure database defaults](https://docs.redis.com/staging/DOC-2630/rs/databases/configure/db-defaults/)
- [Replica HA](https://docs.redis.com/staging/DOC-2630/rs/databases/configure/replica-ha/#configure-cluster-policy-for-replica-ha)
- [Internode encryption](https://docs.redis.com/staging/DOC-2630/rs/security/internode-encryption/#change-cluster-policy)