### PR TITLE
RS: Removed OpenSSL 1.0.2 requirement for RS 7.4 on RHEL

### DIFF
--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -38,7 +38,7 @@ Redis Enterprise Software is supported on several operating systems, cloud envi
 
 1. <a name="table-note-1" style="display: block; height: 80px; margin-top: -80px;"></a>The server version of Ubuntu is recommended for production installations. The desktop version is only recommended for development deployments.
 
-2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>RHEL and CentOS deployments require OpenSSL 1.0.2 and [firewall configuration]({{<relref "/rs/installing-upgrading/configuring/centos-rhel-firewall">}}).
+2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>RHEL and CentOS deployments require [firewall configuration]({{<relref "/rs/installing-upgrading/configuring/centos-rhel-firewall">}}).
 
 3. <a name="table-note-3" style="display: block; height: 80px; margin-top: -80px;"></a>Based on the corresponding RHEL version.
 

--- a/content/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -112,7 +112,7 @@ To prepare for the future removal of Redis 6.0:
 
 1. <a name="table-note-1" style="display: block; height: 80px; margin-top: -80px;"></a>The server version of Ubuntu is recommended for production installations. The desktop version is only recommended for development deployments.
 
-2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>RHEL and CentOS deployments require OpenSSL 1.0.2 and [firewall configuration]({{<relref "/rs/installing-upgrading/configuring/centos-rhel-firewall">}}).
+2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>RHEL and CentOS deployments require [firewall configuration]({{<relref "/rs/installing-upgrading/configuring/centos-rhel-firewall">}}).
 
 3. <a name="table-note-3" style="display: block; height: 80px; margin-top: -80px;"></a>Based on the corresponding RHEL version.
 

--- a/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
@@ -204,7 +204,7 @@ To prepare for the future removal of Redis 6.0:
 
 1. <a name="table-note-1" style="display: block; height: 80px; margin-top: -80px;"></a>The server version of Ubuntu is recommended for production installations. The desktop version is only recommended for development deployments.
 
-2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>RHEL and CentOS deployments require OpenSSL 1.0.2 and [firewall configuration]({{<relref "/rs/installing-upgrading/configuring/centos-rhel-firewall">}}).
+2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>RHEL and CentOS deployments require [firewall configuration]({{<relref "/rs/installing-upgrading/configuring/centos-rhel-firewall">}}).
 
 3. <a name="table-note-3" style="display: block; height: 80px; margin-top: -80px;"></a>Based on the corresponding RHEL version.
 


### PR DESCRIPTION
DOC-3365

Staged previews:
- [Supported platforms](https://docs.redis.com/staging/DOC-3365/rs/references/supported-platforms/#table-note-2)
- [7.4.2 release notes index page](https://docs.redis.com/staging/DOC-3365/rs/release-notes/rs-7-4-2-releases/#table-note-2)
- [7.4.2-54 release notes](https://docs.redis.com/staging/DOC-3365/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54/#table-note-2)