### PR TITLE
RS: Preferred endpoint types

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/info.md
+++ b/content/rs/references/cli-utilities/rladmin/info.md
@@ -51,6 +51,7 @@ Cluster configuration:
     slave_ha_bdb_cooldown_period: 7200
     parallel_shards_upgrade: 0
     show_internals: disabled
+    cluster_preferred_endpoint_type_default: ip
     expose_hostnames_for_all_suffixes: disabled
     login_lockout_threshold: 5
     login_lockout_duration: 1800
@@ -118,6 +119,7 @@ db:1 [database1]:
     max_connections: 0
     oss_cluster: disabled
     oss_cluster_api_preferred_ip_type: internal
+    cluster_preferred_endpoint_type: ip
     gradual_src_mode: disabled
     gradual_src_max_sources: 1
     gradual_sync_mode: auto

--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -49,7 +49,7 @@ rladmin tune cluster
 | Parameters                             | Type/Value                        | Description                                                                                                                  |
 |----------------------------------------|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
 | acl_pubsub_default | `resetchannels`<br /> `allchannels` | Default pub/sub ACL rule for all databases in the cluster:<br />•`resetchannels` blocks access to all channels (restrictive)<br />•`allchannels` allows access to all channels (permissive) |
-| cluster_preferred_endpoint_type_default | `ip`<br />`hostname` | The default preferred endpoint type for new databases (defaults to `ip`) |
+| cluster_preferred_endpoint_type_default | `ip`<br />`hostname` | The default preferred endpoint type, returned by `CLUSTER SLOTS`, `CLUSTER SHARDS`, and `CLUSTER NODES`, for new databases (defaults to `ip`) |
 | data_internode_encryption              | `enabled`<br />`disabled`       | Activates or deactivates [internode encryption]({{<relref "/rs/security/internode-encryption">}}) for new databases    |
 | db_conns_auditing                      | `enabled`<br /> `disabled`      | Activates or deactivates [connection auditing]({{<relref "/rs/security/audit-events">}}) by default for new databases of a cluster                                                                  |
 | default_concurrent_restore_actions     | integer<br />`all`              | Default number of concurrent actions when restoring a node from a snapshot (positive integer or "all")                         |

--- a/content/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/rs/references/cli-utilities/rladmin/tune.md
@@ -41,6 +41,7 @@ rladmin tune cluster
         [ db_conns_auditing { enabled | disabled } ]
         [ acl_pubsub_default { resetchannels | allchannels } ]
         [ resp3_default { enabled | disabled } ]
+        [ cluster_preferred_endpoint_type_default { ip | hostname } ]
 ```
 
 ### Parameters
@@ -48,6 +49,7 @@ rladmin tune cluster
 | Parameters                             | Type/Value                        | Description                                                                                                                  |
 |----------------------------------------|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
 | acl_pubsub_default | `resetchannels`<br /> `allchannels` | Default pub/sub ACL rule for all databases in the cluster:<br />•`resetchannels` blocks access to all channels (restrictive)<br />•`allchannels` allows access to all channels (permissive) |
+| cluster_preferred_endpoint_type_default | `ip`<br />`hostname` | The default preferred endpoint type for new databases (defaults to `ip`) |
 | data_internode_encryption              | `enabled`<br />`disabled`       | Activates or deactivates [internode encryption]({{<relref "/rs/security/internode-encryption">}}) for new databases    |
 | db_conns_auditing                      | `enabled`<br /> `disabled`      | Activates or deactivates [connection auditing]({{<relref "/rs/security/audit-events">}}) by default for new databases of a cluster                                                                  |
 | default_concurrent_restore_actions     | integer<br />`all`              | Default number of concurrent actions when restoring a node from a snapshot (positive integer or "all")                         |
@@ -131,6 +133,7 @@ rladmin tune db { db:<id> | <name> }
         [ data_internode_encryption { enabled | disabled } ]
         [ db_conns_auditing { enabled | disabled } ]
         [ resp3 { enabled | disabled } ]
+        [ cluster_preferred_endpoint_type { ip | hostname } ]
 ```
 
 ### Parameters
@@ -140,6 +143,7 @@ rladmin tune db { db:<id> | <name> }
 | db:id                                | integer                          | ID of the specified database                                                                                                          |
 | name                                 | string                           | Name of the specified database                                                                                                        |
 | client_buffer                        | value in MB hard:soft:time       | Redis client output buffer limits                                                                                                     |
+| cluster_preferred_endpoint_type | `ip`<br />`hostname` | The preferred endpoint type returned by `CLUSTER SLOTS`, `CLUSTER SHARDS`, and `CLUSTER NODES` (defaults to `ip`) |
 | conns                                | integer                          | Size of internal connection pool, specified per-thread or per-shard depending on conns_type                                           |
 | conns_type                           | `per-thread`<br /> `per-shard`   | Specifies connection pool size as either per-thread or per-shard                                                                      |
 | continue_on_error                    |                                  | Flag that skips tuning shards that can't be reached                                                                                   |

--- a/content/rs/references/rest-api/objects/bdb/_index.md
+++ b/content/rs/references/rest-api/objects/bdb/_index.md
@@ -65,6 +65,7 @@ An API object that represents a managed database in the cluster.
   "weight": number
 }, ...]
 {{</code>}} | List of shard UIDs and their bigstore RAM weights;<br /> **shard_uid**: Shard UID;<br /> **weight**: Relative weight of RAM distribution |
+| cluster_preferred_endpoint_type | `ip`<br />`hostname` | The preferred endpoint type returned by `CLUSTER SLOTS`, `CLUSTER SHARDS`, and `CLUSTER NODES` (defaults to `ip`) |
 | client_cert_subject_validation_type | **disabled**<br />san_cn<br />full_subject | Enables additional certificate validations that further limit connections to clients with valid certificates during TLS client authentication.<br />**disabled**: Authenticates clients with valid certificates. No additional validations are enforced.<br />**san_cn**: A client certificate is valid only if its Common Name (CN) matches an entry in the list of valid subjects. Ignores other Subject attributes.<br />**full_subject**: A client certificate is valid only if its Subject attributes match an entry in the list of valid subjects. |
 | crdt | boolean (default:&nbsp;false) | Use CRDT-based data types for multi-master replication |
 | crdt_causal_consistency | boolean (default:&nbsp;false) | Causal consistent CRDB. |

--- a/content/rs/references/rest-api/objects/cluster_settings.md
+++ b/content/rs/references/rest-api/objects/cluster_settings.md
@@ -16,6 +16,7 @@ Cluster resources management policy
 | bigstore_migrate_node_threshold_p | integer | Minimum free memory (excluding reserved memory) allowed on a node before automatic migration of shards from it to free more memory |
 | bigstore_provision_node_threshold | integer | Minimum free memory (excluding reserved memory) allowed on a node before new shards can no longer be added to it |
 | bigstore_provision_node_threshold_p | integer | Minimum free memory (excluding reserved memory) allowed on a node before new shards can no longer be added to it |
+| cluster_preferred_endpoint_type_default | `ip`<br />`hostname` | The default preferred endpoint type, returned by `CLUSTER SLOTS`, `CLUSTER SHARDS`, and `CLUSTER NODES`, for new databases (defaults to `ip`) |
 | data_internode_encryption | boolean | Enable/deactivate encryption of the data plane internode communication |
 | db_conns_auditing | boolean | [Audit connections]({{<relref "/rs/security/audit-events">}}) for new databases by default if set to true. |
 | default_concurrent_restore_actions | integer | Default number of restore actions allowed at the same time. Set to 0 to allow any number of simultaneous restore actions. |


### PR DESCRIPTION
Staged previews:
- [rladmin tune](https://docs.redis.com/staging/DOC-2753/rs/references/cli-utilities/rladmin/tune/)
- [rladmin info](https://docs.redis.com/staging/DOC-2753/rs/references/cli-utilities/rladmin/info/)
- [Cluster settings REST API object](https://docs.redis.com/staging/DOC-2753/rs/references/rest-api/objects/cluster_settings/)
- [BDB cluster object](https://docs.redis.com/staging/DOC-2753/rs/references/rest-api/objects/bdb/)