### PR TITLE
DOC-3313: correcting link to Bloom filter quick start

### DIFF
--- a/content/stack/bloom/_index.md
+++ b/content/stack/bloom/_index.md
@@ -111,7 +111,7 @@ reach a larger capacity.
 
 ## More info
 
-- [Probabilistic data structures quick start](https://redis.io/docs/stack/bloom/quick_start/)
+- [Probabilistic data structures quick start](https://redis.io/docs/data-types/probabilistic/bloom-filter/)
 - [Probabilistic data structure commands]({{<relref "/stack/bloom/commands">}})
 - [Probabilistic data structure configuration]({{<relref "/stack/bloom/config">}})
 - [RedisBloom source](https://github.com/RedisBloom/RedisBloom/)


### PR DESCRIPTION
Preview build is here: https://docs.redis.com/staging/DOC-3313/stack/bloom/ .