### PR TITLE
K8s: update distro to remove unsupported 1.28

### DIFF
--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -138,11 +138,11 @@ For details on this platform, see the [AKS documentation](https://learn.microsof
 
 For details on this platform, see the [GKE documentation](https://cloud.google.com/kubernetes-engine/docs).
 
-{{<table-scrollable>}}| **Redis operator** | **<nobr>7.2.4-12</nobr>** | **<nobr>7.2.4-7</nobr>** | **<nobr>7.2.4-2</nobr>** | **<nobr>6.4.2-8</nobr>** | **<nobr>6.4.2-6</nobr>** | **<nobr>6.4.2-5</nobr>** | **<nobr>6.4.2-4</nobr>** | **<nobr>6.2.18-41</nobr>** | **<nobr>6.2.18-3</nobr>** | **<nobr>6.2.12-1</nobr>** | **<nobr><nobr>6.2.10-4</nobr>5</nobr>** | **<nobr>6.2.10-34</nobr>** | **<nobr>6.2.10-4</nobr>** | **<nobr>6.2.8-15</nobr>** | **<nobr>6.2.8-11</nobr>** | **<nobr>6.2.8-2</nobr>** | **<nobr>6.2.4-1</nobr>** |
+{{<table-scrollable>}}
+| **Redis operator** | **<nobr>7.2.4-12</nobr>** | **<nobr>7.2.4-7</nobr>** | **<nobr>7.2.4-2</nobr>** | **<nobr>6.4.2-8</nobr>** | **<nobr>6.4.2-6</nobr>** | **<nobr>6.4.2-5</nobr>** | **<nobr>6.4.2-4</nobr>** | **<nobr>6.2.18-41</nobr>** | **<nobr>6.2.18-3</nobr>** | **<nobr>6.2.12-1</nobr>** | **<nobr><nobr>6.2.10-4</nobr>5</nobr>** | **<nobr>6.2.10-34</nobr>** | **<nobr>6.2.10-4</nobr>** | **<nobr>6.2.8-15</nobr>** | **<nobr>6.2.8-11</nobr>** | **<nobr>6.2.8-2</nobr>** | **<nobr>6.2.4-1</nobr>** |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | **** | Dec 2023 | Oct 2023 | Aug 2023 | July 2023 | June 2023 | April 2023 | March 2023 | Jan 2022 | Nov 2022 | Sept 2022 | July 2022 | May 2022 | March 2022 | Jan 2022 | Jan 2022 | Nov 2021 | Sept 2021 |
 | **Google GKE** |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
-| **1.28** | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | **1.27** | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | **1.26** | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |  |  |
 | **1.25** | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |
@@ -153,7 +153,6 @@ For details on this platform, see the [GKE documentation](https://cloud.google.c
 | **1.2** |  |  |  |  |  |  |  |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecated">&#x26A0;&#xFE0F;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **1.19** |  |  |  |  |  |  |  |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecated">&#x26A0;&#xFE0F;</span> | <span title="Supported">&#x2705;</span> |  | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **1.18** |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | <span title="Supported">&#x2705;</span> |
-
 
 {{</table-scrollable>}}
 

--- a/content/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/kubernetes/reference/supported_k8s_distributions.md
@@ -119,7 +119,6 @@ For details on this platform, see the [AKS documentation](https://learn.microsof
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | **** | Dec 2023 | Oct 2023 | Aug 2023 | Jul 2023 | Jun 2023 | Apr 2023 | Mar 2023 | Jan 2022 | Nov 2022 | Sept 2022 | Jul 2022 | May 2022 | Mar 2022 | Jan 2022 | Jan 2022 | Nov 2021 | Sept 2021 |
 | **Azure AKS** |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
-| **1.28** | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | **1.27** | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | **1.26** | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |  |  |
 | **1.25** | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |  |  |  |  |  |  |

--- a/content/kubernetes/release-notes/7-2-4-releases/7-2-4-12.md
+++ b/content/kubernetes/release-notes/7-2-4-releases/7-2-4-12.md
@@ -74,8 +74,8 @@ Any distribution not listed below is not supported for production workloads.
 |---|---|---|---|---|---|---|
 | Community Kubernetes |  | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | Amazon EKS | <span title="Deprecated">&#x26A0;&#xFE0F;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
-| Azure AKS |  |  | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| Google GKE | <span title="X icon">&#x274c;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| Azure AKS |  |  | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
+| Google GKE | <span title="X icon">&#x274c;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
 | Rancher 2.6 | <span title="X icon">&#x274c;</span> | <span title="X icon">&#x274c;</span> |  |  |  |  |
 | Rancher RKE2 | <span title="Deprecated">&#x26A0;&#xFE0F;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |
 | VMware TKG 2.1 | <span title="Deprecated">&#x26A0;&#xFE0F;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |
@@ -85,6 +85,7 @@ Any distribution not listed below is not supported for production workloads.
 |  | <span title="X icon">&#x274c;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
 | **VMware TKGI version** | **1.14** | **1.15** |  |  |  |  |
 |  | <span title="X icon">&#x274c;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |
+
 
 ## Downloads
 


### PR DESCRIPTION
Jira: DOC-3224

Preview: https://docs.redis.com/staging/DOC-3224/kubernetes/reference/supported_k8s_distributions/
https://docs.redis.com/staging/DOC-3224/kubernetes/release-notes/7-2-4-releases/7-2-4-12/