### PR TITLE
RS: Add Redis v6.x A-A modules limitation to Fuji release notes

### DIFF
--- a/content/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -278,3 +278,9 @@ For clusters containing databases with manually uploaded modules, [cluster recov
 After installing Redis Enterprise Software on the cluster nodes, upload compatible modules to `modulesdir` (`/opt/redislabs/lib/modules`) before continuing the recovery process.
 
 This limitation was fixed in [Redis Enterprise Software version 7.2.4-64]({{<relref "/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64">}}).
+
+#### Creating Redis v6.0/v6.2 Active Active database with modules
+
+Redis enterprise v7.2.4 offers the option to create databases from versions: v6.0, v6.2, v7.2
+There is a limitation to create Active Active databases from versions v6.0, v6.2 with modules
+This limitation will be fixed in Redis enterprise v7.4.2 maintenance release

--- a/content/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -279,8 +279,8 @@ After installing Redis Enterprise Software on the cluster nodes, upload compatib
 
 This limitation was fixed in [Redis Enterprise Software version 7.2.4-64]({{<relref "/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64">}}).
 
-#### Creating Redis v6.0/v6.2 Active Active database with modules
+#### Cannot create Redis v6.x Active-Active databases with modules
 
-Redis enterprise v7.2.4 offers the option to create databases from versions: v6.0, v6.2, v7.2
-There is a limitation to create Active Active databases from versions v6.0, v6.2 with modules
-This limitation will be fixed in Redis enterprise v7.4.2 maintenance release
+You cannot create Active-Active databases that use Redis version 6.0 or 6.2 with modules. Databases that use Redis version 7.2 do not have this limitation.
+
+This limitation will be fixed in a maintenance release for Redis Enterprise version 7.4.2.

--- a/content/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -152,3 +152,9 @@ This issue will be fixed in a future maintenance release.
 #### RedisGraph prevents upgrade to RHEL 9 
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Enterprise cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
+
+#### Creating Redis v6.0/v6.2 Active Active database with modules
+
+Redis enterprise v7.2.4 offers the option to create databases from versions: v6.0, v6.2, v7.2 
+There is a limitation to create Active Active databases from versions v6.0, v6.2 with modules 
+This limitation will be fixed in Redis enterprise v7.4.2 maintenance release

--- a/content/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -153,8 +153,8 @@ This issue will be fixed in a future maintenance release.
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Enterprise cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
-#### Creating Redis v6.0/v6.2 Active Active database with modules
+#### Cannot create Redis v6.x Active-Active databases with modules
 
-Redis enterprise v7.2.4 offers the option to create databases from versions: v6.0, v6.2, v7.2 
-There is a limitation to create Active Active databases from versions v6.0, v6.2 with modules 
-This limitation will be fixed in Redis enterprise v7.4.2 maintenance release
+You cannot create Active-Active databases that use Redis version 6.0 or 6.2 with modules. Databases that use Redis version 7.2 do not have this limitation.
+
+This limitation will be fixed in a maintenance release for Redis Enterprise version 7.4.2.

--- a/content/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -157,4 +157,4 @@ You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Enterprise c
 
 You cannot create Active-Active databases that use Redis version 6.0 or 6.2 with modules. Databases that use Redis version 7.2 do not have this limitation.
 
-This limitation will be fixed in a maintenance release for Redis Enterprise version 7.4.2.
+This limitation will be fixed in a future maintenance release.

--- a/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
@@ -262,7 +262,7 @@ You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Enterprise c
 
 You cannot create Active-Active databases that use Redis version 6.0 or 6.2 with modules. Databases that use Redis version 7.2 do not have this limitation.
 
-This limitation will be fixed in a maintenance release for Redis Enterprise version 7.4.2.
+This limitation will be fixed in a future maintenance release.
 
 ## Security
 

--- a/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
@@ -258,6 +258,12 @@ This issue will be fixed in a future maintenance release.
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Enterprise cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
+#### Cannot create Redis v6.x Active-Active databases with modules
+
+You cannot create Active-Active databases that use Redis version 6.0 or 6.2 with modules. Databases that use Redis version 7.2 do not have this limitation.
+
+This limitation will be fixed in a maintenance release for Redis Enterprise version 7.4.2.
+
 ## Security
 
 #### Open source Redis security fixes compatibility


### PR DESCRIPTION
Opened a new PR to replace https://github.com/RedisLabs/redislabs-docs/pull/3166 because it accidentally included work-in-progress maintenance release notes. This way, we can merge these changes without reverting the commits or being blocked by the maintenance release.

Staged previews:

- [7.4.2 index page](https://docs.redis.com/staging/rs-fuji-rn-patch/rs/release-notes/rs-7-4-2-releases/#cannot-create-redis-v6x-active-active-databases-with-modules)
- [7.4.2-54 release notes](https://docs.redis.com/staging/rs-fuji-rn-patch/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54/#cannot-create-redis-v6x-active-active-databases-with-modules)
- [7.2.4 index page](https://docs.redis.com/staging/rs-fuji-rn-patch/rs/release-notes/rs-7-2-4-releases/#cannot-create-redis-v6x-active-active-databases-with-modules)