### PR TITLE
RS: Fixed typo in rladmin cluster config/join command option cnm_http_port

### DIFF
--- a/content/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -58,7 +58,7 @@ Updates the cluster configuration.
 | control_cipher_suites | list of ciphers | Cipher suites used for TLS connections to the admin console (specified in the format understood by the BoringSSL library)<br />(previously named `cipher_suites`) |
 | cm_port | integer | UI server listening port |
 | cm_session_timeout | integer | Timeout in minutes for the CM session
-| cmn_http_port | integer | HTTP REST API server listening port |
+| cnm_http_port | integer | HTTP REST API server listening port |
 | cnm_https_port | integer | HTTPS REST API server listening port |
 | data_cipher_list | list of ciphers | Cipher suites used by the the data plane (specified in the format understood by the OpenSSL library) |
 | data_cipher_suites_tls_1_3 |  list of ciphers | Specifies the enabled TLS 1.3 ciphers for the data plane |

--- a/content/rs/references/cli-utilities/rladmin/cluster/join.md
+++ b/content/rs/references/cli-utilities/rladmin/cluster/join.md
@@ -30,7 +30,7 @@ rladmin cluster join
         [ external_addr <IP.address.1> [<IP.address.2> ... <IP.address.N>] ]
         [ override_repair ]
         [ accept_servers { enabled | disabled } ]
-        [ cmn_http_port <port> ]
+        [ cnm_http_port <port> ]
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ rladmin cluster join
 | accept_servers | 'enabled'<br />'disabled' | Allows allocation of resources on the new node when enabled (optional) |
 | addr | IP address | Sets a node's internal IP address. If not provided, the node sets the address automatically. (optional) |
 | ccs_persistent_path | filepath (default:&nbsp;/var/opt/redislabs/persist) | Path to the CCS snapshot location (the default is the same as persistent_path) (optional) |
-| cmn_http_port | integer | Joins a cluster that has a non-default cnm_http_port (optional) |
+| cnm_http_port | integer | Joins a cluster that has a non-default cnm_http_port (optional) |
 | ephemeral_path | filepath | Path to the ephemeral storage location (optional) |
 | external_addr | list of IP addresses | Sets a node's external IP addresses (space-delimited list). If not provided, the node sets the address automatically. (optional) |
 | flash_enabled |  | Enables flash capabilities for a database (optional) |


### PR DESCRIPTION
DOC-3245

Staged previews:
- [rladmin cluster config](https://docs.redis.com/staging/DOC-3245/rs/references/cli-utilities/rladmin/cluster/config/)
- [rladmin cluster join ](https://docs.redis.com/staging/DOC-3245/rs/references/cli-utilities/rladmin/cluster/join/)