### PR TITLE
RS: Fix broken relrefs and links in reference docs

### DIFF
--- a/content/rs/references/compatibility/commands/server.md
+++ b/content/rs/references/compatibility/commands/server.md
@@ -65,9 +65,9 @@ Several access control list (ACL) commands are not available in Redis Enterprise
 
 ## Module commands
 
-For Redis Enterprise Software, you can [manage Redis modules]({{<relref "/stack/install/">}}) from the admin console or with [REST API requests](/rs/references/rest-api/requests/modules/).
+For Redis Enterprise Software, you can [manage Redis modules]({{<relref "/stack/install/">}}) from the admin console or with [REST API requests]({{<relref "/rs/references/rest-api/requests/modules">}}).
 
-Redis Cloud manages modules for you and lets you [enable modules](/rc/databases/create-database#modules) when you create a database.
+Redis Cloud manages modules for you and lets you [enable modules]({{<relref "/rc/databases/create-database#modules">}}) when you create a database.
 
 | <span style="min-width: 9em; display: table-cell">Command</span> | Redis<br />Enterprise | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
 |:--------|:----------------------|:-----------------|:------|
@@ -80,7 +80,7 @@ Redis Cloud manages modules for you and lets you [enable modules](/rc/databases/
 
 ## Monitoring commands
 
-Although Redis Enterprise does not support certain monitoring commands, you can use the admin consoles to view Redis Enterprise Software [metrics](/rs/clusters/monitoring/) and [logs](/rs/clusters/logging/) or Redis Cloud [metrics](/rc/databases/monitor-performance/) and [logs](/rc/databases/system-logs/).
+Although Redis Enterprise does not support certain monitoring commands, you can use the admin consoles to view Redis Enterprise Software [metrics]({{<relref "/rs/clusters/monitoring">}}) and [logs]({{<relref "/rs/clusters/logging">}}) or Redis Cloud [metrics]({{<relref "/rc/databases/monitor-performance">}}) and [logs]({{<relref "/rc/logs-reports/system-logs">}}).
 
 | <span style="min-width: 9em; display: table-cell">Command</span> | Redis<br />Enterprise | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
 |:--------|:----------------------|:-----------------|:------|

--- a/content/rs/references/rest-api/requests/bdbs/replica_sources-alerts.md
+++ b/content/rs/references/rest-api/requests/bdbs/replica_sources-alerts.md
@@ -50,7 +50,7 @@ Get all alert states for all replica sources of all BDBs.
 
 Returns a hash of alert UIDs and the alerts states for each BDB.
 
-See [REST API alerts overview] for a description of the alert state object.
+See [REST API alerts overview]({{<relref "/rs/references/rest-api/objects/alert">}}) for a description of the alert state object.
 
 #### Example JSON body
 

--- a/content/rs/references/rest-api/requests/modules/_index.md
+++ b/content/rs/references/rest-api/requests/modules/_index.md
@@ -121,7 +121,7 @@ POST /v1/modules
 Uploads a new module to the cluster.
 
 The request must contain a Redis module, bundled using [RedisModule
-Packer](https://github.com/RedisLabs/RAMP). For modules in Redis Stack, download the module from the [download center](https://redis.com/redis-enterprise-software/download-center/modules/).
+Packer](https://github.com/RedisLabs/RAMP). For modules in Redis Stack, download the module from the [download center](https://redis.com/redis-enterprise-software/download-center/software/).
 
 See [Install a module on a cluster]({{<relref "/stack/install/add-module-to-cluster#rest-api-method">}}) for more information.
 
@@ -215,7 +215,7 @@ Asynchronously uploads a new module to the cluster.
 
 The request must contain a Redis module bundled using [RedisModule Packer](https://github.com/RedisLabs/RAMP).
 
-For modules in Redis Stack, download the module from the [Download Center](https://redis.com/redis-enterprise-software/download-center/modules/). See [Install a module on a cluster]({{<relref "/stack/install/add-module-to-cluster#rest-api-method">}}) for more information.
+For modules in Redis Stack, download the module from the [download center](https://redis.com/redis-enterprise-software/download-center/software/). See [Install a module on a cluster]({{<relref "/stack/install/add-module-to-cluster#rest-api-method">}}) for more information.
 
 #### Permissions
 


### PR DESCRIPTION
DOC-3345

Staged preview:
- [Module commands](https://docs.redis.com/staging/DOC-3345/rs/references/compatibility/commands/server/#module-commands)
- [Monitoring commands](https://docs.redis.com/staging/DOC-3345/rs/references/compatibility/commands/server/#monitoring-commands)
- [GET /v1/bdbs/replica_sources/alerts response](https://docs.redis.com/staging/DOC-3345/rs/references/rest-api/requests/bdbs/replica_sources-alerts/#get-all-response)
- [POST /v1/modules](https://docs.redis.com/staging/DOC-3345/rs/references/rest-api/requests/modules/#post-module)
- [POST /v2/modules](https://docs.redis.com/staging/DOC-3345/rs/references/rest-api/requests/modules/#post-module-v2)