### PR TITLE
Update K8s installation manifests for RedisInsight

### DIFF
--- a/content/ri/installing/install-k8s.md
+++ b/content/ri/installing/install-k8s.md
@@ -35,7 +35,7 @@ spec:
   type: LoadBalancer
   ports:
     - port: 80
-      targetPort: 8001
+      targetPort: 5540
   selector:
     app: redisinsight
 ---
@@ -65,7 +65,7 @@ spec:
         - name: db #Pod volumes to mount into the container's filesystem. Cannot be updated.
           mountPath: /db
         ports:
-        - containerPort: 8001 #exposed container port and protocol
+        - containerPort: 5540 #exposed container port and protocol
           protocol: TCP
       volumes:
       - name: db
@@ -124,7 +124,7 @@ spec:
   type: LoadBalancer
   ports:
     - port: 80
-      targetPort: 8001
+      targetPort: 5540
   selector:
     app: redisinsight
 ---
@@ -187,7 +187,7 @@ spec:
           - name: db #Pod volumes to mount into the container's filesystem. Cannot be updated.
             mountPath: /db
           ports:
-          - containerPort: 8001 #exposed container port and protocol
+          - containerPort: 5540 #exposed container port and protocol
             protocol: TCP
 ```
 
@@ -233,17 +233,17 @@ spec:
           - name: REDISINSIGHT_HOST
             value: "0.0.0.0"
           - name: REDISINSIGHT_PORT
-            value: "8001"
+            value: "5540"
         volumeMounts:
         - name: db #Pod volumes to mount into the container's filesystem. Cannot be updated.
           mountPath: /db
         ports:
-        - containerPort: 8001 #exposed conainer port and protocol
+        - containerPort: 5540 #exposed conainer port and protocol
           protocol: TCP
         livenessProbe:
            httpGet:
               path : /healthcheck/ # exposed RI endpoint for healthcheck
-              port: 8001 # exposed container port
+              port: 5540 # exposed container port
            initialDelaySeconds: 5 # number of seconds to wait after the container starts to perform liveness probe
            periodSeconds: 5 # period in seconds after which liveness probe is performed
            failureThreshold: 1 # number of liveness probe failures after which container restarts
@@ -265,10 +265,10 @@ If the deployment will be exposed by a service whose name is 'redisinsight', set
 3. Once the deployment has been successfully applied and the deployment complete, access RedisInsight. This can be accomplished by exposing the deployment as a K8s Service or by using port forwarding, as in the example below:
 
 ```sh
-kubectl port-forward deployment/redisinsight 8001
+kubectl port-forward deployment/redisinsight 5540
 ```
 
-Open your browser and point to <http://localhost:8001>
+Open your browser and point to <http://localhost:5540>
 
 ## Helm Chart (Experimental)
 

--- a/content/ri/installing/install-k8s.md
+++ b/content/ri/installing/install-k8s.md
@@ -62,13 +62,13 @@ spec:
         image: redislabs/redisinsight:latest #repo/image
         imagePullPolicy: IfNotPresent #Always pull image
         volumeMounts:
-        - name: db #Pod volumes to mount into the container's filesystem. Cannot be updated.
-          mountPath: /db
+        - name: data #Pod volumes to mount into the container's filesystem. Cannot be updated.
+          mountPath: /data
         ports:
         - containerPort: 5540 #exposed container port and protocol
           protocol: TCP
       volumes:
-      - name: db
+      - name: data
         emptyDir: {} # node-ephemeral volume https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
 ```
 
@@ -162,7 +162,7 @@ spec:
         app: redisinsight #label for pod/s
     spec:
       volumes:
-        - name: db
+        - name: data
           persistentVolumeClaim:
             claimName: redisinsight-pv-claim
       initContainers:
@@ -172,11 +172,11 @@ spec:
             - /bin/sh
             - '-c'
             - |
-              chown -R 1001 /db
+              chown -R 1001 /data
           resources: {}
           volumeMounts:
-            - name: db
-              mountPath: /db
+            - name: data
+              mountPath: /data
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       containers:
@@ -184,8 +184,8 @@ spec:
           image: redislabs/redisinsight:latest #repo/image
           imagePullPolicy: IfNotPresent #Always pull image
           volumeMounts:
-          - name: db #Pod volumes to mount into the container's filesystem. Cannot be updated.
-            mountPath: /db
+          - name: data #Pod volumes to mount into the container's filesystem. Cannot be updated.
+            mountPath: /data
           ports:
           - containerPort: 5540 #exposed container port and protocol
             protocol: TCP
@@ -235,8 +235,8 @@ spec:
           - name: REDISINSIGHT_PORT
             value: "5540"
         volumeMounts:
-        - name: db #Pod volumes to mount into the container's filesystem. Cannot be updated.
-          mountPath: /db
+        - name: data #Pod volumes to mount into the container's filesystem. Cannot be updated.
+          mountPath: /data
         ports:
         - containerPort: 5540 #exposed conainer port and protocol
           protocol: TCP
@@ -248,7 +248,7 @@ spec:
            periodSeconds: 5 # period in seconds after which liveness probe is performed
            failureThreshold: 1 # number of liveness probe failures after which container restarts
       volumes:
-      - name: db
+      - name: data
         emptyDir: {} # node-ephemeral volume https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
 ```
 


### PR DESCRIPTION
This PR consists of the following changes,
- Update port number as per latest version of RedisInsight 9https://github.com/RedisInsight/RedisInsight/blob/1963447e832f96d9383c381229a3f68817ad0fc1/Dockerfile#L73)
- Update mount path for the persistent volume. We noticed that data was not being persisted across restarts. (https://github.com/RedisInsight/RedisInsight/blob/1963447e832f96d9383c381229a3f68817ad0fc1/Dockerfile#L66)

On a side note, we also had to update the init container's command to `chmod -R 777 /data` because the default `chown -R 1001 /data` failed.

Signed-off-by: PrayagS <prayag.savsani@blinkit.com>