### PR TITLE
Fixed relrefs appended with _index.md

### DIFF
--- a/content/contribution-guide.md
+++ b/content/contribution-guide.md
@@ -146,8 +146,8 @@ and the concepts must explain any background information that is needed to know 
     - Incorrect - `In this section detailed description of available development tools, like built-in features, widget objects, functions, template mechanism and available libraries is provided.`
     - Correct - `The widget development tools include built-in features, widget objects, functions, template mechanism and available libraries.`
 - Link from text itself instead of “see …”. For example:
-    - Incorrect - `Using the React Utility is the recommended method, and it requires a build operation. You must use the build system described in [Widget building]({{< relref "rs/_index.md" >}}) section.`
-    - Correct - `Using the React Utility is the recommended method, and it requires a build operation in the [widget build system]({{< relref "rs/_index.md" >}}).`
+    - Incorrect - `Using the React Utility is the recommended method, and it requires a build operation. You must use the build system described in [Widget building]({{< relref "rs" >}}) section.`
+    - Correct - `Using the React Utility is the recommended method, and it requires a build operation in the [widget build system]({{< relref "rs" >}}).`
 - Terminology for APIs:
     - Your code calls an API, which usually returns something.
     - A call to a REST API sends an HTTP Request to the API URL and the server that hosts that URL usually returns an HTTP Response.

--- a/content/embeds/cluster-dns-embed.md
+++ b/content/embeds/cluster-dns-embed.md
@@ -17,7 +17,7 @@ Whether you're administering Redis Enterprise Software or accessing databases, t
 
 ## URL-based connections
 
-The fully qualified domain name (FQDN) is the unique cluster identifier that enables clients to connect to [the different components]({{< relref "/rs/concepts/_index.md" >}}) of Redis Enterprise Software.
+The fully qualified domain name (FQDN) is the unique cluster identifier that enables clients to connect to the different components of Redis Enterprise Software.
 The FQDN is a crucial component of the high-availability mechanism because it's used internally to enable and implement automatic and transparent failover of nodes, databases shards, and endpoints.
 
 {{< note >}}

--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -103,7 +103,7 @@ Conflict-free replicated databases (CRDB) are an alternate name for [Active-Acti
 {{%definition "conflict-free replicated data types (CRDT)"%}}
 Techniques used by Redis data types in Active-Active databases that handle conflicting concurrent writes across member Active-Active databases. The Redis Enterprise implementation of CRDT is called an Active-Active database (formerly known as CRDB).
 
-More info: [CRDT info]({{<relref "/rs/databases/active-active/develop/#info" >}}), [Active-Active geo-distributed Redis]({{< relref "/rs/databases/active-active/_index.md" >}}), [CRDT wikipedia](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
+More info: [CRDT info]({{<relref "/rs/databases/active-active/develop/#info" >}}), [Active-Active geo-distributed Redis]({{< relref "/rs/databases/active-active" >}}), [CRDT wikipedia](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
 {{%/definition%}}
 
 {{%definition "CustomResourceDefinition (CRD)"%}}

--- a/content/kubernetes/deployment/quick-start.md
+++ b/content/kubernetes/deployment/quick-start.md
@@ -29,7 +29,7 @@ To deploy Redis Enterprise Software for Kubernetes and start your Redis Enterpri
 - Apply the operator bundle and verify it's running.
 - Create a Redis Enterprise cluster (REC).
 
-This guide works with most supported Kubernetes distributions. If you're using OpenShift, see [Redis Enterprise on OpenShift]({{< relref "/kubernetes/deployment/openshift/_index.md" >}}). For details on what is currently supported, see [supported distributions]({{<relref "/kubernetes/reference/supported_k8s_distributions.md">}}).
+This guide works with most supported Kubernetes distributions. If you're using OpenShift, see [Redis Enterprise on OpenShift]({{< relref "/kubernetes/deployment/openshift" >}}). For details on what is currently supported, see [supported distributions]({{<relref "/kubernetes/reference/supported_k8s_distributions.md">}}).
 
 
 ## Prerequisites

--- a/content/rc/api/_index.md
+++ b/content/rc/api/_index.md
@@ -22,7 +22,7 @@ You can use the API to:
 ## Getting started
 
 1. [Enable the API]({{< relref  "/rc/api/get-started/enable-the-api.md" >}})
-1. [Authenticate and authorize]({{< relref  "/rc/api/get-started/_index.md" >}})
+1. [Authenticate and authorize]({{< relref  "/rc/api/get-started" >}})
 1. [Create API keys]({{< relref  "/rc/api/get-started/manage-api-keys.md" >}})
 1. [Use the API]({{< relref  "/rc/api/get-started/use-rest-api.md" >}})
 1. [Learn the API lifecycle]({{< relref  "/rc/api/get-started/process-lifecycle.md" >}})
@@ -43,4 +43,4 @@ You can use the API to:
 
 - Use the [Redis Cloud API]({{< relref  "/rc/api/get-started/use-rest-api.md" >}})
 - [Full API Reference](https://api.redislabs.com/v1/swagger-ui.html)
-- Secure [authentication and authorization]({{< relref  "/rc/api/get-started/_index.md" >}})
+- Secure [authentication and authorization]({{< relref  "/rc/api/get-started" >}})

--- a/content/rc/api/get-started/use-rest-api.md
+++ b/content/rc/api/get-started/use-rest-api.md
@@ -85,7 +85,7 @@ Some API operations require input, such as:
         ![swagger-post-edit-body](/images/rv/api/swagger-post-edit-body.png)
 
 {{< warning >}}
-The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You should modify these examples to suit your specific needs and account settings. The examples will fail if used as-is. <br/><br/>For more examples showing how to use specific endpoints, see [REST API examples]({{< relref "/rc/api/examples/_index.md" >}}).
+The Swagger UI generates default JSON examples for `POST` and `PUT` operations. You should modify these examples to suit your specific needs and account settings. The examples will fail if used as-is. <br/><br/>For more examples showing how to use specific endpoints, see [REST API examples]({{< relref "/rc/api/examples" >}}).
 {{< /warning >}}
 
 ## Use the `cURL` HTTP client

--- a/content/rc/rc-quickstart.md
+++ b/content/rc/rc-quickstart.md
@@ -138,7 +138,7 @@ See [Redis CLI](https://redis.io/docs/connect/cli/) to learn how to use `redis-c
 
 - [Connect your application](https://redis.io/docs/connect/clients/)
 - [Import data]({{< relref "/rc/databases/import-data.md" >}})
-- [Manage databases]({{< relref "/rc/databases/_index.md" >}})
+- [Manage databases]({{< relref "/rc/databases" >}})
 - [Data persistence]({{< relref "/rc/databases/configuration/data-persistence.md" >}})
 - [Secure your Redis Cloud database]({{< relref "/rc/security/" >}})
 - [Back-up Flexible databases]({{< relref "/rc/databases/back-up-data.md" >}})

--- a/content/ri/_index.md
+++ b/content/ri/_index.md
@@ -27,5 +27,5 @@ RedisInsight also has support for several Redis modules, including [RedisGraph](
 
 ## Start using RedisInsight
 
-- [Install RedisInsight]({{<relref "/ri/installing/_index.md" >}})
+- [Install RedisInsight]({{<relref "/ri/installing" >}})
 - [Add a Redis database]({{<relref "/ri/using-redisinsight/add-instance.md">}})

--- a/content/rs/clusters/add-node.md
+++ b/content/rs/clusters/add-node.md
@@ -27,7 +27,7 @@ Before you add a node to the cluster:
     If the clock in the node you are trying to join to the cluster is not synchronized with the nodes already in the cluster,
     the action fails and an error message is shown indicating that you must synchronize the clocks first.
 
-- You must [update the DNS records]({{< relref "/rs/networking/cluster-dns/_index.md" >}})
+- You must [update the DNS records]({{< relref "/rs/networking/cluster-dns" >}})
     each time a node is added or replaced.
 
 - We recommend that you add nodes one after the other rather than in parallel
@@ -36,7 +36,7 @@ Before you add a node to the cluster:
 
 To add a node to an existing cluster:
 
-1. [Install the Redis Enterprise Software installation package]({{< relref "/rs/installing-upgrading/_index.md" >}}) on a clean installation
+1. [Install the Redis Enterprise Software installation package]({{< relref "/rs/installing-upgrading" >}}) on a clean installation
     of a [supported operating system]({{< relref "/rs/installing-upgrading/install/plan-deployment/supported-platforms.md" >}}).
 
 1. To connect to the management UI of the new Redis Enterprise Software installation, go to: <https://URL or IP address:8443/new>

--- a/content/rs/clusters/cluster-recovery.md
+++ b/content/rs/clusters/cluster-recovery.md
@@ -53,7 +53,7 @@ The cluster recovery process includes:
 
 1. (Optional) If you want to recover the cluster to the original cluster nodes, uninstall RS from the nodes.
 
-1. Install [RS]({{< relref "/rs/installing-upgrading/_index.md" >}}) on the new cluster nodes.
+1. Install [RS]({{< relref "/rs/installing-upgrading" >}}) on the new cluster nodes.
 
     Do not configure the cluster nodes (`rladmin cluster create` in the CLI or **Setup** in the admin console).
 
@@ -121,7 +121,7 @@ Otherwise, the node gets the same rack ID as the original node.
     {{% expand "Command syntax" %}}
 `nodes` - The IP address of a node in the cluster that this node is joining.
 
-`name` - The [FQDN name]({{< relref "/rs/networking/cluster-dns/_index.md" >}})
+`name` - The [FQDN name]({{< relref "/rs/networking/cluster-dns" >}})
 of the cluster this node is joining.
 
 `username` - The email address of the cluster administrator.
@@ -152,7 +152,7 @@ providing a different value and using the `override_rack_id` flag.
     and that the databases are pending recovery.
 
     {{< note >}}
-Make sure that you update your [DNS records]({{< relref "/rs/networking/cluster-dns/_index.md" >}})
+Make sure that you update your [DNS records]({{< relref "/rs/networking/cluster-dns" >}})
 with the IP addresses of the new nodes.
     {{< /note >}}
 

--- a/content/rs/clusters/logging/log-security.md
+++ b/content/rs/clusters/logging/log-security.md
@@ -14,7 +14,7 @@ aliases: [
   /rs/clusters/logging/log-security/,
 ]
 ---
-Redis Enterprise comes with [a set of logs]({{< relref "/rs/clusters/logging/_index.md" >}}) on the server and available through the user interface to assist users in investigating actions taken on the server and to troubleshoot issues.
+Redis Enterprise comes with [a set of logs]({{< relref "/rs/clusters/logging" >}}) on the server and available through the user interface to assist users in investigating actions taken on the server and to troubleshoot issues.
 
 ## Send logs to a remote logging server
 

--- a/content/rs/clusters/new-cluster-setup.md
+++ b/content/rs/clusters/new-cluster-setup.md
@@ -23,7 +23,7 @@ In a cluster that consists of only one node, some features and capabilities are 
 such as database replication that provides high availability.
 {{< /note >}}
 
-To set up a new cluster, you must first [install the Redis Enterprise Software package]({{< relref "/rs/installing-upgrading/_index.md" >}})
+To set up a new cluster, you must first [install the Redis Enterprise Software package]({{< relref "/rs/installing-upgrading" >}})
 and then set up the cluster as described below.
 After the cluster is created you can [add multiple nodes to the cluster]({{< relref "/rs/clusters/add-node.md" >}}).
 

--- a/content/rs/clusters/optimize/turn-off-services.md
+++ b/content/rs/clusters/optimize/turn-off-services.md
@@ -25,9 +25,9 @@ The services that you can turn off are:
 
 - RS Admin Console - `cm_server`
 - Logs in CSV format - `stats_archiver`
-- [LDAP authentication]({{< relref "/rs/security/ldap/_index.md" >}}) - `saslauthd`
+- [LDAP authentication]({{< relref "/rs/security/access-control/ldap" >}}) - `saslauthd`
 - [Discovery service]({{< relref "rs/networking/cluster-dns.md" >}})- `mdns_server`, `pdns_server`
-- [Active-Active databases]({{< relref "/rs/databases/active-active/_index.md" >}}) - `crdb_coordinator`, `crdb_worker`
+- [Active-Active databases]({{< relref "/rs/databases/active-active" >}}) - `crdb_coordinator`, `crdb_worker`
 - Alert Manager - `alert_mgr` (For best results, disable only if you have an alternate alert system.)
 
 To turn off a service with the `rladmin cluster config` command, use the `services` parameter and the name of the service, followed by `disabled`.

--- a/content/rs/clusters/remove-node.md
+++ b/content/rs/clusters/remove-node.md
@@ -71,7 +71,7 @@ You can migrate resources by using the `rladmin` command-line interface
 (CLI)]({{<relref "/rs/references/cli-utilities/rladmin">}}).
 
 {{< note >}}
-The [DNS records]({{< relref "/rs/networking/cluster-dns/_index.md" >}}) must be updated each time a node is added or replaced.
+The [DNS records]({{< relref "/rs/networking/cluster-dns" >}}) must be updated each time a node is added or replaced.
 {{< /note >}}
 
 ## Remove a node
@@ -110,5 +110,5 @@ POST https://<hostname>:9443/v1/nodes/<node_id>/actions/remove
 {{< note >}}
 If you need to add a removed node back to the cluster,
 you must [uninstall]({{< relref "/rs/installing-upgrading/uninstalling.md" >}})
-and [reinstall]({{< relref "/rs/installing-upgrading/_index.md" >}}) the software on that node.
+and [reinstall]({{< relref "/rs/installing-upgrading" >}}) the software on that node.
 {{< /note >}}

--- a/content/rs/databases/active-active/create.md
+++ b/content/rs/databases/active-active/create.md
@@ -15,7 +15,7 @@ aliases: [
 
 ]
 ---
-[Active-Active geo-replicated databases]({{< relref "/rs/databases/active-active/_index.md" >}}) (formerly known as CRDBs) give applications write access
+[Active-Active geo-replicated databases]({{< relref "/rs/databases/active-active" >}}) (formerly known as CRDBs) give applications write access
 to replicas of the dataset in different geographical locations.
 
 The participating Redis Enterprise Software clusters that host the instances can be in [distributed geographic locations]({{< relref "/rs/databases/active-active/" >}}).

--- a/content/rs/databases/active-active/develop/_index.md
+++ b/content/rs/databases/active-active/develop/_index.md
@@ -65,5 +65,5 @@ in between.
 |  t6 |  | SET key1 “d” |
 
 [Learn more about
-synchronization]({{< relref "/rs/databases/active-active/_index.md" >}}) for
+synchronization]({{< relref "/rs/databases/active-active" >}}) for
 each supported data type and [how to develop]({{< relref "/rs/databases/active-active/develop/develop-for-aa.md" >}}) with them on Redis Enterprise Software.

--- a/content/rs/databases/active-active/synchronization-mode.md
+++ b/content/rs/databases/active-active/synchronization-mode.md
@@ -12,7 +12,7 @@ aliases: [
     /rs/databases/active-active/synchronization-mode/,
 ]
 ---
-Replicated databases, such as [Replica Of]({{< relref "/rs/databases/import-export/replica-of/" >}}) and [Active-Active]({{< relref "/rs/databases/active-active/_index.md" >}}) databases,
+Replicated databases, such as [Replica Of]({{< relref "/rs/databases/import-export/replica-of/" >}}) and [Active-Active]({{< relref "/rs/databases/active-active" >}}) databases,
 use proxy endpoints to synchronize database changes with the databases on other participating clusters.
 
 To improve the throughput and lower the latency for synchronization traffic,

--- a/content/rs/databases/auto-tiering/quickstart.md
+++ b/content/rs/databases/auto-tiering/quickstart.md
@@ -21,7 +21,7 @@ aliases: /rs/getting-started/creating-database/redis-flash/
 ---
 This page guides you through a quick setup of [Auto Tiering]({{< relref "/rs/databases/auto-tiering/" >}}) with a single node for testing and demo purposes. 
 
-For production environments, you can find more detailed installation instructions in the [install and setup]({{< relref "/rs/installing-upgrading/_index.md" >}}) section.
+For production environments, you can find more detailed installation instructions in the [install and setup]({{< relref "/rs/installing-upgrading" >}}) section.
 
 The steps to set up a Redis Enterprise Software cluster using Auto Tiering
 with a single node are:

--- a/content/rs/databases/configure/_index.md
+++ b/content/rs/databases/configure/_index.md
@@ -76,7 +76,7 @@ If you create a database with Auto Tiering enabled, you also need to set the RAM
 for this database. Minimum RAM is 10%. Maximum RAM is 50%.
     {{< /note >}}
 
-- [**Modules**]({{< relref "/rs/developing/modules/_index.md" >}}) - When you create a new in-memory database, you can enable multiple Redis modules in the database. For Auto Tiering databases, you can add modules that support Auto Tiering.
+- [**Modules**]({{< relref "/stack" >}}) - When you create a new in-memory database, you can enable multiple Redis modules in the database. For Auto Tiering databases, you can add modules that support Auto Tiering.
         
     {{< note >}}
 To use modules, add them when you create a new database.

--- a/content/rs/databases/import-export/_index.md
+++ b/content/rs/databases/import-export/_index.md
@@ -30,4 +30,4 @@ Schedule backups of your databases to make sure you always have valid backups.
 
 ## [Migrate to Active-Active]({{< relref "/rs/databases/import-export/migrate-to-active-active.md" >}})
 
-Migrate a database to an [Active-Active]({{< relref "/rs/databases/active-active/_index.md" >}}) database using [Replica Of]({{<relref "/rs/databases/import-export/replica-of/">}}).
+Migrate a database to an [Active-Active]({{< relref "/rs/databases/active-active" >}}) database using [Replica Of]({{<relref "/rs/databases/import-export/replica-of/">}}).

--- a/content/rs/databases/import-export/migrate-to-active-active.md
+++ b/content/rs/databases/import-export/migrate-to-active-active.md
@@ -14,7 +14,7 @@ aliases: [
 ]
 ---
 
-If you have data in a single-region Redis Enterprise Software database that you want to migrate to an [Active-Active databases]({{< relref "/rs/databases/active-active/_index.md" >}}),
+If you have data in a single-region Redis Enterprise Software database that you want to migrate to an [Active-Active databases]({{< relref "/rs/databases/active-active" >}}),
 you'll need to create a new Active-Active database and migrate the data into the new database as a [Replica Of]({{<relref "/rs/databases/import-export/replica-of/">}}) the existing database.
 This process will gradually populate the data in the Active-Active database.
 

--- a/content/rs/databases/import-export/replica-of/_index.md
+++ b/content/rs/databases/import-export/replica-of/_index.md
@@ -26,7 +26,7 @@ synchronize the database, either within Redis Enterprise or external to Redis En
 
 You can [create Active-Passive]({{< relref "/rs/databases/import-export/replica-of/create.md" >}}) databases on Redis Enterprise Software or Redis Cloud.
 
-[Active-Active Geo-Distribution (CRDB)]({{< relref "/rs/databases/active-active/_index.md" >}})
+[Active-Active Geo-Distribution (CRDB)]({{< relref "/rs/databases/active-active" >}})
 provides these benefits and also provides write access to all of the database replicas.
 
 {{< warning >}}

--- a/content/rs/databases/memory-performance/eviction-policy.md
+++ b/content/rs/databases/memory-performance/eviction-policy.md
@@ -38,7 +38,7 @@ To prevent this from happening, make sure your database is large enough to hold 
 
 `volatile-lru` is the default eviction policy for most databases.
 
-The default policy for [Active-Active databases]({{< relref "/rs/databases/active-active/_index.md" >}}) is _noeviction_ policy.
+The default policy for [Active-Active databases]({{< relref "/rs/databases/active-active" >}}) is _noeviction_ policy.
 
 ## Active-Active database eviction
 

--- a/content/rs/installing-upgrading/configuring/change-location-socket-files.md
+++ b/content/rs/installing-upgrading/configuring/change-location-socket-files.md
@@ -22,7 +22,7 @@ The default location was changed in case you run any maintenance procedures that
 When you upgrade Redis Enterprise Software from an earlier version to 5.2.2 or later, the socket files
 are not moved to the new location by default. You need to either specify a custom location
 for the socket files during [installation]({{< relref
-"/rs/installing-upgrading/_index.md" >}}) or use the [following procedure](#change-socket-file-locations) after installation.
+"/rs/installing-upgrading" >}}) or use the [following procedure](#change-socket-file-locations) after installation.
 
 ## Change socket file locations
 

--- a/content/rs/installing-upgrading/install/_index.md
+++ b/content/rs/installing-upgrading/install/_index.md
@@ -53,5 +53,5 @@ To learn more about customization and find answers to related questions, see:
 After your cluster is set up with nodes, you can:
 
 - [Add users]({{<relref "/rs/security/access-control/manage-users/add-users">}}) to the cluster with specific permissions.  To begin, start with [Access control]({{<relref "/rs/security/access-control">}}).
-- [Create databases]({{< relref "/rs/administering/creating-databases/_index.md" >}}) to use with your applications.
+- [Create databases]({{< relref "/rs/databases/create" >}}) to use with your applications.
 

--- a/content/rs/installing-upgrading/install/install-on-linux.md
+++ b/content/rs/installing-upgrading/install/install-on-linux.md
@@ -130,7 +130,7 @@ As a workaround to install Redis Enterprise Software without using any root dire
 1. [Create]({{< relref "/rs/clusters/new-cluster-setup.md" >}})
     or [join]({{< relref "/rs/clusters/add-node.md" >}}) an existing Redis Enterprise Software cluster.
 
-1. [Create a database]({{< relref "/rs/administering/creating-databases/_index.md" >}}).
+1. [Create a database]({{< relref "/rs/databases/create" >}}).
 
     For geo-distributed Active-Active replication, create an [Active-Active]({{< relref "/rs/databases/active-active/create.md" >}}) database.
 

--- a/content/rs/installing-upgrading/install/plan-deployment/_index.md
+++ b/content/rs/installing-upgrading/install/plan-deployment/_index.md
@@ -20,7 +20,7 @@ Before installing Redis Enterprise Software, you need to:
     - Multiple Linux distributions (Ubuntu, Red Hat Enterprise Linux (RHEL), IBM CentOS, Oracle Linux)
     - [Amazon AWS AMI]({{< relref "configuring-aws-instances.md" >}})
     - [Docker container]({{< relref "/rs/installing-upgrading/quickstarts/docker-quickstart" >}}) (for development and testing only)
-    - [Kubernetes]({{< relref "/kubernetes/_index.md" >}})
+    - [Kubernetes]({{< relref "/kubernetes" >}})
 
     For more details, see [Supported platforms]({{< relref "/rs/installing-upgrading/install/plan-deployment/supported-platforms.md" >}}).
 

--- a/content/rs/installing-upgrading/install/plan-deployment/configuring-aws-instances.md
+++ b/content/rs/installing-upgrading/install/plan-deployment/configuring-aws-instances.md
@@ -30,7 +30,7 @@ connected. When you set up Redis Enterprise Software on the instance, make sure 
 persistence storage]({{< relref "/rs/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage" >}}) is configured to use this volume.
 
 {{< note >}}
-After [installing the Redis Enterprise Software package]({{< relref "/rs/installing-upgrading/_index.md" >}}) on the instance
+After [installing the Redis Enterprise Software package]({{< relref "/rs/installing-upgrading" >}}) on the instance
 and **before** running through [the setup process]({{< relref "/rs/clusters/new-cluster-setup.md" >}}),
 you must give the group `redislabs` permission to the EBS volume by
 running the following command from the OS command-line interface (CLI):
@@ -69,7 +69,7 @@ When configuring the security group:
     access the admin console.
 - If you are using the DNS resolving option with Redis Enterprise Software, define a DNS UDP
     rule for port 53 to allow access to the databases' endpoints by
-    using the [DNS resolving mechanism]({{< relref "/rs/networking/cluster-dns/_index.md" >}}).
+    using the [DNS resolving mechanism]({{< relref "/rs/networking/cluster-dns" >}}).
 - To create a cluster that has multiple nodes all running as instances on AWS,
     you need to define a security group that has an All TCP rule for all ports, 0 - 65535,
     and add it to all instances that are part of the cluster.
@@ -78,5 +78,5 @@ When configuring the security group:
 
 After successfully launching the instances:
 
-1. Install Redis Enterprise Software from the [Linux package or AWS AMI]({{< relref "/rs/installing-upgrading/_index.md" >}}).
+1. Install Redis Enterprise Software from the [Linux package or AWS AMI]({{< relref "/rs/installing-upgrading" >}}).
 2. [Set up the cluster]({{< relref "/rs/clusters/new-cluster-setup.md" >}}).

--- a/content/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -25,7 +25,7 @@ Before upgrading a cluster:
 
 - Verify access to [rlcheck]({{< relref "/rs/references/cli-utilities/rlcheck/" >}}) and [rladmin]({{< relref "/rs/references/cli-utilities/rladmin/#use-the-rladmin-shell" >}}) commands
 
-- Verify that you meet the upgrade path requirements for your desired cluster version and review the relevant [release notes]({{< relref "/rs/release-notes/_index.md" >}}) for any preparation instructions.
+- Verify that you meet the upgrade path requirements for your desired cluster version and review the relevant [release notes]({{< relref "/rs/release-notes" >}}) for any preparation instructions.
 
 - Upgrade the cluster's primary (master) node first. To identify the primary node, use one of the following methods:
 

--- a/content/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -36,7 +36,7 @@ The upgrade policy is only relevant for Redis Enterprise Software versions 6.2.4
 
 Before upgrading a database:
 
-- Review the relevant [release notes]({{< relref "/rs/release-notes/_index.md" >}}) for any preparation instructions.
+- Review the relevant [release notes]({{< relref "/rs/release-notes" >}}) for any preparation instructions.
 
 - Verify that the database version meets the minimums specified earlier.
 

--- a/content/rs/networking/cluster-dns.md
+++ b/content/rs/networking/cluster-dns.md
@@ -32,7 +32,7 @@ Whether you're administering Redis Enterprise Software or accessing databases, t
 
 ## URL-based connections
 
-The fully qualified domain name (FQDN) is the unique cluster identifier that enables clients to connect to [the different components]({{< relref "/rs/concepts/_index.md" >}}) of Redis Enterprise Software.
+The fully qualified domain name (FQDN) is the unique cluster identifier that enables clients to connect to the different components of Redis Enterprise Software.
 The FQDN is a crucial component of the high-availability mechanism because it's used internally to enable and implement automatic and transparent failover of nodes, databases, shards, and endpoints.
 
 {{< note >}}

--- a/content/rs/networking/cluster-lba-setup.md
+++ b/content/rs/networking/cluster-lba-setup.md
@@ -40,7 +40,7 @@ The architecture is shown in the following diagram with 3 nodes Redis Enterprise
 
 ### Prerequisites
 
-- [Install]({{< relref "/rs/installing-upgrading/_index.md" >}}) the latest version of RS on your clusters
+- [Install]({{< relref "/rs/installing-upgrading" >}}) the latest version of RS on your clusters
 - Configure the cluster with the cluster name (FQDN) even though DNS is not in use.
     Remember that the same cluster name is used to issue the licence keys.
     We recommend that you use a “.local” suffix in the FQDN.

--- a/content/rs/networking/mdns.md
+++ b/content/rs/networking/mdns.md
@@ -15,7 +15,7 @@ aliases: [
 mDNS is only supported for development and testing environments.
 {{< /note >}}
 
-If you choose to use the mDNS protocol when [you set the cluster name]({{< relref "/rs/networking/cluster-dns/_index.md" >}}),
+If you choose to use the mDNS protocol when [you set the cluster name]({{< relref "/rs/networking/cluster-dns" >}}),
 make sure that the configurations and prerequisites for resolving database endpoints are met on the client machines.
 If you have [Replica Of]({{< relref "/rs/databases/import-export/replica-of/" >}}) databases on the cluster,
 the configurations and prerequisites are also required for the Redis Enterprise Software nodes.

--- a/content/rs/new-features-redis-enterprise.md
+++ b/content/rs/new-features-redis-enterprise.md
@@ -23,7 +23,7 @@ provide smart and automatic conflict resolution based on the data type's
 intent.
 
 For more information, go here. For information, go to [Developing with
-Active-Active databases]({{< relref "/rs/developing/crdbs/_index.md" >}}).
+Active-Active databases]({{< relref "/rs/developing/crdbs" >}}).
 
 ## Redis modules
 
@@ -37,17 +37,17 @@ Enterprise is known for.
 
 Redis developed and certified these modules for use with Redis Enterprise Software:
 
-- [RedisBloom]({{< relref "/modules/redisbloom/_index.md" >}})
+- [RedisBloom]({{< relref "/modules/redisbloom" >}})
     - Enables Redis to have a scalable bloom filter as a data type. Bloom
       filters are probabilistic data structures that quickly determine if something is contained within a set.
 - [RedisGraph](https://oss.redislabs.com/redisgraph/#quickstart)
     - RedisGraph is the first queryable Property Graph database to use sparse
       matrices to represent the adjacency matrix in graphs and linear algebra to query the graph.
       RedisGraph uses [Cypher](https://www.opencypher.org/) as its query language.
-- [RedisJSON]({{< relref "/modules/redisjson/_index.md" >}})
+- [RedisJSON]({{< relref "/modules/redisjson" >}})
     - Now you have the convenience JSON as a built-in data type and easily
       able to address nested data via a path.
-- [RediSearch]({{< relref "/modules/redisearch/_index.md" >}})
+- [RediSearch]({{< relref "/modules/redisearch" >}})
     - This module turns Redis into a distributed in-memory
       full-text indexing and search beast.
 

--- a/content/rs/references/cli-utilities/crdb-cli/_index.md
+++ b/content/rs/references/cli-utilities/crdb-cli/_index.md
@@ -17,7 +17,7 @@ Each cluster that hosts an instance is called a **participating cluster**.
 
 An Active-Active database requires two or more participating clusters.
 Each instance is responsible for updating the instances that reside on other participating clusters with the transactions it receives.
-Write conflicts are resolved using [conflict-free replicated data types]({{< relref "/rs/databases/active-active/_index.md" >}}) (CRDTs).
+Write conflicts are resolved using [conflict-free replicated data types]({{< relref "/rs/databases/active-active" >}}) (CRDTs).
 
 To programmatically maintain an Active-Active database and its instances, you can use the `crdb-cli` command-line tool.
 

--- a/content/rs/references/memtier-benchmark.md
+++ b/content/rs/references/memtier-benchmark.md
@@ -55,7 +55,7 @@ You can run all of these tests on Amazon AWS with these hosts:
 To learn how to install Redis Enterprise Software and set up a cluster, see:
 
 - [Redis Enterprise Software quickstart]({{< relref "rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart" >}}) for a test installation
-- [Install and upgrade]({{< relref "/rs/installing-upgrading/_index.md" >}}) for a production installation
+- [Install and upgrade]({{< relref "/rs/installing-upgrading" >}}) for a production installation
 
 These tests use a quorum node to reduce AWS EC2 instance use while maintaining the three nodes required to support a quorum node in case of node failure.  Quorum nodes can be on less powerful instances because they do not have shards or support traffic.
 

--- a/content/rs/references/rest-api/_index.md
+++ b/content/rs/references/rest-api/_index.md
@@ -17,9 +17,9 @@ Here, you'll find the details of the API and how to use it.
 
 For more info, see:
 
-- Supported [request endpoints]({{<relref "/rs/references/rest-api/requests/_index.md" >}}), organized by path
-- Supported [objects]({{<relref "/rs/references/rest-api/objects/_index.md" >}}), both request and response
-- Built-in roles and associated [permissions]({{<relref "/rs/references/rest-api/permissions/_index.md" >}})
+- Supported [request endpoints]({{<relref "/rs/references/rest-api/requests" >}}), organized by path
+- Supported [objects]({{<relref "/rs/references/rest-api/objects" >}}), both request and response
+- Built-in roles and associated [permissions]({{<relref "/rs/references/rest-api/permissions" >}})
 - [Redis Enterprise Software REST API quick start]({{<relref "/rs/references/rest-api/quick-start" >}}) with examples
 
 ## Authentication
@@ -39,7 +39,7 @@ For more examples, see the [Redis Enterprise Software REST API quick start]({{<r
 
 ### Permissions
 
-By default, the admin user is authorized for access to all endpoints. Use [role-based access controls]({{< relref "/rs/security/access-control" >}}) and [role permissions]({{<relref "/rs/references/rest-api/permissions/_index.md" >}}) to manage access.
+By default, the admin user is authorized for access to all endpoints. Use [role-based access controls]({{< relref "/rs/security/access-control" >}}) and [role permissions]({{<relref "/rs/references/rest-api/permissions" >}}) to manage access.
 
 If a user attempts to access an endpoint that is not allowed in their role, the request will fail with a [`403 Forbidden`](https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden) status code. For more details on which user roles can access certain endpoints, see [Permissions]({{<relref "/rs/references/rest-api/permissions">}}).
 

--- a/content/rs/release-notes/legacy-release-notes/redis-enterprise-5.md
+++ b/content/rs/release-notes/legacy-release-notes/redis-enterprise-5.md
@@ -47,7 +47,7 @@ provide smart and automatic conflict resolution based on the data type's
 intent.
 
 For more information, go here. For information, go to [Developing with
-CRDBs]({{< relref "/rs/developing/crdbs/_index.md" >}}).
+CRDBs](https://docs.redis.com/latest/rs/databases/active-active/develop/develop-for-aa/).
 
 ### Redis modules
 

--- a/content/rs/release-notes/legacy-release-notes/rlec-4-0-june-2015.md
+++ b/content/rs/release-notes/legacy-release-notes/rlec-4-0-june-2015.md
@@ -93,7 +93,7 @@ update this file.
 
 - **Issue**: In case you deploy a cluster and use the DNS option for
     the cluster name (see details in [How to set the Cluster Name
-    (FQDN)]({{< relref "/rs/networking/cluster-dns/_index.md" >}}),
+    (FQDN)]({{< relref "/rs/networking/cluster-dns" >}}),
     do not configure the DNS entries for the cluster nodes, and try to
     configure a database that is a replica of another database within
     the cluster, then the UI allows you to configure the source database
@@ -106,7 +106,7 @@ update this file.
     the cluster does not operate correctly. You have to either update
     the DNS accordingly, or recreate the cluster and use the mDNS option
     for the cluster name as described in [How to set the Cluster Name
-    (FQDN)]({{< relref "/rs/networking/cluster-dns/_index.md" >}}).
+    (FQDN)]({{< relref "/rs/networking/cluster-dns" >}}).
     
 - **Issue**: When taking a node offline or removing a node, if the
     node being taken offline or removed is currently serving as the web

--- a/content/rs/release-notes/legacy-release-notes/rlec-4-2-october-2015.md
+++ b/content/rs/release-notes/legacy-release-notes/rlec-4-2-october-2015.md
@@ -67,7 +67,7 @@ before running through the upgrade process.
     parameter for default answers ("Y") or "-c" for file path parameters
     for custom answers. For additional details, refer to [Accessing and
     installing the setup
-    package]({{< relref "/rs/installing-upgrading/_index.md" >}})
+    package]({{< relref "/rs/installing-upgrading" >}})
     section.
 - New rladmin command-line-interface "info" command allows for
     fetching current value of tunable parameters.

--- a/content/rs/release-notes/legacy-release-notes/rs-5-2-june-2018.md
+++ b/content/rs/release-notes/legacy-release-notes/rs-5-2-june-2018.md
@@ -28,7 +28,7 @@ than 4.5, you should first upgrade to version 5.0 (or at least
 RS 5.2 adds active-active Redis (CRDB) support for Sorted Sets and
 Lists. Now all major Redis data types are supported with CRDT, so you
 can use Redis Enterprise in an active-active manner for all your Redis
-use cases, with seamless conflict resolution. [Click here]({{< relref "/rs/developing/crdbs/_index.md" >}})
+use cases, with seamless conflict resolution. [Click here](https://docs.redis.com/latest/rs/databases/active-active/develop/develop-for-aa/)
 for more information about how to develop applications with
 geo-replicated CRDBs.
 

--- a/content/stack/search/search-active-active.md
+++ b/content/stack/search/search-active-active.md
@@ -7,7 +7,7 @@ alwaysopen: false
 categories: ["Modules"]
 aliases: /modules/redisearch/redisearch-active-active/
 ---
-Starting with RediSearch 2.x, supported in Redis Enterprise Software (RS) 6.0 and later, you can [enable search and query]({{<relref "/stack/install/add-module-to-database">}}) for [Active-Active databases]({{< relref "/rs/databases/active-active/_index.md" >}}) at the time of creation.
+Starting with RediSearch 2.x, supported in Redis Enterprise Software (RS) 6.0 and later, you can [enable search and query]({{<relref "/stack/install/add-module-to-database">}}) for [Active-Active databases]({{< relref "/rs/databases/active-active" >}}) at the time of creation.
 
 You can run search operations on any instance of an Active-Active database.
 


### PR DESCRIPTION
I found a bug where relrefs that end with "_index.md" are not properly caught and reported by Hugo's build process when the index page's file path changes. Instead, they create an endless loop of linking to the top of the current page.

This PR fixes the currently broken relrefs and will hopefully help us catch any potential broken links if these index pages are moved in the future.