### PR TITLE
RS: Add CVE-2023-41056 to 7.2.4 maintenance release notes

### DIFF
--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
@@ -147,9 +147,13 @@ Redis Enterprise 7.2.4-64 supports open source Redis 7.2, 6.2, and 6.0. Below is
 
 Redis 7.2.x:
 
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
+
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.2.1)
 
 Redis 7.0.x:
+
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
 
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.0.13)
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
@@ -135,9 +135,13 @@ Redis Enterprise 7.2.4-64 supports open source Redis 7.2, 6.2, and 6.0. Below is
 
 Redis 7.2.x:
 
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
+
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.2.1)
 
 Redis 7.0.x:
+
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
 
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.0.13)
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
@@ -172,9 +172,13 @@ Redis Enterprise 7.2.4-92 and 7.2.4-86 support open source Redis 7.2, 6.2, and 6
 
 Redis 7.2.x:
 
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
+
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.2.1)
 
 Redis 7.0.x:
+
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
 
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.0.13)
 


### PR DESCRIPTION
DOC-3283

Staged previews:
- [7.2.4-92 (November 2023)](https://docs.redis.com/staging/DOC-3283/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92/#security)
- [7.2.4-72 (October 2023) ](https://docs.redis.com/staging/DOC-3283/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72/#security)
- [7.2.4-64 (September 2023) ](https://docs.redis.com/staging/DOC-3283/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64/#security)