### PR TITLE
RS: Cannot mix RAM-only and flash clusters in Active-Active config

### DIFF
--- a/content/rs/databases/active-active/create.md
+++ b/content/rs/databases/active-active/create.md
@@ -91,6 +91,10 @@ Every instance of an Active-Active database can receive write operations, and al
 
         {{<image filename="images/rs/screenshots/databases/active-active-databases/create-db-add-participating-clusters.png" alt="Add cluster panel.">}}{{</image>}}
 
+        {{<note>}}
+You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
+        {{</note>}}
+
     1. Click **Join cluster** to add the cluster to the list of participating clusters. 
 
 1. Enter a **Database name**.

--- a/content/rs/databases/active-active/create.md
+++ b/content/rs/databases/active-active/create.md
@@ -92,7 +92,7 @@ Every instance of an Active-Active database can receive write operations, and al
         {{<image filename="images/rs/screenshots/databases/active-active-databases/create-db-add-participating-clusters.png" alt="Add cluster panel.">}}{{</image>}}
 
         {{<note>}}
-You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
+You cannot add RAM-only clusters and [flash-enabled clusters]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
         {{</note>}}
 
     1. Click **Join cluster** to add the cluster to the list of participating clusters. 

--- a/content/rs/databases/active-active/manage.md
+++ b/content/rs/databases/active-active/manage.md
@@ -40,6 +40,10 @@ After you add new participating clusters to an existing Active-Active database,
 the new database instance can accept connections and read operations.
 The new instance does not accept write operations until it is in the syncing state.
 
+{{<note>}}
+You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
+{{</note>}}
+
 To add a new participating cluster to an existing Active-Active configuration using the Cluster Manager UI:
 
 1. Select the Active-Active database from the **Databases** list and go to its **Configuration** screen.

--- a/content/rs/databases/active-active/manage.md
+++ b/content/rs/databases/active-active/manage.md
@@ -41,7 +41,7 @@ the new database instance can accept connections and read operations.
 The new instance does not accept write operations until it is in the syncing state.
 
 {{<note>}}
-You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
+You cannot add RAM-only clusters and [flash-enabled clusters]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
 {{</note>}}
 
 To add a new participating cluster to an existing Active-Active configuration using the Cluster Manager UI:

--- a/content/rs/databases/active-active/planning.md
+++ b/content/rs/databases/active-active/planning.md
@@ -24,7 +24,7 @@ See [Active-Active Redis]({{<relref "/rs/databases/active-active/">}}) for more 
 You need at least [two participating clusters]({{<relref "/rs/clusters/new-cluster-setup">}}) for an Active-Active database. If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
 
 {{<note>}}
-You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
+You cannot add RAM-only clusters and [flash-enabled clusters]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
 {{</note>}}
 
 Changes made from the admin console to an Active-Active database configuration only apply to the cluster you are editing. For global configuration changes across all clusters, use the `crdb-cli` command-line utility.

--- a/content/rs/databases/active-active/planning.md
+++ b/content/rs/databases/active-active/planning.md
@@ -21,7 +21,7 @@ See [Active-Active Redis]({{<relref "/rs/databases/active-active/">}}) for more 
 
 ## Participating clusters
 
-You must [set up at least two participating clusters]({{<relref "/rs/clusters/new-cluster-setup">}}) for an Active-Active database. If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
+You need at least [two participating clusters]({{<relref "/rs/clusters/new-cluster-setup">}}) for an Active-Active database. If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
 
 {{<note>}}
 You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.

--- a/content/rs/databases/active-active/planning.md
+++ b/content/rs/databases/active-active/planning.md
@@ -21,7 +21,7 @@ See [Active-Active Redis]({{<relref "/rs/databases/active-active/">}}) for more 
 
 ## Participating clusters
 
-Active-Active databases require you to [set up at least two participating clusters]({{<relref "/rs/clusters/new-cluster-setup.md">}}). If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
+You must [set up at least two participating clusters]({{<relref "/rs/clusters/new-cluster-setup">}}) for an Active-Active database. If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
 
 {{<note>}}
 You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.

--- a/content/rs/databases/active-active/planning.md
+++ b/content/rs/databases/active-active/planning.md
@@ -21,7 +21,11 @@ See [Active-Active Redis]({{<relref "/rs/databases/active-active/">}}) for more 
 
 ## Participating clusters
 
-For Active-Active databases, you need to [set up your participating clusters]({{<relref "/rs/clusters/new-cluster-setup.md">}}). At least two participating clusters. If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
+Active-Active databases require you to [set up at least two participating clusters]({{<relref "/rs/clusters/new-cluster-setup.md">}}). If your database requires more than ten participating clusters, contact Redis support. You can [add or remove participating clusters]({{<relref "/rs/databases/active-active/manage#participating-clusters/">}}) after database creation.
+
+{{<note>}}
+You cannot add RAM-only clusters and clusters with flash storage enabled for [Auto Tiering]({{<relref "/rs/databases/auto-tiering">}}) to the same Active-Active configuration.
+{{</note>}}
 
 Changes made from the admin console to an Active-Active database configuration only apply to the cluster you are editing. For global configuration changes across all clusters, use the `crdb-cli` command-line utility.
 


### PR DESCRIPTION
DOC-3268

Staged previews:
- [Considerations for planning Active-Active databases](https://docs.redis.com/staging/DOC-3268/rs/databases/active-active/planning/#participating-clusters)
- [Create an Active-Active database](https://docs.redis.com/staging/DOC-3268/rs/databases/active-active/create/#create-an-active-active-database) - step 7b
- [Add participating clusters](https://docs.redis.com/staging/DOC-3268/rs/databases/active-active/manage/#add-participating-clusters)