### PR TITLE
RS: Add supported platforms snapshot disclaimer to previous RS release notes

### DIFF
--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103.md
@@ -55,6 +55,8 @@ Redis Enterprise Software version 6.4.2-103 includes the following Redis Stack m
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -185,6 +185,8 @@ Certain operating systems, such as RHEL 8, have already removed support for the 
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-105.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-105.md
@@ -53,6 +53,8 @@ Redis Enterprise Software versions 7.2.4-105 includes the following Redis Stack 
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
@@ -624,6 +624,8 @@ For more information about request and response policies, see [Redis command tip
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
@@ -79,6 +79,8 @@ Redis Enterprise Software version 7.2.4-64 includes the following Redis Stack mo
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
@@ -59,6 +59,8 @@ Redis Enterprise Software version 7.2.4-72 includes the following Redis Stack mo
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
@@ -87,6 +87,8 @@ The following issues were resolved in ​Redis Enterprise Software version 7.2.4
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.

--- a/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
@@ -170,6 +170,8 @@ To prepare for the future removal of Redis 6.0:
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 
 <span title="Warning icon">&#x26A0;&#xFE0F;</span> Deprecated – The platform is still supported for this version of Redis Enterprise Software, but support will be removed in a future release.


### PR DESCRIPTION
DOC-3543

The supported platforms snapshot disclaimer from the most recent Redis Enterprise Software release now appears on all release notes that have a supported platforms snapshot:
- [All 7.4.2 release notes](https://docs.redis.com/staging/DOC-3543/rs/release-notes/rs-7-4-2-releases/)
- [All 7.2.4 release notes](https://docs.redis.com/staging/DOC-3543/rs/release-notes/rs-7-2-4-releases/)
- [6.4.2-103 release notes](https://docs.redis.com/staging/DOC-3543/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103/)