### PR TITLE
RS: Changed links to relrefs

### DIFF
--- a/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103.md
+++ b/content/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103.md
@@ -55,7 +55,7 @@ Redis Enterprise Software version 6.4.2-103 includes the following Redis Stack m
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -165,7 +165,7 @@ Amazon Linux 1 support is considered deprecated and will be removed in a future 
 
 #### Ubuntu 16.04
 
-The deprecation of Ubuntu 16.04 was announced in the [Redis Enterprise Software 6.4.2 release notes](http://localhost:1313/rs/release-notes/rs-6-4-2-releases/#deprecations). As of Redis Enterprise Software 7.2.4, Ubuntu 16.04 is no longer supported.
+The deprecation of Ubuntu 16.04 was announced in the [Redis Enterprise Software 6.4.2 release notes]({{<relref "/rs/release-notes/rs-6-4-2-releases#deprecations">}}). As of Redis Enterprise Software 7.2.4, Ubuntu 16.04 is no longer supported.
 
 #### RC4 encryption cipher
 
@@ -185,7 +185,7 @@ Certain operating systems, such as RHEL 8, have already removed support for the 
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-105.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-105.md
@@ -53,7 +53,7 @@ Redis Enterprise Software versions 7.2.4-105 includes the following Redis Stack 
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
@@ -556,7 +556,7 @@ Amazon Linux 1 support is considered deprecated and will be removed in a future 
 
 #### Ubuntu 16.04
 
-The deprecation of Ubuntu 16.04 was announced in the [Redis Enterprise Software 6.4.2 release notes](http://localhost:1313/rs/release-notes/rs-6-4-2-releases/#deprecations). As of Redis Enterprise Software 7.2.4, Ubuntu 16.04 is no longer supported.
+The deprecation of Ubuntu 16.04 was announced in the [Redis Enterprise Software 6.4.2 release notes]({{<relref "/rs/release-notes/rs-6-4-2-releases#deprecations">}}). As of Redis Enterprise Software 7.2.4, Ubuntu 16.04 is no longer supported.
 
 #### RC4 encryption cipher
 
@@ -624,7 +624,7 @@ For more information about request and response policies, see [Redis command tip
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
@@ -79,7 +79,7 @@ Redis Enterprise Software version 7.2.4-64 includes the following Redis Stack mo
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
@@ -59,7 +59,7 @@ Redis Enterprise Software version 7.2.4-72 includes the following Redis Stack mo
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
+++ b/content/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
@@ -87,7 +87,7 @@ The following issues were resolved in ​Redis Enterprise Software version 7.2.4
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -77,7 +77,7 @@ To prepare for the future removal of Redis 6.0:
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software and Redis Stack modules.
 

--- a/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-104.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-104.md
@@ -87,7 +87,7 @@ Bundled Redis modules compatible with Redis database versions 6.0 and 6.2:
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software and Redis Stack modules.
 

--- a/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
+++ b/content/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
@@ -170,7 +170,7 @@ To prepare for the future removal of Redis 6.0:
 
 ### Supported platforms
 
-The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference](http://localhost:1313/rs/references/supported-platforms/) for more details about operating system compatibility.
+The following table provides a snapshot of supported platforms as of this Redis Enterprise Software release. See the [supported platforms reference]({{<relref "/rs/references/supported-platforms">}}) for more details about operating system compatibility.
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Enterprise Software.
 

--- a/content/rs/security/certificates/ocsp-stapling.md
+++ b/content/rs/security/certificates/ocsp-stapling.md
@@ -75,7 +75,7 @@ To set up OCSP stapling with the [REST API]({{<relref "/rs/references/rest-api">
 
 To set up OCSP stapling with the [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin">}}) command-line utility:
 
-1. Use [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/certificate">}}) to [replace the proxy certificate]({{<relref "http://localhost:1313/rs/security/certificates/updating-certificates#use-the-cli">}}) with a certificate signed by your third-party CA.
+1. Use [`rladmin`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/certificate">}}) to [replace the proxy certificate]({{<relref "/rs/security/certificates/updating-certificates#use-the-cli">}}) with a certificate signed by your third-party CA.
 
 1. Update the cluster's OCSP settings with the [`rladmin cluster ocsp config`]({{<relref "/rs/references/cli-utilities/rladmin/cluster/ocsp#ocsp-config">}}) command if you don't want to use their default values.
 


### PR DESCRIPTION
Fixing some incorrect links that should've been relrefs.

Staged previews:
- [7.4.2 release notes](https://docs.redis.com/staging/DOC-3543-fix-relrefs/rs/release-notes/rs-7-4-2-releases/)
- [7.2.4 release notes](https://docs.redis.com/staging/DOC-3543-fix-relrefs/rs/release-notes/rs-7-2-4-releases/)
- [6.4.2-103 release notes](https://docs.redis.com/staging/DOC-3543-fix-relrefs/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103/)
- [Set up OCSP stapling with rladmin](https://docs.redis.com/staging/DOC-3543-fix-relrefs/rs/security/certificates/ocsp-stapling/#rladmin-method)