### PR TITLE
RS 6.4: Added example to sign private key with CA

### DIFF
--- a/content/rs/security/certificates/create-certificates.md
+++ b/content/rs/security/certificates/create-certificates.md
@@ -212,6 +212,10 @@ However you choose to create the certificates, be sure to incorporate the guidel
 
 3.  Sign the private key using your certificate authority.
 
+    ```sh
+    $ openssl x509 -req -in <key-file-name>.csr -signkey <key-file-name>.pem -out <cert-name>.pem
+    ```
+
     The signing process varies for each organization and CA vendor.  Consult your security team and certificate authority for specific instructions describing how to sign a certificate.
 
 4.  Upload the certificate to your cluster.
@@ -219,11 +223,11 @@ However you choose to create the certificates, be sure to incorporate the guidel
     You can use [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/certificate">}}) to replace the existing certificates with new certificates:
 
     ``` console
-    $ rladmin cluster certificate set <CertName> certificate_file \
-       <CertFilename>.pem key_file <KeyFilename>.pem
+    $ rladmin cluster certificate set <cert-name> certificate_file \
+       <cert-name>.pem key_file <key-file-name>.pem
     ```
 
-    For a list of values supported by the _\<CertName>_ parameter, see the [earlier table](#replace-self-signed).
+    For a list of values supported by the `<cert-name>` parameter, see the [earlier table](#replace-self-signed).
 
     You can also use the REST API.  To learn more, see [Update certificates]({{<relref "/rs/security/certificates/updating-certificates#how-to-update-certificates">}}).
 


### PR DESCRIPTION
[DOC-3093](https://redislabs.atlassian.net/browse/DOC-3093)

[Staged preview](https://docs.redis.com/staging/DOC-3093-v6.4/rs/security/certificates/create-certificates/#create-certificates)

Note: I will open similar PRs for 7.2 and 6.2 docs.

[DOC-3093]: https://redislabs.atlassian.net/browse/DOC-3093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ