### PR TITLE
RS: syncer_state REST API references

### DIFF
--- a/content/rs/references/rest-api/requests/bdbs/syncer_state/_index.md
+++ b/content/rs/references/rest-api/requests/bdbs/syncer_state/_index.md
@@ -1,0 +1,76 @@
+---
+Title: Syncer state requests
+linkTitle: syncer_state
+description: Syncer state requests
+weight: $weight
+alwaysopen: false
+headerRange: "[1-2]"
+categories: ["RS"]
+aliases: 
+---
+
+| Method | Path | Description |
+|--------|------|-------------|
+| [GET](#get-syncer-state) | `/v1/bdbs/{uid}/syncer_state` | Get a CRDB's syncer state |
+
+## Get syncer state {#get-syncer-state}
+
+```sh
+GET /v1/bdbs/{int: uid}/syncer_state
+```
+
+Get a CRDB's syncer state as JSON.
+
+{{<warning>}}
+This endpoint is deprecated as of Redis Enterprise Software version 7.2.4 and will be removed in a future release. Use [`/v1/bdbs/<uid>/syncer_state/crdt`]({{<relref "/rs/references/rest-api/requests/bdbs/syncer_state/crdt">}}) instead.
+{{</warning>}}
+
+### Permissions
+
+| Permission name | Roles   |
+|-----------------|---------|
+| [view_bdb_info]({{<relref "/rs/references/rest-api/permissions#view_bdb_info">}}) |  admin<br />cluster_member<br />cluster_viewer<br />db_member<br />db_viewer |
+
+### Request {#get-request}
+
+#### Example HTTP request
+
+```sh
+GET /v1/bdbs/1/syncer_state
+```
+
+#### Headers
+
+| Key | Value |
+|-----|-------|
+| Host | The domain name or IP of the cluster |
+| Accept | application/json |
+
+#### URL parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| uid | integer | The unique ID of the database requested. |
+
+### Response {#get-response}
+
+Returns a JSON object that represents the syncer state.
+
+#### Example JSON body
+
+```json
+{
+    "DB": 22,
+    "RunID": 1584086516,
+    // additional fields...
+}
+```
+
+#### Status codes {#get-status-codes}
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | OK |
+| [404 Not Found](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) | Syncer state key does not exist |
+| [500 Internal Server Error](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1) | Internal error |
+| [503 Service Unavailable](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4) | Redis connection error, service unavailable |

--- a/content/rs/references/rest-api/requests/bdbs/syncer_state/_index.md
+++ b/content/rs/references/rest-api/requests/bdbs/syncer_state/_index.md
@@ -43,7 +43,7 @@ GET /v1/bdbs/1/syncer_state
 
 | Key | Value |
 |-----|-------|
-| Host | The domain name or IP of the cluster |
+| Host | The domain name or IP of the cluster. |
 | Accept | application/json |
 
 #### URL parameters

--- a/content/rs/references/rest-api/requests/bdbs/syncer_state/crdt.md
+++ b/content/rs/references/rest-api/requests/bdbs/syncer_state/crdt.md
@@ -1,0 +1,72 @@
+---
+Title: CRDT syncer state requests
+linkTitle: crdt
+description: CRDT syncer state requests
+weight: $weight
+alwaysopen: false
+headerRange: "[1-2]"
+categories: ["RS"]
+aliases: 
+---
+
+| Method | Path | Description |
+|--------|------|-------------|
+| [GET](#get-syncer-state) | `/v1/bdbs/{uid}/syncer_state/crdt` |  Get a CRDB's syncer state |
+
+## Get CRDB syncer state {#get-syncer-state}
+
+```sh
+GET /v1/bdbs/{int: uid}/syncer_state/crdt
+```
+
+Get a CRDB's syncer state as JSON.
+
+### Permissions
+
+| Permission name | Roles   |
+|-----------------|---------|
+| [view_bdb_info]({{<relref "/rs/references/rest-api/permissions#view_bdb_info">}}) |  admin<br />cluster_member<br />cluster_viewer<br />db_member<br />db_viewer |
+
+### Request {#get-request}
+
+#### Example HTTP request
+
+```sh
+GET /v1/bdbs/1/syncer_state/crdt
+```
+
+#### Headers
+
+| Key | Value |
+|-----|-------|
+| Host | The domain name or IP of the cluster |
+| Accept | application/json |
+
+#### URL parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| uid | integer | The unique ID of the database requested. |
+
+### Response {#get-response}
+
+Returns a JSON object that represents the syncer state.
+
+#### Example JSON body
+
+```json
+{
+    "DB": 22,
+    "RunID": 1584086516,
+    // additional fields...
+}
+```
+
+#### Status codes {#get-status-codes}
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | OK |
+| [404 Not Found](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) | Syncer state key does not exist |
+| [500 Internal Server Error](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1) | Internal error |
+| [503 Service Unavailable](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4) | Redis connection error, service unavailable |

--- a/content/rs/references/rest-api/requests/bdbs/syncer_state/crdt.md
+++ b/content/rs/references/rest-api/requests/bdbs/syncer_state/crdt.md
@@ -39,7 +39,7 @@ GET /v1/bdbs/1/syncer_state/crdt
 
 | Key | Value |
 |-----|-------|
-| Host | The domain name or IP of the cluster |
+| Host | The domain name or IP of the cluster. |
 | Accept | application/json |
 
 #### URL parameters

--- a/content/rs/references/rest-api/requests/bdbs/syncer_state/replica.md
+++ b/content/rs/references/rest-api/requests/bdbs/syncer_state/replica.md
@@ -1,0 +1,72 @@
+---
+Title: Replica syncer state requests
+linkTitle: replica
+description: Replica syncer state requests
+weight: $weight
+alwaysopen: false
+headerRange: "[1-2]"
+categories: ["RS"]
+aliases: 
+---
+
+| Method | Path | Description |
+|--------|------|-------------|
+| [GET](#get-syncer-state) | `/v1/bdbs/{uid}/syncer_state/replica` | Get a CRDB replica's syncer state |
+
+## Get replica syncer state {#get-syncer-state}
+
+```sh
+GET /v1/bdbs/{int: uid}/syncer_state/replica
+```
+
+Get a CRDB replica's syncer state as JSON.
+
+### Permissions
+
+| Permission name | Roles   |
+|-----------------|---------|
+| [view_bdb_info]({{<relref "/rs/references/rest-api/permissions#view_bdb_info">}}) |  admin<br />cluster_member<br />cluster_viewer<br />db_member<br />db_viewer |
+
+### Request {#get-request}
+
+#### Example HTTP request
+
+```sh
+GET /v1/bdbs/1/syncer_state/replica
+```
+
+#### Headers
+
+| Key | Value |
+|-----|-------|
+| Host | The domain name or IP of the cluster |
+| Accept | application/json |
+
+#### URL parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| uid | integer | The unique ID of the database requested. |
+
+### Response {#get-response}
+
+Returns a JSON object that represents the syncer state.
+
+#### Example JSON body
+
+```json
+{
+    "DB": 22,
+    "RunID": 1584086516,
+    // additional fields...
+}
+```
+
+#### Status codes {#get-status-codes}
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | OK |
+| [404 Not Found](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5) | Syncer state key does not exist |
+| [500 Internal Server Error](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1) | Internal error |
+| [503 Service Unavailable](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4) | Redis connection error, service unavailable |

--- a/content/rs/references/rest-api/requests/bdbs/syncer_state/replica.md
+++ b/content/rs/references/rest-api/requests/bdbs/syncer_state/replica.md
@@ -39,7 +39,7 @@ GET /v1/bdbs/1/syncer_state/replica
 
 | Key | Value |
 |-----|-------|
-| Host | The domain name or IP of the cluster |
+| Host | The domain name or IP of the cluster. |
 | Accept | application/json |
 
 #### URL parameters


### PR DESCRIPTION
DOC-3270

Staged previews:
- [/v1/bdbs/{uid}/syncer_state](https://docs.redis.com/staging/DOC-3270/rs/references/rest-api/requests/bdbs/syncer_state/)
- [/v1/bdbs/{uid}/syncer_state/crdt](https://docs.redis.com/staging/DOC-3270/rs/references/rest-api/requests/bdbs/syncer_state/crdt/)
- [/v1/bdbs/{uid}/syncer_state/replica](https://docs.redis.com/staging/DOC-3270/rs/references/rest-api/requests/bdbs/syncer_state/replica/)