### PR TITLE
RC: Wrong link in cloud Grafana documentation 

### DIFF
--- a/content/rc/cloud-integrations/prometheus-integration.md
+++ b/content/rc/cloud-integrations/prometheus-integration.md
@@ -174,7 +174,7 @@ Once the Prometheus and Grafana Docker containers are running, and Prometheus is
 Redis publishes two preconfigured dashboards for Redis Cloud and Grafana:
 
 * The [subscription status dashboard](https://grafana.com/grafana/dashboards/18406-subscription-status-dashboard/) provides an overview of your Redis Cloud subscriptions.
-* The [database status dashboard](https://grafana.com/grafana/dashboards/18408-database-status-dashboard/) displays specific database metrics, including latency, memory usage, ops/second, and key count.
+* The [database status dashboard](https://grafana.com/grafana/dashboards/18407-database-status-dashboard/) displays specific database metrics, including latency, memory usage, ops/second, and key count.
 
 These dashboards are open source. For additional dashboard options, or to file an issue, see the [Redis Enterprise Grafana Dashboards Github repository](https://github.com/redis-field-engineering/redis-enterprise-grafana-dashboards).
 


### PR DESCRIPTION
Ticket: DOC-3368
Staging link: https://docs.redis.com/staging/DOC-3370/rc/cloud-integrations/prometheus-integration/