### PR TITLE
RS: Bundle 2 Redis Stack feature sets

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/status.md
+++ b/content/rs/references/cli-utilities/rladmin/status.md
@@ -210,18 +210,22 @@ Returns the status of modules installed on the cluster and modules used by datab
 $ rladmin status modules extra all                
 CLUSTER MODULES:
 MODULE           VERSION   MIN_REDIS_VERSION  ID                                
-RedisBloom       2.6.3     7.1                34db7c796489202a0ae5dda292211c87  
-RediSearch 2     2.8.8     7.1                4812fb26eda4a7372ffbc18c04b268d5  
+RedisBloom       2.4.5     6.0                1b895a180592cbcae5bd3bff6af24be2  
+RedisBloom       2.6.8     7.1                95264e7c9ac9540268c115c86a94659b  
+RediSearch 2     2.6.12    6.0                2c000539f65272f7a2712ed3662c2b6b  
+RediSearch 2     2.8.9     7.1                dd9a75710db528afa691767e9310ac6f  
 RedisGears       2.0.15    7.1                18c83d024b8ee22e7caf030862026ca6  
 RedisGraph       2.10.12   6.0                5a1f2fdedb8f6ca18f81371ea8d28f68  
-RedisJSON        2.6.6     7.1                11e55072ef5216f721fcff3575e35d1a  
-RedisTimeSeries  1.10.6    7.1                95d5258cb1ad6cf2c25fa4852954eeb1  
+RedisJSON        2.4.7     6.0                28308b101a0203c21fa460e7eeb9344a  
+RedisJSON        2.6.8     7.1                b631b6a863edde1b53b2f7a27a49c004  
+RedisTimeSeries  1.8.11    6.0                8fe09b00f56afe5dba160d234a6606af  
+RedisTimeSeries  1.10.9    7.1                98a492a017ea6669a162fd3503bf31f3  
 
 DATABASE MODULES:
 DB:ID      NAME             MODULE            VERSION  ARGS              STATUS 
-db:1       search-json-db   RediSearch 2      2.8.8    PARTITIONS AUTO   OK     
-db:1       search-json-db   RedisJSON         2.6.6                      OK     
-db:2       timeseries-db    RedisTimeSeries   1.10.6                     OK     
+db:1       search-json-db   RediSearch 2      2.8.9    PARTITIONS AUTO   OK     
+db:1       search-json-db   RedisJSON         2.6.8                      OK     
+db:2       timeseries-db    RedisTimeSeries   1.10.9                     OK      
 ```
 
 ## `status nodes`

--- a/content/rs/references/rest-api/objects/bdb/_index.md
+++ b/content/rs/references/rest-api/objects/bdb/_index.md
@@ -125,7 +125,7 @@ An API object that represents a managed database in the cluster.
   "module_name": string,
   "semantic_version": string
 }, ...]
-{{</code>}} | List of modules associated with database<br />**module_id**: Module UID <br />**module_args**: Module command line arguments (pattern does not allow special characters &,\<,>,")<br />**module_name**: Module's name<br />**semantic_version**: Module's semantic version |
+{{</code>}} | List of modules associated with the database<br /><br />**module_id**: Module UID <br />**module_args**: Module command-line arguments (pattern does not allow special characters &,\<,>,")<br />**module_name**: Module's name<br />**semantic_version**: Module's semantic version<br /><br />As of Redis Enterprise Software v7.4.2, **module_id** and **semantic_version** are optional. |
 | mtls_allow_outdated_certs | boolean | An optional mTLS relaxation flag for certs verification |
 | mtls_allow_weak_hashing | boolean | An optional mTLS relaxation flag for certs verification |
 | name | string | Database name |

--- a/content/rs/references/rest-api/requests/bdbs/upgrade.md
+++ b/content/rs/references/rest-api/requests/bdbs/upgrade.md
@@ -64,6 +64,8 @@ Upgrade a database.
 | preserve_roles | boolean | Preserve shards' master/replica roles (requires an extra failover) (default: false) |
 | parallel_shards_upgrade | integer | Max number of shards to upgrade in parallel (default: all) |
 | modules | list of modules | List of dicts representing the modules that will be upgraded.<br></br>Each dict includes:<br></br>• `current_module`: uid of a module to upgrade<br></br>• `new_module`: uid of the module we want to upgrade to<br></br>• `new_module_args`: args list for the new module (no defaults for the three module-related parameters).
+| redis_version | version number | Upgrades the database to the specified Redis version instead of the latest version |
+| latest_with_modules | boolean | Upgrades the database to the latest Redis version and latest supported versions of modules available in the cluster |
 
 ### Response {#post-response} 
 

--- a/content/stack/install/_index.md
+++ b/content/stack/install/_index.md
@@ -8,7 +8,7 @@ categories: ["Modules"]
 aliases: /modules/install/
 ---
 
-Several modules, which provide Redis Stack features, come packaged with [Redis Enterprise]({{<relref "/rs">}}). However, if you want to use additional modules or upgrade a module to a more recent version, you need to:
+Several modules, which provide Redis Stack features, come packaged with [Redis Enterprise]({{<relref "/rs">}}). As of version 7.4.2, Redis Enterprise includes two Redis Stack feature sets, compatible with different Redis database versions. However, if you want to use additional modules or upgrade a module to a more recent version, you need to:
 
 1. [Install a module package]({{<relref "/stack/install/add-module-to-cluster">}}) on the cluster.
 1. [Enable a module]({{<relref "/stack/install/add-module-to-database">}}) for a new database or [upgrade a module]({{<relref "/stack/install/upgrade-module">}}) in an existing database.

--- a/content/stack/install/_index.md
+++ b/content/stack/install/_index.md
@@ -8,7 +8,7 @@ categories: ["Modules"]
 aliases: /modules/install/
 ---
 
-Several modules, which provide Redis Stack features, come packaged with [Redis Enterprise]({{<relref "/rs">}}). As of version 7.4.2, Redis Enterprise includes two Redis Stack feature sets, compatible with different Redis database versions. However, if you want to use additional modules or upgrade a module to a more recent version, you need to:
+Several modules, which provide Redis Stack features, come packaged with [Redis Enterprise]({{<relref "/rs">}}). As of version 7.4.2, Redis Enterprise includes two feature sets, compatible with different Redis database versions. However, if you want to use additional modules or upgrade a module to a more recent version, you need to:
 
 1. [Install a module package]({{<relref "/stack/install/add-module-to-cluster">}}) on the cluster.
 1. [Enable a module]({{<relref "/stack/install/add-module-to-database">}}) for a new database or [upgrade a module]({{<relref "/stack/install/upgrade-module">}}) in an existing database.

--- a/content/stack/install/add-module-to-cluster.md
+++ b/content/stack/install/add-module-to-cluster.md
@@ -10,7 +10,7 @@ aliases:
     - /modules/install/add-module-to-cluster/
 ---
 
-[Redis Enterprise]({{<relref "/rs">}}) comes packaged with several modules. As of version 7.4.2, Redis Enterprise includes two Redis Stack feature sets, compatible with different Redis database versions. You can view the installed modules, their versions, and their minimum compatible Redis database versions from **Cluster > Modules** in the Redis Enterprise Cluster Manager UI.
+[Redis Enterprise]({{<relref "/rs">}}) comes packaged with several modules. As of version 7.4.2, Redis Enterprise includes two feature sets, compatible with different Redis database versions. You can view the installed modules, their versions, and their minimum compatible Redis database versions from **Cluster > Modules** in the Redis Enterprise Cluster Manager UI.
 
 To use other modules or upgrade an existing module to a more recent version, you need to install the new module package on your cluster.
 

--- a/content/stack/install/add-module-to-cluster.md
+++ b/content/stack/install/add-module-to-cluster.md
@@ -10,7 +10,7 @@ aliases:
     - /modules/install/add-module-to-cluster/
 ---
 
-[Redis Enterprise]({{<relref "/rs">}}) comes packaged with several modules. You can view the installed modules and their versions from **Cluster > Modules** in the Redis Enterprise admin console.
+[Redis Enterprise]({{<relref "/rs">}}) comes packaged with several modules. As of version 7.4.2, Redis Enterprise includes two Redis Stack feature sets, compatible with different Redis database versions. You can view the installed modules, their versions, and their minimum compatible Redis database versions from **Cluster > Modules** in the Redis Enterprise Cluster Manager UI.
 
 To use other modules or upgrade an existing module to a more recent version, you need to install the new module package on your cluster.
 
@@ -36,7 +36,7 @@ Use one of the following methods to add a module to a Redis Enterprise cluster:
 
 - REST API [`POST` request to the `/v2/modules`]({{<relref "/rs/references/rest-api/requests/modules#post-module-v2">}}) endpoint
 
-- Redis Enterprise admin console
+- Redis Enterprise Cluster Manager UI
 
 - For RedisGears, follow these [installation instructions]({{<relref "/stack/gears-v1/installing-redisgears">}})
 
@@ -57,9 +57,9 @@ To add a module to the cluster using the REST API:
 
 1. If the module installation succeeds, the `POST` request returns a [JSON object]({{<relref "/rs/references/rest-api/objects/module">}}) that represents the new module. If it fails, it may return a JSON object with an `error_code` and `description` with more details.
 
-### Admin console method
+### Cluster Manager UI method
 
-To add a module to the cluster using the admin console:
+To add a module to the cluster using the Cluster Manager UI:
 
 1. Go to **Cluster > Modules**.
 

--- a/content/stack/install/add-module-to-database.md
+++ b/content/stack/install/add-module-to-database.md
@@ -29,7 +29,7 @@ Modules add additional functionality to Redis databases for specific use cases. 
 You can only add modules to a database when you first create it. You cannot add modules to an existing database.
 {{</note>}}
 
-In the Redis Enterprise admin console, follow these steps to add modules to a database:
+In the Redis Enterprise Cluster Manager UI, follow these steps to add modules to a database:
 
 1. From the **Databases** screen, select **Quick database** or **Create database**.
 


### PR DESCRIPTION
DOC-3274

Staged previews:
- [Install and upgrade modules index page](https://docs.redis.com/staging/DOC-3274/stack/install/)
- [Install a module on a cluster](https://docs.redis.com/staging/DOC-3274/stack/install/add-module-to-cluster/)
- [rladmin status modules reference](https://docs.redis.com/staging/DOC-3274/rs/references/cli-utilities/rladmin/status/#status-modules) - example output now shows 2 sets of modules
- [Upgrade database REST API request parameters](https://docs.redis.com/staging/DOC-3274/rs/references/rest-api/requests/bdbs/upgrade/#request-body) - added `latest_with_modules` and `redis_version` request parameters
- [BDB REST API object reference](https://docs.redis.com/staging/DOC-3274/rs/references/rest-api/objects/bdb/) - marked `module_list`'s `module_id` and `semantic_version` as optional 