### PR TITLE
Fix `base64 --decode` example

### DIFF
--- a/content/kubernetes/security/manage-rec-credentials.md
+++ b/content/kubernetes/security/manage-rec-credentials.md
@@ -38,7 +38,7 @@ The credentials can be used to access the Redis Enterprise admin console or the 
 1. Decode the password and username with the `echo` command and the password from the previous step.
 
     ```bash
-    echo MTIzNDU2NzgK | base64 --decodexc
+    echo MTIzNDU2NzgK | base64 --decode
     ```
 
     This outputs the password and username in plain text. In this example, the plain text password is `12345678` and the username is `demo@example.com`.


### PR DESCRIPTION
`base64 --decodexc` is invalid (no such flag).
The correct flag is `base64 --decode`.