### PR TITLE
Update resp.md

### DIFF
--- a/content/rs/references/compatibility/resp.md
+++ b/content/rs/references/compatibility/resp.md
@@ -17,6 +17,11 @@ RESP (Redis Serialization Protocol) is the protocol that clients use to communic
 
 - RESP3 is supported by Redis Enterprise 7.2 and later.
 
+{{<note>}}
+Redis Enterprise versions which support RESP3 continue to support RESP2
+{{</note>}}
+
+
 ## Enable RESP3 for a database {#enable-resp3}
 
 To use RESP3 with a Redis Enterprise Software database:

--- a/content/rs/references/compatibility/resp.md
+++ b/content/rs/references/compatibility/resp.md
@@ -18,7 +18,7 @@ RESP (Redis Serialization Protocol) is the protocol that clients use to communic
 - RESP3 is supported by Redis Enterprise 7.2 and later.
 
 {{<note>}}
-Redis Enterprise versions which support RESP3 continue to support RESP2
+Redis Enterprise versions that support RESP3 continue to support RESP2.
 {{</note>}}
 
 


### PR DESCRIPTION
Added a note that RESP2 can still be used in versions which also support RESP3. Several customers asked about it, so let's clarify this.