### PR TITLE
6.4: Fixed version selector to keep the full URL path instead of trimming it

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -45,10 +45,10 @@
                     <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
                 </button>
                 <div class="menu__version-selector__list version-selector-control">
-                    <a href="https://docs.redis.com/7.2/rs" id="version-select-7.2" onclick="_setSelectedVersion('7.2', 'v7.2 (latest)')">v7.2 (latest)</a>
-                    <a href="https://docs.redis.com/6.4/rs" id="version-select-6.4" onclick="_setSelectedVersion('6.4', 'v6.4')">v6.4</a>
-                    <a href="https://docs.redis.com/6.2/rs" id="version-select-6.2" onclick="_setSelectedVersion('6.2', 'v6.2')">v6.2</a>
-                    <a href="https://docs.redis.com/6.0/rs" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.0')">v6.0</a>
+                    <a href="https://docs.redis.com/7.2{{.RelPermalink}}" id="version-select-7.2" onclick="_setSelectedVersion('7.2', 'v7.2 (latest)')">v7.2 (latest)</a>
+                    <a href="https://docs.redis.com/6.4{{.RelPermalink}}" id="version-select-6.4" onclick="_setSelectedVersion('6.4', 'v6.4')">v6.4</a>
+                    <a href="https://docs.redis.com/6.2{{.RelPermalink}}" id="version-select-6.2" onclick="_setSelectedVersion('6.2', 'v6.2')">v6.2</a>
+                    <a href="https://docs.redis.com/6.0{{.RelPermalink}}" id="version-select-6.0" onclick="_setSelectedVersion('6.0', 'v6.0')">v6.0</a>
                 </div>
             </div>
             {{end}}
@@ -62,8 +62,8 @@
                     <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
                 </button>
                 <div class="menu__version-selector__list version-selector-control">
-                    <a href="https://docs.redis.com/7.2/kubernetes" id="version-select-7.2" onclick="_setSelectedVersion('7.2', 'v7.2 (latest)')">v7.2 (latest)</a>
-                    <a href="https://docs.redis.com/6.4/kubernetes" id="version-select-6.x" onclick="_setSelectedVersion('6.4', 'v6.x')">v6.x</a>
+                    <a href="https://docs.redis.com/7.2{{.RelPermalink}}" id="version-select-7.2" onclick="_setSelectedVersion('7.2', 'v7.2 (latest)')">v7.2 (latest)</a>
+                    <a href="https://docs.redis.com/6.4{{.RelPermalink}}" id="version-select-6.x" onclick="_setSelectedVersion('6.4', 'v6.x')">v6.x</a>
                 </div>
             </div>
             {{end}}
@@ -76,8 +76,8 @@
                     <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
                 </button>
                 <div class="menu__version-selector__list version-selector-control">
-                    <a href="https://docs.redis.com/latest/rdi" id="version-select-latest" onclick="_setSelectedVersion('latest', 'latest')">latest</a>
-                    <a href="https://docs.redis.com/rdi-preview/rdi" id="version-select-rdi-preview" onclick="_setSelectedVersion('rdi-preview', 'preview')">preview</a>
+                    <a href="https://docs.redis.com/latest{{.RelPermalink}}" id="version-select-latest" onclick="_setSelectedVersion('latest', 'latest')">latest</a>
+                    <a href="https://docs.redis.com/rdi-preview{{.RelPermalink}}" id="version-select-rdi-preview" onclick="_setSelectedVersion('rdi-preview', 'preview')">preview</a>
                 </div>
             </div>
             {{end}}


### PR DESCRIPTION
[DOC-2707](https://redislabs.atlassian.net/browse/DOC-2707)

To test, click on the version selector and compare the URLs/links between the [staged preview](https://docs.redis.com/staging/DOC-2707-6.4/rs/security/) and [v6.4](https://docs.redis.com/6.4/rs/security/).

When you click on a different version in the staged preview, you should be redirected to a different version of the same page instead of being redirected to the main [Redis Enterprise Software page](https://docs.redis.com/latest/rs/).

Note: I will need to open similar PRs for each version branch to fix this across all versions of the site.

[DOC-2707]: https://redislabs.atlassian.net/browse/DOC-2707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ