### PR TITLE
Update memtier-benchmark.md

### DIFF
--- a/content/rs/references/memtier-benchmark.md
+++ b/content/rs/references/memtier-benchmark.md
@@ -192,6 +192,6 @@ You can either monitor the results in the **metrics** tab of the admin console o
 You should expect to see an average throughput of:
 
 - Around 160,000 ops/sec when testing without replication (i.e. Four master shards)
-- Around 115,000 ops/sec when testing with enabled replication (i.e. Four master and 2 replica shards)
+- Around 115,000 ops/sec when testing with enabled replication (i.e. 2 master and 2 replica shards)
 
 In both cases, the average latency should be below one millisecond.


### PR DESCRIPTION
Changed a possible typo from 'Four masters and 2 replicas' to '2 masters and 2 replicas'