### PR TITLE
RS: Configure CRDB coordinator port with rladmin or REST API

### DIFF
--- a/content/rs/networking/port-configurations.md
+++ b/content/rs/networking/port-configurations.md
@@ -33,7 +33,7 @@ Redis Enterprise Software's port usage falls into three general categories:
 | TCP | 8001 | <span title="Not configurable">&#x274c; No</span> | Internal, External | Traffic from application to Redis Enterprise Software [Discovery Service]({{< relref "/rs/databases/durability-ha/discovery-service.md" >}}) |
 | TCP | 8000, 8070, 8071, 9090, 9125 | <span title="Not configurable">&#x274c; No</span> | Internal, External | Metrics exported and managed by the web proxy |
 | TCP | 8443 | <span title="Configurable">&#x2705; Yes</span> | Internal, External | Secure (HTTPS) access to the management web UI |
-| TCP | 9081 | <span title="Not configurable">&#x274c; No</span> | Internal | Active-Active management (internal) |
+| TCP | 9081 | <span title="Configurable">&#x2705; Yes</span> | Internal | CRDB coordinator for Active-Active management (internal) |
 | TCP | 9443 (Recommended), 8080 | <span title="Configurable">&#x2705; Yes</span> | Internal, External, Active-Active | REST API traffic, including cluster management and node bootstrap |
 | TCP | 10000-19999 | <span title="Configurable">&#x2705; Yes</span> | Internal, External, Active-Active | Database traffic |
 | UDP | 53, 5353 | <span title="Not configurable">&#x274c; No</span> | Internal, External | DNS/mDNS traffic |
@@ -76,9 +76,9 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
     { "reserved_ports": ["11000", "13000-13010"] }
     ```
 
-### Change the admin console port
+### Change the Cluster Manager UI port
 
-The Redis Enterprise Software admin console uses port 8443, by default. You can change this to a custom port as long as the new port is not in use by another process.
+The Redis Enterprise Software Cluster Manager UI uses port 8443, by default. You can change this to a custom port as long as the new port is not in use by another process.
 
 To change this port, run:
 
@@ -165,7 +165,7 @@ After you turn off HTTP support, traffic sent to the unencrypted API endpoint is
 
 ### HTTP to HTTPS redirection
 Starting with version 6.0.12, you cannot use automatic HTTP to HTTPS redirection.
-To poll metrics from the `metrics_exporter` or to access the admin console, use HTTPS in your request. HTTP requests won't be automatically redirected to HTTPS for those services. 
+To poll metrics from the `metrics_exporter` or to access the Cluster Manager UI, use HTTPS in your request. HTTP requests won't be automatically redirected to HTTPS for those services. 
 
 ## Nodes on different VLANs
 

--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -23,6 +23,7 @@ Updates the cluster configuration.
         [ cm_session_timeout <minutes> ]
         [ cnm_http_port <number> ]
         [ cnm_https_port <number> ]
+        [ crdb_coordinator_port <number> ]
         [ data_cipher_list <openSSL cipher list> ]
         [ data_cipher_suites_tls_1_3 <openSSL cipher list> ]
         [ debuginfo_path <filepath> ]
@@ -60,6 +61,7 @@ Updates the cluster configuration.
 | cm_session_timeout | integer | Timeout in minutes for the CM session
 | cmn_http_port | integer | HTTP REST API server listening port |
 | cnm_https_port | integer | HTTPS REST API server listening port |
+| crdb_coordinator_port | integer, (range:&nbsp;1024-65535) (default:&nbsp;9081) | CRDB coordinator port |
 | data_cipher_list | list of ciphers | Cipher suites used by the the data plane (specified in the format understood by the OpenSSL library) |
 | data_cipher_suites_tls_1_3 |  list of ciphers | Specifies the enabled TLS 1.3 ciphers for the data plane |
 | debuginfo_path | filepath | Local directory to place generated support package files |

--- a/content/rs/references/rest-api/objects/bootstrap/_index.md
+++ b/content/rs/references/rest-api/objects/bootstrap/_index.md
@@ -14,6 +14,7 @@ A bootstrap configuration object.
 | action | 'create_cluster'<br />'join_cluster'<br />'recover_cluster' | Action to perform |
 | cluster | [cluster_identity]({{<relref "/rs/references/rest-api/objects/bootstrap/cluster_identity">}}) object | Cluster to join or create |
 | cnm_https_port | integer | Port to join a cluster with non-default cnm_https port |
+| crdb_coordinator_port | integer, (range:&nbsp;1024-65535) (default:&nbsp;9081) | CRDB coordinator port |
 | credentials | [credentials]({{<relref "/rs/references/rest-api/objects/bootstrap/credentials">}}) object | Cluster admin credentials |
 | dns_suffixes | {{<code>}}
 [{

--- a/content/rs/references/rest-api/objects/cluster/_index.md
+++ b/content/rs/references/rest-api/objects/cluster/_index.md
@@ -20,6 +20,7 @@ An API object that represents the cluster.
 | cnm_https_port | integer, (range:&nbsp;1024-65535) | API HTTPS listening port |
 | control_cipher_suites | string | Specifies the enabled ciphers for the control plane. The ciphers are specified in the format understood by the BoringSSL library. |
 | control_cipher_suites_tls_1_3 | string | Specifies the enabled TLS 1.3 ciphers for the control plane. The ciphers are specified in the format understood by the BoringSSL library. (read-only) |
+| crdb_coordinator_port | integer, (range:&nbsp;1024-65535) (default:&nbsp;9081) | CRDB coordinator port |
 | crdt_rest_client_retries | integer | Maximum number of retries for the REST client used by the Active-Active management API |
 | crdt_rest_client_timeout | integer | Timeout for REST client used by the Active-Active management API |
 | created_time | string | Cluster creation date (read-only) |


### PR DESCRIPTION
Staged previews:
- [Network ports table](https://docs.redis.com/staging/DOC-3371/rs/networking/port-configurations/#ports-and-port-ranges-used-by-redis-enterprise-software)
- [rladmin cluster config](https://docs.redis.com/staging/DOC-3371/rs/references/cli-utilities/rladmin/cluster/config/)
- [Bootstrap REST API object](https://docs.redis.com/staging/DOC-3371/rs/references/rest-api/objects/bootstrap/)
- [Cluster REST API object](https://docs.redis.com/staging/DOC-3371/rs/references/rest-api/objects/cluster/)