### PR TITLE
RS: Bug fix to remove default_redis_version from upgrade DB doc

### DIFF
--- a/content/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -10,7 +10,7 @@ aliases:
 
 ## Default Redis database versions {#default-db-versions}
 
-When you upgrade an existing database or create a new one, it uses the default Redis version (`default_redis_version`) unless you specify the database version explicitly with `redis_version` in the [REST API]({{<relref "/rs/references/rest-api/requests/bdbs">}}) or [`rladmin upgrade db`]({{<relref "/rs/references/cli-utilities/rladmin/upgrade#upgrade-db">}}).
+When you upgrade an existing database, it uses the latest bundled Redis version unless you specify a different version with the `redis_version` option in the [REST API]({{<relref "/rs/references/rest-api/requests/bdbs">}}) or [`rladmin upgrade db`]({{<relref "/rs/references/cli-utilities/rladmin/upgrade#upgrade-db">}}).
 
 Redis Enterprise Software v6.x includes two Redis database versions: 6.0 and 6.2.
 As of version 7.2, Redis Enterprise Software includes three Redis database versions.


### PR DESCRIPTION
DOC-3315

[Staged preview](https://docs.redis.com/staging/DOC-3315/rs/installing-upgrading/upgrading/upgrade-database/)